### PR TITLE
i9 // Parsing Improvements for BLASTp

### DIFF
--- a/cpt_protein_blast_grouping/.shed.yml
+++ b/cpt_protein_blast_grouping/.shed.yml
@@ -1,0 +1,4 @@
+categories: []
+description: cpt_protein_blast_grouping
+name: cpt_protein_blast_grouping
+owner: cpt

--- a/cpt_protein_blast_grouping/macros.xml
+++ b/cpt_protein_blast_grouping/macros.xml
@@ -1,0 +1,1 @@
+../macros.xml

--- a/cpt_protein_blast_grouping/protein_blast_grouping.py
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.py
@@ -1,5 +1,6 @@
 import argparse
 import re
+import sys
 
 
 class BlastProteinResultParser:
@@ -37,7 +38,9 @@ class BlastProteinResultParser:
         sorted_results = sorted(self.results.items(), key=sort_key, reverse=True)
         return sorted_results[:num_hits]
 
-    def print_results(self, num_hits, sort_key="unique_queries"):
+    def print_results(
+        self, num_hits, sort_key="unique_queries", output_file=sys.stdout
+    ):
         top_hits = self.get_top_hits(num_hits, sort_key)
         print(f"# Top {num_hits} Hits")
         print(
@@ -49,7 +52,8 @@ class BlastProteinResultParser:
             print(
                 "{:<50} {:<25} {:<25}".format(
                     organism, len(data["unique_queries"]), len(data["unique_hits"])
-                )
+                ),
+                file=output_file,
             )
 
 
@@ -62,6 +66,12 @@ def main():
         "--hits", type=int, default=5, help="Number of top hits to display"
     )
     parser.add_argument(
+        "--output",
+        type=argparse.FileType("w"),
+        default="-",
+        help="Output file (default: stdout)",
+    )
+    parser.add_argument(
         "--sort",
         choices=["unique_queries", "unique_hits"],
         default="unique_queries",
@@ -71,7 +81,9 @@ def main():
 
     blast_parser = BlastProteinResultParser(args.blast)
     blast_parser.parse_blast()
-    blast_parser.print_results(args.hits, args.sort)
+    blast_parser.print_results(args.hits, args.sort, args.output)
+
+    args.output.close()
 
 
 if __name__ == "__main__":

--- a/cpt_protein_blast_grouping/protein_blast_grouping.py
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.py
@@ -42,16 +42,20 @@ class BlastProteinResultParser:
         self, num_hits, sort_key="unique_queries", output_file=sys.stdout
     ):
         top_hits = self.get_top_hits(num_hits, sort_key)
-        print(f"# Top {num_hits} Hits")
+        print(f"# Top {num_hits} Hits", file=output_file)
         print(
-            "{:<50} {:<25} {:<25}".format(
-                "# Name", "Unique Query Matches", "Unique Subject Hits"
-            )
+            "{:>4} {:<20} {:>10} {:>10}".format(
+                "Rank", "Phage Name", "Unique Query Matches", "Unique Subject Hits"
+            ),
+            file=output_file,
         )
-        for organism, data in top_hits:
+        for rank, (organism, data) in enumerate(top_hits):
             print(
-                "{:<50} {:<25} {:<25}".format(
-                    organism, len(data["unique_queries"]), len(data["unique_hits"])
+                "{:>4} {:<50} {:<25} {:<25}".format(
+                    rank,
+                    organism,
+                    len(data["unique_queries"]),
+                    len(data["unique_hits"]),
                 ),
                 file=output_file,
             )

--- a/cpt_protein_blast_grouping/protein_blast_grouping.py
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.py
@@ -1,0 +1,78 @@
+import argparse
+import re
+
+
+class BlastProteinResultParser:
+    def __init__(self, blast_file):
+        self.blast_file = blast_file
+        self.results = {}
+
+    def parse_blast(self):
+        for line in self.blast_file:
+            parts = line.strip().split("\t")
+            query_id = parts[0]
+            subject_titles = parts[2].split("<>")
+            for title in subject_titles:
+                organism = self.extract_organism(title)
+                if organism:
+                    if organism not in self.results:
+                        self.results[organism] = {
+                            "unique_queries": set(),
+                            "unique_hits": set(),
+                        }
+                    #  "unique query" == query proteins had a LEAST one match in organism
+                    self.results[organism]["unique_queries"].add(query_id)
+                    #  "unique hits" == unique proteins from eahc organism were matched by ANY of the queries
+                    self.results[organism]["unique_hits"].add(parts[1])
+
+    @staticmethod
+    def extract_organism(title):
+        match = re.search(r"\[(.*?)\]", title)
+        return match.group(1) if match else None
+
+    def get_top_hits(self, num_hits, key="unique_queries"):
+        def sort_key(item):
+            return len(item[1][key])
+
+        sorted_results = sorted(self.results.items(), key=sort_key, reverse=True)
+        return sorted_results[:num_hits]
+
+    def print_results(self, num_hits, sort_key="unique_queries"):
+        top_hits = self.get_top_hits(num_hits, sort_key)
+        print(f"# Top {num_hits} Hits")
+        print(
+            "{:<50} {:<25} {:<25}".format(
+                "# Name", "Unique Query Matches", "Unique Subject Hits"
+            )
+        )
+        for organism, data in top_hits:
+            print(
+                "{:<50} {:<25} {:<25}".format(
+                    organism, len(data["unique_queries"]), len(data["unique_hits"])
+                )
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse BLAST results and group by 'top hits' to an organism"
+    )
+    parser.add_argument("blast", type=argparse.FileType("r"), help="Blast Results")
+    parser.add_argument(
+        "--hits", type=int, default=5, help="Number of top hits to display"
+    )
+    parser.add_argument(
+        "--sort",
+        choices=["unique_queries", "unique_hits"],
+        default="unique_queries",
+        help="Sort results by 'unique_queries' (default) or 'unique_hits'",
+    )
+    args = parser.parse_args()
+
+    blast_parser = BlastProteinResultParser(args.blast)
+    blast_parser.parse_blast()
+    blast_parser.print_results(args.hits, args.sort)
+
+
+if __name__ == "__main__":
+    main()

--- a/cpt_protein_blast_grouping/protein_blast_grouping.py
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.py
@@ -44,19 +44,12 @@ class BlastProteinResultParser:
         top_hits = self.get_top_hits(num_hits, sort_key)
         print(f"# Top {num_hits} Hits", file=output_file)
         print(
-            "{:>4} {:<20} {:>10} {:>10}".format(
-                "Rank", "Phage Name", "Unique Query Matches", "Unique Subject Hits"
-            ),
+            "Rank\tPhage Name\tUnique Query Matches\tUnique Subject Hits",
             file=output_file,
         )
         for rank, (organism, data) in enumerate(top_hits):
             print(
-                "{:>4} {:<50} {:<25} {:<25}".format(
-                    rank,
-                    organism,
-                    len(data["unique_queries"]),
-                    len(data["unique_hits"]),
-                ),
+                f"{rank}\t{organism}\t{len(data['unique_queries'])}\t{len(data['unique_hits'])}",
                 file=output_file,
             )
 

--- a/cpt_protein_blast_grouping/protein_blast_grouping.py
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.py
@@ -42,12 +42,12 @@ class BlastProteinResultParser:
         self, num_hits, sort_key="unique_queries", output_file=sys.stdout
     ):
         top_hits = self.get_top_hits(num_hits, sort_key)
-        print(f"# Top {num_hits} Hits", file=output_file)
         print(
             "Rank\tPhage Name\tUnique Query Matches\tUnique Subject Hits",
             file=output_file,
         )
-        for rank, (organism, data) in enumerate(top_hits):
+        for r, (organism, data) in enumerate(top_hits):
+            rank = r + 1  # 1-based ranking
             print(
                 f"{rank}\t{organism}\t{len(data['unique_queries'])}\t{len(data['unique_hits'])}",
                 file=output_file,

--- a/cpt_protein_blast_grouping/protein_blast_grouping.xml
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.xml
@@ -6,7 +6,7 @@
   <expand macro="requirements"/>
   <command detect_errors="aggressive">
     <![CDATA[
-      $__tool_directory__/protein_blast_grouping.py
+      python $__tool_directory__/protein_blast_grouping.py
       '${blast_in.blast}'
       --hits '$hits'
       --sort '$sort.sortType'

--- a/cpt_protein_blast_grouping/protein_blast_grouping.xml
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.xml
@@ -6,11 +6,11 @@
   <expand macro="requirements"/>
   <command detect_errors="aggressive">
     <![CDATA[
-      '$__tool_directory__/protein_blast_grouping.py'
+      $__tool_directory__/protein_blast_grouping.py
       '${blast_in.blast}'
       --hits '$hits'
       --sort '$sort.sortType'
-      > '$grouping_output'
+      --output '$grouping_output'
     ]]>
   </command>
   <inputs>
@@ -45,13 +45,14 @@
       <output name="grouping_output" file="outfile.txt" lines_diff="1"/>
     </test>
   </tests>
-  <help>
-**What it does**
-* Reads a tab-delimited BLAST output file.
-* Extracts organism names from the subject titles (text in square brackets).
-* Counts unique query proteins that matched each organism and unique hit proteins from each organism.
-* Sorts and displays results based on either unique queries or unique hits.
-* The output is a formatted table showing the top N organisms with the most matches.
+  <help><![CDATA[
+  **What it does**
+  * Reads a tab-delimited BLAST output file.
+  * Extracts organism names from the subject titles (text in square brackets).
+  * Counts unique query proteins that matched each organism and unique hit proteins from each organism.
+  * Sorts and displays results based on either unique queries or unique hits.
+  * The output is a formatted table showing the top N organisms with the most matches.
+  ]]>
 </help>
   <expand macro="citations-2020"/>
 </tool>

--- a/cpt_protein_blast_grouping/protein_blast_grouping.xml
+++ b/cpt_protein_blast_grouping/protein_blast_grouping.xml
@@ -1,0 +1,57 @@
+<tool id="edu.tamu.cpt.blast.protein_grouping" name="Protein Blast Grouping" version="0.0.1">
+  <description>Based on a BLASTp result</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="aggressive">
+    <![CDATA[
+      '$__tool_directory__/protein_blast_grouping.py'
+      '${blast_in.blast}'
+      --hits '$hits'
+      --sort '$sort.sortType'
+      > '$grouping_output'
+    ]]>
+  </command>
+  <inputs>
+    <conditional name="blast_in">
+      <param name="blastType" type="select" label="Blastn Input Type">
+        <option value="TSV">Blast Tabular</option>
+      </param>
+      <when value="TSV">
+        <param label="BLASTp Results" name="blast" type="data" format="tsv,tabular"/>
+      </when>
+    </conditional>
+    <param label="Number of results to return" name="hits" type="integer" value="5" min="1" max="30"/>
+    <conditional name="sort">
+      <param name="sortType" type="select" label="Sort by">
+        <option value="unique_queries" selected="true">Unique Queries</option>
+        <option value="unique_hits">Unique Hits</option>
+      </param>
+      <when value="unique_queries"/>
+      <when value="unique_hits"/>
+    </conditional>
+  </inputs>
+  <outputs>
+    <data format="tabular" name="grouping_output" label="Top BlastP Hits"/>
+  </outputs>
+  <tests>
+    <test>
+      <conditional name="blast_in">
+        <param name="blastType" value="TSV"/>
+        <param name="blast" value="infile.txt"/>
+      </conditional>
+      <param name="hits" value="20"/>
+      <output name="grouping_output" file="outfile.txt" lines_diff="1"/>
+    </test>
+  </tests>
+  <help>
+**What it does**
+* Reads a tab-delimited BLAST output file.
+* Extracts organism names from the subject titles (text in square brackets).
+* Counts unique query proteins that matched each organism and unique hit proteins from each organism.
+* Sorts and displays results based on either unique queries or unique hits.
+* The output is a formatted table showing the top N organisms with the most matches.
+</help>
+  <expand macro="citations-2020"/>
+</tool>

--- a/cpt_protein_blast_grouping/test-data/infile.txt
+++ b/cpt_protein_blast_grouping/test-data/infile.txt
@@ -1,0 +1,7414 @@
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNY41722.1	UNY41722.1 capsid scaffolding protein [Burkholderia phage Milagro]	UNY41722.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNY41662.1	UNY41662.1 capsid scaffolding protein [Burkholderia phage Musica]	UNY41662.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADP02333.1	ADP02333.1 gp40 [Burkholderia phage KL3]	ADP02333.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNY41778.1	UNY41778.1 capsid scaffolding protein [Burkholderia phage Menos]	UNY41778.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNY41833.1	UNY41833.1 capsid scaffolding protein [Burkholderia phage Momento]	UNY41833.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UKM53765.1	UKM53765.1 capsid scaffolding protein [Burkholderia phage PhiBP82.2]	UKM53765.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UPI15557.1	UPI15557.1 capsid scaffolding protein [Burkholderia phage PhiBP82.3]	UPI15557.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AFV51397.1	AFV51397.1 O capsid scaffolding protein [Burkholderia phage phiX216]	AFV51397.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AIP84294.1	AIP84294.1 phage capsid scaffolding (GPO) serine peptidase family protein [Burkholderia phage BEK]	AIP84294.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAZ72645.1	AAZ72645.1 phage capsid scaffolding protein [Burkholderia phage phiE52237]	AAZ72645.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ABO60716.1	ABO60716.1 gp3, phage capsid scaffolding protein (GPO) [Burkholderia phage phiE202]	ABO60716.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ABO60773.1	ABO60773.1 gp3, phage capsid scaffolding protein (GPO) [Burkholderia phage phiE12-2]	ABO60773.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WWY66145.1	WWY66145.1 head scaffolding protein [Burkholderia phage vB_HM387]	WWY66145.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QPI18543.1	QPI18543.1 capsid scaffolding protein [Burkholderia phage phiE094]	QPI18543.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QWY84948.1	QWY84948.1 capsid scaffolding protein [Burkholderia phage PK23]	QWY84948.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27622.1	QBP27622.1 capsid scaffolding protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27622.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADX32417.1	ADX32417.1 capsid scaffolding protein [Erwinia phage ENT90]	ADX32417.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AQT27281.1	AQT27281.1 capsid scaffolding protein [Salmonella phage SEN8]	AQT27281.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNA05911.1	UNA05911.1 capsid scaffolding protein [Yersinia phage vB_YenM_56.17]	UNA05911.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNA05864.1	UNA05864.1 capsid scaffolding protein [Yersinia phage vB_YenM_06.16-2]	UNA05864.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BCB23213.1	BCB23213.1 capsid scaffolding protein (O) [Burkholderia phage FLC5]	BCB23213.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AKA61129.1	AKA61129.1 putative capsid scaffolding protein [Burkholderia phage AP3]	AKA61129.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNA05966.1	UNA05966.1 capsid scaffolding protein [Yersinia phage vB_YenM_201.16]	UNA05966.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BDD79918.1	BDD79918.1 hypothetical protein [Burkholderia phage FLC10]	BDD79918.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADQ92392.1	ADQ92392.1 capsid scaffolding protein [Salmonella phage RE2010]	ADQ92392.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP08044.1	QBP08044.1 capsid scaffolding protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08044.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27772.1	QBP27772.1 capsid scaffolding protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27772.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27926.1	QBP27926.1 capsid scaffolding protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27926.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	USM11610.1	USM11610.1 capsid scaffolding protein [Burkholderia phage Carl1]	USM11610.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UKL54246.1	UKL54246.1 capsid scaffolding protein [Yersinia phage vB_YenM_31.17]	UKL54246.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBQ71996.1	QBQ71996.1 capsid scaffolding protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ71996.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADP02288.1	ADP02288.1 gp41 [Burkholderia phage KS5]	ADP02288.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAH1234681.1	CAH1234681.1 capsid-scaffolding protein [Escherichia phage Cartapus]	CAH1234681.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27417.1	QBP27417.1 capsid scaffolding protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27417.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP07824.1	QBP07824.1 capsid scaffolding protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07824.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27882.1	QBP27882.1 capsid scaffolding protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27882.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP08084.1	QBP08084.1 capsid scaffolding protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08084.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27657.1	QBP27657.1 capsid scaffolding protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27657.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ARB15685.1	ARB15685.1 capsid scaffolding protein [Klebsiella phage 4LV2017]	ARB15685.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP27979.1	QBP27979.1 capsid scaffolding protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27979.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBQ71731.1	QBQ71731.1 capsid scaffolding protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71731.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC10477.1	URC10477.1 capsid scaffolding protein [Escherichia phage vB_EcoM-813R9]	URC10477.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AVP40001.1	AVP40001.1 capsid scaffolding protein [Ralstonia phage RsoM1USA]	AVP40001.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNI73732.1	UNI73732.1 capsid scaffolding protein [Klebsiella phage KP12]	UNI73732.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADP02379.1	ADP02379.1 gp34 [Burkholderia phage KS14]	ADP02379.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BAP28109.1	BAP28109.1 hypothetical protein [Ralstonia phage RSY1]	BAP28109.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QPB09398.1	QPB09398.1 scaffolding protein [Burkholderia phage Mana]	QPB09398.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ALF02284.2	ALF02284.2 capsid scaffolding protein [Salmonella phage SEN4]	ALF02284.2	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	APC62517.1	APC62517.1 capsid scaffolding protein [Salmonella phage SEN5]	APC62517.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QYW06324.1	QYW06324.1 capsid scaffolding protein [Shewanella phage vB_SspM_M16-3]	QYW06324.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UNA05739.1	UNA05739.1 capsid scaffolding protein [Yersinia phage vB_YenM_42.18]	UNA05739.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBQ71547.1	QBQ71547.1 capsid scaffolding protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71547.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BAF52384.1	BAF52384.1 phage capsid scaffolding protein [Ralstonia phage RSA1]	BAF52384.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QYC52662.1	QYC52662.1 two transmembrane protein [Salmonella phage BIS20]	QYC52662.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WPJ53113.1	WPJ53113.1 capsid assembly scaffolding protein [Klebsiella phage RCIP0057]	WPJ53113.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43138.1	CAC43138.1 capsid scaffolding protein [Enterobacteria phage PhiD160]	CAC43138.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43128.1	CAC43128.1 capsid scaffolding protein [Enterobacteria phage PhiD124]	CAC43128.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43148.1	CAC43148.1 capsid scaffolding protein [Enterobacteria phage PhiD252]	CAC43148.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URE76621.1	URE76621.1 capsid scaffolding protein [Escherichia phage vB_EcoM-613R3]	URE76621.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UPI11451.1	UPI11451.1 hypothetical protein COILCCMC_00003 [Yersinia phage VB-YPM-4]	UPI11451.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QKE55583.1	QKE55583.1 hypothetical protein vBYpM46_00003 [Yersinia phage vB_YpM_46]	QKE55583.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UPI11501.1	UPI11501.1 hypothetical protein BFNKNBEH_00011 [Yersinia phage VB-YPM-18]	UPI11501.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WOZ56083.1	WOZ56083.1 hypothetical protein B476A_00003 [Yersinia phage vB_YpM_476A]	WOZ56083.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QKE55491.1	QKE55491.1 hypothetical protein vBYpM22_00006 [Yersinia phage vB_YpM_22]	QKE55491.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WOZ56123.1	WOZ56123.1 hypothetical protein B476B_00003 [Yersinia phage vB_YpM_476B]	WOZ56123.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43101.1	CAC43101.1 capsid scaffolding protein [Enterobacteria phage HK114]	CAC43101.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD37964.1	VUD37964.1 Phage capsid scaffolding protein [Peduovirus P22H1]	VUD37964.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UTC25949.1	UTC25949.1 capsid scaffolding protein [Salmonella phage vB_Sal_PHB48]	UTC25949.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ULG00982.1	ULG00982.1 capsid scaffolding protein [Escherichia phage 9W]	ULG00982.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD37921.1	VUD37921.1 Phage capsid scaffolding protein [Peduovirus P22H4]	VUD37921.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ULG01135.1	ULG01135.1 capsid scaffolding protein [Escherichia phage 10W]	ULG01135.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ULG00866.1	ULG00866.1 capsid scaffolding protein [Escherichia phage 11W]	ULG00866.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD39481.1	VUD39481.1 Phage capsid scaffolding protein [Peduovirus P24C9]	VUD39481.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AKH49375.1	AKH49375.1 capsid scaffolding protein [Escherichia phage pro483]	AKH49375.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WPJ21687.1	WPJ21687.1 capsid assembly scaffolding protein [Bacillus phage vB_BpuM-ZY1]	WPJ21687.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD39019.1	VUD39019.1 Phage capsid scaffolding protein [Peduovirus P24A7b]	VUD39019.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43153.1	CAC43153.1 capsid scaffolding protein [Enterobacteria phage PhiD266]	CAC43153.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WOZ55991.1	WOZ55991.1 hypothetical protein B115_00003 [Yersinia phage vB_YpM_115]	WOZ55991.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WOZ56037.1	WOZ56037.1 hypothetical protein B117_00003 [Yersinia phage vB_YpM_117]	WOZ56037.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ASD51184.1	ASD51184.1 capsid scaffolding protein [Erwinia phage EtG]	ASD51184.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAN28221.1	AAN28221.1 gpO [Escherichia phage Wphi]	AAN28221.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAG9593807.1	CAG9593807.1 hypothetical protein P2DC1_00003 [Peduovirus P2]	CAG9593807.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAN08366.1	AAN08366.1 gp4 [Salmonella phage PSP3]	AAN08366.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC09613.1	URC09613.1 capsid scaffolding protein [Escherichia phage vB_EcoM-569R9]	URC09613.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAG9593802.1	CAG9593802.1 hypothetical protein P2SIAC10_00041 [Peduovirus P2]	CAG9593802.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAG9593884.1	CAG9593884.1 hypothetical protein P2SIDE7_00038 [Peduovirus P2]	CAG9593884.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAH0786525.1	CAH0786525.1 hypothetical protein P2AC1_00040 [Escherichia phage P2_AC1]	CAH0786525.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QIW90062.1	QIW90062.1 capsid scaffolding serine peptidase family protein [Yersinia phage P37]	QIW90062.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URP83664.1	URP83664.1 capsid scaffolding protein [Escherichia phage S164]	URP83664.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43111.1	CAC43111.1 capsid scaffolding protein [Enterobacteria phage HK240]	CAC43111.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AGX84566.1	AGX84566.1 capsid scaffold [Enterobacteria phage fiAA91-ss]	AGX84566.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43171.1	CAC43171.1 capsid scaffolding protein [Peduovirus Wphi]	CAC43171.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WXX18239.1	WXX18239.1 major capsid protein [Yersinia phage GCS667]	WXX18239.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC10092.1	URC10092.1 capsid scaffolding protein [Escherichia phage vB_EcoM-640R3]	URC10092.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WFG40975.1	WFG40975.1 head scaffolding protein [Salmonella phage MET_P1_103_31]	WFG40975.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAC34149.1	AAC34149.1 V protein [Escherichia phage 186]	AAC34149.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AGF88416.1	AGF88416.1 capsid-scaffolding protein [Salmonella phage FSLSP004]	AGF88416.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AJA72927.1	AJA72927.1 capsid scaffolding protein O [Mannheimia phage vB_MhM_587AP1]	AJA72927.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ALF02242.1	ALF02242.1 capsid scaffolding protein [Salmonella phage SEN1]	ALF02242.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WWQ72086.1	WWQ72086.1 capsid scaffolding protein [Pseudomonas phage Sirocco]	WWQ72086.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43077.1	CAC43077.1 capsid scaffolding protein [Enterobacteria phage 299]	CAC43077.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QEI25343.1	QEI25343.1 capsid scaffolding protein [Salmonella phage SI22]	QEI25343.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QEI25388.1	QEI25388.1 capsid scaffolding protein [Salmonella phage SW9]	QEI25388.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43106.1	CAC43106.1 capsid scaffolding protein [Enterobacteria phage HK239]	CAC43106.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ABD90604.1	ABD90604.1 capsid scaffolding protein O [Mannheimia phage phiMhaA1-BAA410]	ABD90604.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ABD90555.1	ABD90555.1 capsid scaffolding protein O [Mannheimia phage PHL101]	ABD90555.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AJA73107.1	AJA73107.1 capsid scaffolding protein O [Mannheimia phage vB_MhM_2256AP1]	AJA73107.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AJA72876.1	AJA72876.1 capsid scaffolding protein O [Mannheimia phage vB_MhM_535AP1]	AJA72876.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AFL46451.1	AFL46451.1 capsid scaffolding protein O [Mannheimia phage vB_MhM_1152AP]	AFL46451.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QXF95269.1	QXF95269.1 capsid scaffolding protein [Yersinia phage HQ103]	QXF95269.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	API82938.1	API82938.1 Phage capsid scaffolding protein (GPO) serine peptidase [Salmonella phage STYP1]	API82938.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43096.1	CAC43096.1 capsid scaffolding protein [Enterobacteria phage HK113]	CAC43096.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AKH49343.1	AKH49343.1 capsid scaffolding protein [Escherichia phage pro147]	AKH49343.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43086.1	CAC43086.1 capsid scaffolding protein [Enterobacteria phage HK109]	CAC43086.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAP04440.1	AAP04440.1 gpO [Yersinia phage L-413C]	AAP04440.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAD03270.1	AAD03270.1 gpO [Bacteriophage P2]	AAD03270.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43133.1	CAC43133.1 capsid scaffolding protein [Enterobacteria phage PhiD145]	CAC43133.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43158.1	CAC43158.1 capsid scaffolding protein [Enterobacteria phage PK]	CAC43158.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QKE55627.1	QKE55627.1 hypothetical protein vBYpM50_00006 [Yersinia phage vB_YpM_50]	QKE55627.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC10014.1	URC10014.1 capsid scaffolding protein [Escherichia phage vB_EcoM-473R3]	URC10014.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UYL85506.1	UYL85506.1 capsid scaffolding protein [Acidovorax phage Alfacinha1]	UYL85506.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QDJ98469.1	QDJ98469.1 capsid assembly scaffolding protein [Escherichia phage vB_EcoM-12474II]	QDJ98469.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43116.1	CAC43116.1 capsid scaffolding protein [Enterobacteria phage HK241]	CAC43116.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QDJ98601.1	QDJ98601.1 capsid assembly scaffolding protein [Escherichia phage vB_EcoM-12474V]	QDJ98601.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QDJ98557.1	QDJ98557.1 capsid assembly scaffolding protein [Escherichia phage vB_EcoM-12474IV]	QDJ98557.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QDJ98472.1	QDJ98472.1 capsid assembly scaffolding protein [Escherichia phage vB_EcoM-12474III]	QDJ98472.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QDP43497.1	QDP43497.1 capsid scaffolding protein [Bacteriophage R18C]	QDP43497.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ULG00680.1	ULG00680.1 capsid scaffolding protein [Escherichia phage D8]	ULG00680.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD38858.1	VUD38858.1 Phage capsid scaffolding protein [Peduovirus P24E6b]	VUD38858.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ULG01140.1	ULG01140.1 capsid scaffolding protein [Escherichia phage 12W]	ULG01140.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43143.1	CAC43143.1 capsid scaffolding protein [Phage PhiD218]	CAC43143.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43072.1	CAC43072.1 capsid scaffolding protein [Enterobacteria phage 18]	CAC43072.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AZF87845.1	AZF87845.1 capsid scaffolding protein [Pseudomonas phage Dobby]	AZF87845.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BAA36229.1	BAA36229.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36229.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43123.1	CAC43123.1 capsid scaffolding protein [Enterobacteria phage PhiD5]	CAC43123.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBI84112.1	QBI84112.1 capsid scaffolding protein [Pseudomonas phage vB_Pae_BR319a]	QBI84112.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD38008.1	VUD38008.1 Phage capsid scaffolding protein [Peduovirus P24B2]	VUD38008.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AJA73055.1	AJA73055.1 capsid scaffolding protein O [Mannheimia phage vB_MhM_1127AP1]	AJA73055.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC09852.1	URC09852.1 capsid scaffolding protein [Escherichia phage vB_EcoM-720R8]	URC09852.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WYC18442.1	WYC18442.1 capsid scaffolding protein [Yersinia phage vB_YpM_MHG38]	WYC18442.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WYC18374.1	WYC18374.1 capsid scaffolding protein [Yersinia phage vB_YpM_MDG94-186]	WYC18374.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WYC18400.1	WYC18400.1 capsid scaffolding protein [Yersinia phage vB_YpM_MDG45]	WYC18400.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	CAC43091.1	CAC43091.1 capsid scaffolding protein [Enterobacteria phage HK111]	CAC43091.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AGG36519.1	AGG36519.1 phage capsid scaffolding protein [Escherichia phage P2]	AGG36519.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UYL85405.1	UYL85405.1 capsid scaffolding protein [Acidovorax phage Alfacinha3]	UYL85405.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UGC97286.1	UGC97286.1 capsid scaffolding protein [Aeromonas phage vB_AsaM_LPM4]	UGC97286.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ARB15639.1	ARB15639.1 capsid scaffolding protein [Klebsiella phage 3LV2017]	ARB15639.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AYD79790.1	AYD79790.1 hypothetical protein OGLPLLMI_00024 [Enterobacter phage phiT5282H]	AYD79790.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP07916.1	QBP07916.1 capsid scaffolding protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07916.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AFJ75478.1	AFJ75478.1 phage capsid scaffolding protein [Stenotrophomonas phage Smp131]	AFJ75478.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QBP07939.1	QBP07939.1 capsid scaffolding protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07939.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAA32203.1	AAA32203.1 V protein, partial [Eganvirus ev186]	AAA32203.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BAH15160.1	BAH15160.1 scaffolding protein [Serratia phage KSP20]	BAH15160.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URE76766.1	URE76766.1 capsid scaffolding protein [Escherichia phage vB_EcoM-705R2]	URE76766.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	URC09568.1	URC09568.1 capsid scaffolding protein [Escherichia phage vB_EcoM-569R5]	URC09568.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AIZ95133.1	AIZ95133.1 capsid scaffolding protein [Escherichia phage P88]	AIZ95133.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUD40165.1	VUD40165.1 Phage capsid scaffolding protein [Xuanwuvirus P884B11]	VUD40165.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WOZ57141.1	WOZ57141.1 gpO family capsid scaffolding protein [Citrobacter phage Shae_phiSM]	WOZ57141.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AGK86778.1	AGK86778.1 phage capsid scaffolding protein [Burkholderia phage ST79]	AGK86778.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AUR95199.1	AUR95199.1 capsid scaffolding protein (GPO) serine peptidase [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95199.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QGF21296.1	QGF21296.1 capsid scaffolding protein [Vibrio phage vB_ValM-yong1]	QGF21296.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WPJ21748.1	WPJ21748.1 capsid scaffolding protein [Vibrio phage L9-1]	WPJ21748.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QMP23898.1	QMP23898.1 capsid scaffolding protein [Vibrio phage ValB1MD-2]	QMP23898.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WBY65476.1	WBY65476.1 hypothetical protein FP3_000045 [Pasteurella phage vB_PmuM_CFP3]	WBY65476.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ADX32378.1	ADX32378.1 putative capsid scaffolding protein [Cronobacter phage ESSI-2]	ADX32378.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UKL54201.1	UKL54201.1 capsid scaffolding protein [Yersinia phage vB_YenM_324]	UKL54201.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WMT83781.1	WMT83781.1 prohead protease/scaffold [Pseudoalteromonas phage proACA1-A]	WMT83781.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WMT83729.1	WMT83729.1 prohead protease/scaffold [Pseudoalteromonas phage ACA2]	WMT83729.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WMT83677.1	WMT83677.1 prohead protease/scaffold [Pseudoalteromonas phage ACA1]	WMT83677.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AOY11833.1	AOY11833.1 capsid-scaffolding protein [Salinivibrio phage SMHB1]	AOY11833.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAB09202.1	AAB09202.1 hypothetical protein [Haemophilus phage HP1]	AAB09202.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAK37799.1	AAK37799.1 orf17 [Haemophilus phage HP2]	AAK37799.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	UYE91964.1	UYE91964.1 capsid protein [Aeromonas phage A051]	UYE91964.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ABG73175.1	ABG73175.1 putative capsid scaffolding protein [Aeromonas phage phiO18P]	ABG73175.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAZ93655.1	AAZ93655.1 unknown [Pasteurella phage F108]	AAZ93655.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ALY08258.1	ALY08258.1 serine peptidase [Pseudomonas phage phi3]	ALY08258.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WGL39675.1	WGL39675.1 capsid scaffolding protein [Aeromonas phage P05B]	WGL39675.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	WKV24004.1	WKV24004.1 capsid scaffolding protein [Pseudomonas phage PaBSM-2607-JFK]	WKV24004.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	ANA87655.1	ANA87655.1 capsid scaffolding protein [Vibrio phage VcP032]	ANA87655.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	BAF98816.1	BAF98816.1 putative capsid scaffolding protein [Vibrio phage Kappa]	BAF98816.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AAL47516.1	AAL47516.1 orf17 [Bacteriophage K139]	AAL47516.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	AGW43561.1	AGW43561.1 capsid-scaffolding protein [Vibrio phage VPUSM 8]	AGW43561.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUF53426.1	VUF53426.1 Phage capsid scaffolding protein [Escherichia phage ESSI2_ev239]	VUF53426.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QEI25523.1	QEI25523.1 capsid scaffolding protein [Salmonella phage SW3]	QEI25523.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QEI25485.1	QEI25485.1 capsid scaffolding protein [Salmonella phage SW5]	QEI25485.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	QEI25432.1	QEI25432.1 capsid scaffolding protein [Salmonella phage SI7]	QEI25432.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	APM00236.1	APM00236.1 capsid scaffolding protein [Pseudoalteromonas phage C5a]	APM00236.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUF53471.1	VUF53471.1 probable capsid scaffolding protein [Escherichia phage ESSI2_ev040]	VUF53471.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUF53441.1	VUF53441.1 capsid scaffolding protein [Escherichia phage ESSI2_ev015]	VUF53441.1	0
+99974bdd-2c83-421a-b7a3-dab7d44153ab	VUF53507.1	VUF53507.1 capsid scaffolding protein [Escherichia phage ESSI2_ev129]	VUF53507.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNY41663.1	UNY41663.1 major capsid protein [Burkholderia phage Musica]	UNY41663.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNY41723.1	UNY41723.1 major capsid protein [Burkholderia phage Milagro]	UNY41723.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADP02332.1	ADP02332.1 gp39 [Burkholderia phage KL3]	ADP02332.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNY41779.1	UNY41779.1 major capsid protein [Burkholderia phage Menos]	UNY41779.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNY41834.1	UNY41834.1 major capsid protein [Burkholderia phage Momento]	UNY41834.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ABO60701.1	ABO60701.1 gp2, phage major capsid protein, P2 family [Burkholderia phage phiE202]	ABO60701.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAZ72643.1	AAZ72643.1 P2 family phage major capsid protein [Burkholderia phage phiE52237]	AAZ72643.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UPI15558.1	UPI15558.1 major capsid protein [Burkholderia phage PhiBP82.3]	UPI15558.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QPI18544.1	QPI18544.1 major capsid protein [Burkholderia phage phiE094]	QPI18544.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AIP84271.1	AIP84271.1 phage major capsid protein, P2 family [Burkholderia phage BEK]	AIP84271.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AFV51398.1	AFV51398.1 N capsid protein [Burkholderia phage phiX216]	AFV51398.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ABO60795.1	ABO60795.1 gp2, phage major capsid protein, P2 family [Burkholderia phage phiE12-2]	ABO60795.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WWY66146.1	WWY66146.1 major capsid protein [Burkholderia phage vB_HM387]	WWY66146.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QWY84949.1	QWY84949.1 major capsid protein [Burkholderia phage PK23]	QWY84949.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UKM53766.1	UKM53766.1 major capsid protein [Burkholderia phage PhiBP82.2]	UKM53766.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADP02378.1	ADP02378.1 gp33 [Burkholderia phage KS14]	ADP02378.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AVP40002.1	AVP40002.1 capsid protein [Ralstonia phage RsoM1USA]	AVP40002.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	USM11611.1	USM11611.1 major capsid precursor [Burkholderia phage Carl1]	USM11611.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADP02287.1	ADP02287.1 gp40 [Burkholderia phage KS5]	ADP02287.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AKA61130.1	AKA61130.1 putative major capsid protein [Burkholderia phage AP3]	AKA61130.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QPB09399.1	QPB09399.1 major capsid protein [Burkholderia phage Mana]	QPB09399.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BAP28110.1	BAP28110.1 hypothetical protein [Ralstonia phage RSY1]	BAP28110.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QYW06323.1	QYW06323.1 major capsid protein [Shewanella phage vB_SspM_M16-3]	QYW06323.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BAF52385.1	BAF52385.1 P2 family phage major capsid protein [Ralstonia phage RSA1]	BAF52385.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BCB23212.1	BCB23212.1 capsid protein (N) [Burkholderia phage FLC5]	BCB23212.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BDD79919.1	BDD79919.1 hypothetical protein [Burkholderia phage FLC10]	BDD79919.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WWQ72087.1	WWQ72087.1 major capsid protein, P2 family [Pseudomonas phage Sirocco]	WWQ72087.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBI84113.1	QBI84113.1 major capsid protein [Pseudomonas phage vB_Pae_BR319a]	QBI84113.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AZF87846.1	AZF87846.1 major capsid protein [Pseudomonas phage Dobby]	AZF87846.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27621.1	QBP27621.1 major capsid protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27621.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BAA36230.1	BAA36230.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36230.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADX32413.1	ADX32413.1 major capsid protein [Erwinia phage ENT90]	ADX32413.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WPJ21688.1	WPJ21688.1 major capsid protein [Bacillus phage vB_BpuM-ZY1]	WPJ21688.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADQ92393.1	ADQ92393.1 major capsid protein [Salmonella phage RE2010]	ADQ92393.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNA05740.1	UNA05740.1 major capsid protein [Yersinia phage vB_YenM_42.18]	UNA05740.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBQ71997.1	QBQ71997.1 P2 family major capsid protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ71997.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AGK86779.1	AGK86779.1 phage major capsid protein [Burkholderia phage ST79]	AGK86779.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27418.1	QBP27418.1 major capsid protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27418.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP07823.1	QBP07823.1 major capsid protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07823.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27881.1	QBP27881.1 major capsid protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27881.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP08085.1	QBP08085.1 major capsid protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08085.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27658.1	QBP27658.1 major capsid protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27658.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27978.1	QBP27978.1 P2 family major capsid protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27978.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBQ71730.1	QBQ71730.1 major capsid protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71730.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AQT27282.1	AQT27282.1 major capsid protein [Salmonella phage SEN8]	AQT27282.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ARB15686.1	ARB15686.1 major capsid protein [Klebsiella phage 4LV2017]	ARB15686.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43124.1	CAC43124.1 major capsid protein [Enterobacteria phage PhiD5]	CAC43124.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAH1234682.1	CAH1234682.1 major capsid protein, P2 family [Escherichia phage Cartapus]	CAH1234682.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC10476.1	URC10476.1 major capsid protein [Escherichia phage vB_EcoM-813R9]	URC10476.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNI73731.1	UNI73731.1 major capsid protein [Klebsiella phage KP12]	UNI73731.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC10093.1	URC10093.1 major capsid protein [Escherichia phage vB_EcoM-640R3]	URC10093.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP08043.1	QBP08043.1 major capsid protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08043.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27771.1	QBP27771.1 major capsid protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27771.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP27925.1	QBP27925.1 major capsid protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27925.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QKE55628.1	QKE55628.1 hypothetical protein vBYpM50_00007 [Yersinia phage vB_YpM_50]	QKE55628.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43102.1	CAC43102.1 major capsid protein [Enterobacteria phage HK114]	CAC43102.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD39020.1	VUD39020.1 Phage major capsid protein [Peduovirus P24A7b]	VUD39020.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QIW90061.1	QIW90061.1 P2 family major capsid protein [Yersinia phage P37]	QIW90061.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBQ71548.1	QBQ71548.1 major capsid protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71548.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAG9593801.1	CAG9593801.1 hypothetical protein P2SIAC10_00040 [Peduovirus P2]	CAG9593801.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43112.1	CAC43112.1 major capsid protein [Enterobacteria phage HK240]	CAC43112.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UPI11502.1	UPI11502.1 hypothetical protein BFNKNBEH_00012 [Yersinia phage VB-YPM-18]	UPI11502.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WOZ56084.1	WOZ56084.1 hypothetical protein B476A_00004 [Yersinia phage vB_YpM_476A]	WOZ56084.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QKE55492.1	QKE55492.1 hypothetical protein vBYpM22_00007 [Yersinia phage vB_YpM_22]	QKE55492.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WOZ56124.1	WOZ56124.1 hypothetical protein B476B_00004 [Yersinia phage vB_YpM_476B]	WOZ56124.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD37965.1	VUD37965.1 Phage major capsid protein [Peduovirus P22H1]	VUD37965.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43154.1	CAC43154.1 major capsid protein [Enterobacteria phage PhiD266]	CAC43154.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAD03271.1	AAD03271.1 gpN [Bacteriophage P2]	AAD03271.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	USS98702.1	USS98702.1 major capsid protein, partial [Escherichia phage MMS10]	USS98702.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43149.1	CAC43149.1 major capsid protein [Enterobacteria phage PhiD252]	CAC43149.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD38009.1	VUD38009.1 Phage major capsid protein [Peduovirus P24B2]	VUD38009.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43159.1	CAC43159.1 major capsid protein [Enterobacteria phage PK]	CAC43159.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UPI11452.1	UPI11452.1 hypothetical protein COILCCMC_00004 [Yersinia phage VB-YPM-4]	UPI11452.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QKE55584.1	QKE55584.1 hypothetical protein vBYpM46_00004 [Yersinia phage vB_YpM_46]	QKE55584.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QDJ98468.1	QDJ98468.1 capsid protein [Escherichia phage vB_EcoM-12474II]	QDJ98468.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QDJ98600.1	QDJ98600.1 capsid protein [Escherichia phage vB_EcoM-12474V]	QDJ98600.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QXF95270.1	QXF95270.1 major capsid protein [Yersinia phage HQ103]	QXF95270.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QDJ98556.1	QDJ98556.1 capsid protein [Escherichia phage vB_EcoM-12474IV]	QDJ98556.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAH0786524.1	CAH0786524.1 hypothetical protein P2AC1_00039 [Escherichia phage P2_AC1]	CAH0786524.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43087.1	CAC43087.1 major capsid protein [Enterobacteria phage HK109]	CAC43087.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAP04441.1	AAP04441.1 gpN [Yersinia phage L-413C]	AAP04441.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ULG01134.1	ULG01134.1 major capsid protein [Escherichia phage 10W]	ULG01134.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ULG00867.1	ULG00867.1 major capsid protein [Escherichia phage 11W]	ULG00867.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD39484.1	VUD39484.1 Phage major capsid protein [Peduovirus P24C9]	VUD39484.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43139.1	CAC43139.1 major capsid protein [Enterobacteria phage PhiD160]	CAC43139.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43073.1	CAC43073.1 major capsid protein [Enterobacteria phage 18]	CAC43073.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AKH49376.1	AKH49376.1 major capsid protein [Escherichia phage pro483]	AKH49376.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43097.1	CAC43097.1 major capsid protein [Enterobacteria phage HK113]	CAC43097.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ULG00983.1	ULG00983.1 major capsid protein [Escherichia phage 9W]	ULG00983.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD37922.1	VUD37922.1 Phage major capsid protein [Peduovirus P22H4]	VUD37922.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC10013.1	URC10013.1 major capsid protein [Escherichia phage vB_EcoM-473R3]	URC10013.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AKH49342.1	AKH49342.1 major capsid protein [Escherichia phage pro147]	AKH49342.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	API82939.1	API82939.1 Phage major capsid protein, P2 family [Salmonella phage STYP1]	API82939.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43078.1	CAC43078.1 major capsid protein [Enterobacteria phage 299]	CAC43078.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WFG40974.1	WFG40974.1 major capsid protein [Salmonella phage MET_P1_103_31]	WFG40974.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43134.1	CAC43134.1 major capsid protein [Enterobacteria phage PhiD145]	CAC43134.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAG9593808.1	CAG9593808.1 hypothetical protein P2DC1_00004 [Peduovirus P2]	CAG9593808.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43107.1	CAC43107.1 major capsid protein [Enterobacteria phage HK239]	CAC43107.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WOZ55992.1	WOZ55992.1 hypothetical protein B115_00004 [Yersinia phage vB_YpM_115]	WOZ55992.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WOZ56038.1	WOZ56038.1 hypothetical protein B117_00004 [Yersinia phage vB_YpM_117]	WOZ56038.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ULG00681.1	ULG00681.1 major capsid protein [Escherichia phage D8]	ULG00681.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD38860.1	VUD38860.1 Phage major capsid protein [Peduovirus P24E6b]	VUD38860.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ULG01141.1	ULG01141.1 major capsid protein [Escherichia phage 12W]	ULG01141.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43117.1	CAC43117.1 major capsid protein [Enterobacteria phage HK241]	CAC43117.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QDP43498.1	QDP43498.1 major capsid protein [Bacteriophage R18C]	QDP43498.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43144.1	CAC43144.1 major capsid protein [Phage PhiD218]	CAC43144.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URP83665.1	URP83665.1 major capsid protein [Escherichia phage S164]	URP83665.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AGX84567.1	AGX84567.1 major capsid protein precursor [Enterobacteria phage fiAA91-ss]	AGX84567.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAG9593883.1	CAG9593883.1 hypothetical protein P2SIDE7_00037 [Peduovirus P2]	CAG9593883.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UYL85507.1	UYL85507.1 major capsid protein, P2 family [Acidovorax phage Alfacinha1]	UYL85507.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43092.1	CAC43092.1 major capsid protein [Enterobacteria phage HK111]	CAC43092.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAN28222.1	AAN28222.1 gpN [Escherichia phage Wphi]	AAN28222.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43172.1	CAC43172.1 major capsid protein [Peduovirus Wphi]	CAC43172.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WPJ53112.1	WPJ53112.1 capsid protein [Klebsiella phage RCIP0057]	WPJ53112.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URE76620.1	URE76620.1 major capsid protein [Escherichia phage vB_EcoM-613R3]	URE76620.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	CAC43129.1	CAC43129.1 major capsid protein [Enterobacteria phage PhiD124]	CAC43129.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAC34150.1	AAC34150.1 major capsid protein [Escherichia phage 186]	AAC34150.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QYC52663.1	QYC52663.1 major capsid protein [Salmonella phage BIS20]	QYC52663.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UTC25948.1	UTC25948.1 major capsid protein [Salmonella phage vB_Sal_PHB48]	UTC25948.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ALF02243.1	ALF02243.1 major capsid protein [Salmonella phage SEN1]	ALF02243.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QEI25344.1	QEI25344.1 major capsid protein [Salmonella phage SI22]	QEI25344.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QEI25389.1	QEI25389.1 P2 family major capsid protein [Salmonella phage SW9]	QEI25389.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ASD51183.1	ASD51183.1 major capsid protein [Erwinia phage EtG]	ASD51183.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UYL85406.1	UYL85406.1 major capsid protein, P2 family [Acidovorax phage Alfacinha3]	UYL85406.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WXX18238.1	WXX18238.1 major capsid protein [Yersinia phage GCS667]	WXX18238.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAN08367.1	AAN08367.1 gp5 [Salmonella phage PSP3]	AAN08367.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WYC18443.1	WYC18443.1 major capsid protein [Yersinia phage vB_YpM_MHG38]	WYC18443.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WYC18375.1	WYC18375.1 major capsid protein [Yersinia phage vB_YpM_MDG94-186]	WYC18375.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WYC18401.1	WYC18401.1 major capsid protein [Yersinia phage vB_YpM_MDG45]	WYC18401.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AGG36520.1	AGG36520.1 phage major capsid protein [Escherichia phage P2]	AGG36520.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AGF88417.1	AGF88417.1 capsid protein [Salmonella phage FSLSP004]	AGF88417.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UKL54247.1	UKL54247.1 major capsid protein [Yersinia phage vB_YenM_31.17]	UKL54247.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UZV40208.1	UZV40208.1 major capsid protein, P2 family [Acidovorax phage Acica]	UZV40208.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNA05912.1	UNA05912.1 major capsid protein [Yersinia phage vB_YenM_56.17]	UNA05912.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNA05865.1	UNA05865.1 major capsid protein [Yersinia phage vB_YenM_06.16-2]	UNA05865.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UNA05967.1	UNA05967.1 major capsid protein [Yersinia phage vB_YenM_201.16]	UNA05967.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UGC97285.1	UGC97285.1 major capsid protein [Aeromonas phage vB_AsaM_LPM4]	UGC97285.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC09615.1	URC09615.1 major capsid protein [Escherichia phage vB_EcoM-569R9]	URC09615.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AFJ75479.1	AFJ75479.1 phage major capsid protein precursor [Stenotrophomonas phage Smp131]	AFJ75479.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AJA72928.1	AJA72928.1 major capsid protein N [Mannheimia phage vB_MhM_587AP1]	AJA72928.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AJA73056.1	AJA73056.1 major capsid protein N [Mannheimia phage vB_MhM_1127AP1]	AJA73056.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ABD90605.1	ABD90605.1 major capsid protein N [Mannheimia phage phiMhaA1-BAA410]	ABD90605.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ABD90556.1	ABD90556.1 major capsid protein N [Mannheimia phage PHL101]	ABD90556.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AJA73108.1	AJA73108.1 major capsid protein N [Mannheimia phage vB_MhM_2256AP1]	AJA73108.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AJA72877.1	AJA72877.1 major capsid protein N [Mannheimia phage vB_MhM_535AP1]	AJA72877.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AFL46452.1	AFL46452.1 major capsid protein N [Mannheimia phage vB_MhM_1152AP]	AFL46452.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ALF02293.1	ALF02293.1 major capsid protein [Salmonella phage SEN4]	ALF02293.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ALF02342.1	ALF02342.1 major capsid protein [Salmonella phage SEN5]	ALF02342.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AIZ95134.1	AIZ95134.1 major capsid protein [Escherichia phage P88]	AIZ95134.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WOZ57140.1	WOZ57140.1 major capsid protein [Citrobacter phage Shae_phiSM]	WOZ57140.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URE76767.1	URE76767.1 major capsid protein [Escherichia phage vB_EcoM-705R2]	URE76767.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC09569.1	URC09569.1 major capsid protein [Escherichia phage vB_EcoM-569R5]	URC09569.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ALY08259.1	ALY08259.1 major capsid protein [Pseudomonas phage phi3]	ALY08259.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BAH15161.1	BAH15161.1 major capsid protein [Serratia phage KSP20]	BAH15161.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ARB15640.1	ARB15640.1 major capsid protein [Klebsiella phage 3LV2017]	ARB15640.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WKV24005.1	WKV24005.1 major capsid protein [Pseudomonas phage PaBSM-2607-JFK]	WKV24005.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP07915.1	QBP07915.1 major capsid protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07915.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AYD79791.1	AYD79791.1 hypothetical protein OGLPLLMI_00025 [Enterobacter phage phiT5282H]	AYD79791.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QBP07940.1	QBP07940.1 major capsid protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07940.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC09850.1	URC09850.1 major capsid protein [Escherichia phage vB_EcoM-720R8]	URC09850.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WMT83782.1	WMT83782.1 major capsid protein [Pseudoalteromonas phage proACA1-A]	WMT83782.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WMT83730.1	WMT83730.1 major capsid protein [Pseudoalteromonas phage ACA2]	WMT83730.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WMT83678.1	WMT83678.1 major capsid protein [Pseudoalteromonas phage ACA1]	WMT83678.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QDJ98515.1	QDJ98515.1 capsid protein [Escherichia phage vB_EcoM-12474III]	QDJ98515.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	APM00237.1	APM00237.1 major capsid protein [Pseudoalteromonas phage C5a]	APM00237.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AGW43562.1	AGW43562.1 capsid protein [Vibrio phage VPUSM 8]	AGW43562.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UKL54202.1	UKL54202.1 major capsid protein [Yersinia phage vB_YenM_324]	UKL54202.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ANA87656.1	ANA87656.1 major capsid protein [Vibrio phage VcP032]	ANA87656.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	BAF98817.1	BAF98817.1 putative major capsid protein [Vibrio phage Kappa]	BAF98817.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAL47517.1	AAL47517.1 orf18 [Bacteriophage K139]	AAL47517.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AOY11834.1	AOY11834.1 capsid protein [Salinivibrio phage SMHB1]	AOY11834.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUF53412.1	VUF53412.1 Phage major capsid protein [Escherichia phage ESSI2_ev239]	VUF53412.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QEI25524.1	QEI25524.1 P2 family major capsid protein [Salmonella phage SW3]	QEI25524.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QEI25486.1	QEI25486.1 P2 family major capsid protein [Salmonella phage SW5]	QEI25486.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QEI25433.1	QEI25433.1 P2 family major capsid protein [Salmonella phage SI7]	QEI25433.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUF53484.1	VUF53484.1 Phage major capsid protein [Escherichia phage ESSI2_ev129]	VUF53484.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ABG73176.1	ABG73176.1 putative major capsid protein [Aeromonas phage phiO18P]	ABG73176.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUF53453.1	VUF53453.1 Phage major capsid protein [Escherichia phage ESSI2_ev040]	VUF53453.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUF53429.1	VUF53429.1 Phage major capsid protein [Escherichia phage ESSI2_ev015]	VUF53429.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	UYE91965.1	UYE91965.1 major capsid protein [Aeromonas phage A051]	UYE91965.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AUR95200.1	AUR95200.1 P2 family major capsid protein [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95200.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WGL39676.1	WGL39676.1 major capsid protein [Aeromonas phage P05B]	WGL39676.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	ADX32373.1	ADX32373.1 major capsid protein [Cronobacter phage ESSI-2]	ADX32373.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	VUD40167.1	VUD40167.1 Phage major capsid protein [Xuanwuvirus P884B11]	VUD40167.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QGF21297.1	QGF21297.1 major capsid protein [Vibrio phage vB_ValM-yong1]	QGF21297.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	QMP23897.1	QMP23897.1 P2 family major capsid protein [Vibrio phage ValB1MD-2]	QMP23897.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WPJ21749.1	WPJ21749.1 major capsid protein, P2 family [Vibrio phage L9-1]	WPJ21749.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAK37800.1	AAK37800.1 orf18 [Haemophilus phage HP2]	AAK37800.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAB09203.1	AAB09203.1 hypothetical protein [Haemophilus phage HP1]	AAB09203.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	AAZ93656.1	AAZ93656.1 unknown [Pasteurella phage F108]	AAZ93656.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	WBY65475.1	WBY65475.1 hypothetical protein FP3_000044 [Pasteurella phage vB_PmuM_CFP3]	WBY65475.1	0
+0abc2a9f-ebe7-4fcf-8cac-ab5c5f5722d1	URC09851.1	URC09851.1 major capsid protein [Escherichia phage vB_EcoM-720R8]	URC09851.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNY41724.1	UNY41724.1 terminase small subunit [Burkholderia phage Milagro]	UNY41724.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNY41664.1	UNY41664.1 terminase small subunit [Burkholderia phage Musica]	UNY41664.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADP02331.1	ADP02331.1 gp38 [Burkholderia phage KL3]	ADP02331.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNY41780.1	UNY41780.1 terminase small subunit [Burkholderia phage Menos]	UNY41780.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNY41835.1	UNY41835.1 terminase small subunit [Burkholderia phage Momento]	UNY41835.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QWY84950.1	QWY84950.1 terminase endonuclease subunit [Burkholderia phage PK23]	QWY84950.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAZ72642.1	AAZ72642.1 phage small terminase subunit [Burkholderia phage phiE52237]	AAZ72642.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ABO60765.1	ABO60765.1 gp1, phage small terminase subunit [Burkholderia phage phiE12-2]	ABO60765.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WWY66147.1	WWY66147.1 terminase small subunit [Burkholderia phage vB_HM387]	WWY66147.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UPI15559.1	UPI15559.1 terminase, endonuclease subunit [Burkholderia phage PhiBP82.3]	UPI15559.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AFV51399.1	AFV51399.1 M terminase endonuclease subunit [Burkholderia phage phiX216]	AFV51399.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QPI18538.1	QPI18538.1 terminase small subunit [Burkholderia phage phiE094]	QPI18538.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ABO60709.1	ABO60709.1 gp1, phage terminase, endonuclease subunit [Burkholderia phage phiE202]	ABO60709.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UKM53767.1	UKM53767.1 terminase, endonuclease subunit [Burkholderia phage PhiBP82.2]	UKM53767.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BCB23211.1	BCB23211.1 terminase endonuclease subunit (M) [Burkholderia phage FLC5]	BCB23211.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BDD79920.1	BDD79920.1 hypothetical protein [Burkholderia phage FLC10]	BDD79920.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADP02377.1	ADP02377.1 gp32 [Burkholderia phage KS14]	ADP02377.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AKA61131.1	AKA61131.1 putative small terminase subunit [Burkholderia phage AP3]	AKA61131.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AIP84300.1	AIP84300.1 phage small terminase subunit [Burkholderia phage BEK]	AIP84300.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QPB09400.1	QPB09400.1 terminase small subunit [Burkholderia phage Mana]	QPB09400.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AVP40003.1	AVP40003.1 terminase small subunit [Ralstonia phage RsoM1USA]	AVP40003.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	USM11612.1	USM11612.1 terminase small subunit [Burkholderia phage Carl1]	USM11612.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADP02286.1	ADP02286.1 gp39 [Burkholderia phage KS5]	ADP02286.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WPJ21689.1	WPJ21689.1 small terminase subunit [Bacillus phage vB_BpuM-ZY1]	WPJ21689.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BAP28111.1	BAP28111.1 hypothetical protein [Ralstonia phage RSY1]	BAP28111.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BAF52386.1	BAF52386.1 terminase [Ralstonia phage RSA1]	BAF52386.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ABD90606.1	ABD90606.1 terminase small subunit [Mannheimia phage phiMhaA1-BAA410]	ABD90606.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ABD90557.1	ABD90557.1 terminase small subunit [Mannheimia phage PHL101]	ABD90557.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AJA73109.1	AJA73109.1 terminase, small subunit [Mannheimia phage vB_MhM_2256AP1]	AJA73109.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AJA72878.1	AJA72878.1 terminase, small subunit [Mannheimia phage vB_MhM_535AP1]	AJA72878.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AJA73057.1	AJA73057.1 terminase small subunit [Mannheimia phage vB_MhM_1127AP1]	AJA73057.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AFL46453.1	AFL46453.1 terminase small subunit [Mannheimia phage vB_MhM_1152AP]	AFL46453.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AZF87847.1	AZF87847.1 terminase small subunit [Pseudomonas phage Dobby]	AZF87847.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AJA72929.1	AJA72929.1 terminase endonuclease subunit [Mannheimia phage vB_MhM_587AP1]	AJA72929.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WWQ72088.1	WWQ72088.1 terminase small subunit [Pseudomonas phage Sirocco]	WWQ72088.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBI84114.1	QBI84114.1 terminase, endonuclease subunit [Pseudomonas phage vB_Pae_BR319a]	QBI84114.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BAA36231.1	BAA36231.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36231.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNI73730.1	UNI73730.1 terminase endonuclease subunit [Klebsiella phage KP12]	UNI73730.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27620.1	QBP27620.1 terminase small subunit [Klebsiella phage ST13-OXA48phi12.1]	QBP27620.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27419.1	QBP27419.1 small terminase subunit [Klebsiella phage ST512-KPC3phi13.2]	QBP27419.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP07822.1	QBP07822.1 terminase, endonuclease subunit [Klebsiella phage ST11-VIM1phi8.4]	QBP07822.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27880.1	QBP27880.1 terminase, endonuclease subunit [Klebsiella phage ST11-OXA48phi15.3]	QBP27880.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP08086.1	QBP08086.1 small terminase subunit [Klebsiella phage ST11-OXA245phi3.1]	QBP08086.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27659.1	QBP27659.1 terminase, endonuclease subunit [Klebsiella phage ST340-VIM1phi10.2]	QBP27659.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ARB15687.1	ARB15687.1 terminase, endonuclease subunit [Klebsiella phage 4LV2017]	ARB15687.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27977.1	QBP27977.1 terminase, endonuclease subunit [Klebsiella phage ST258-KPC3phi16.2]	QBP27977.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBQ71729.1	QBQ71729.1 terminase [Klebsiella phage ST437-OXA245phi4.2]	QBQ71729.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC10475.1	URC10475.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-813R9]	URC10475.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAH1234683.1	CAH1234683.1 terminase endonuclease subunit [Escherichia phage Cartapus]	CAH1234683.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UKL54248.1	UKL54248.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_31.17]	UKL54248.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNA05913.1	UNA05913.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_56.17]	UNA05913.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADX32420.1	ADX32420.1 terminase endonuclease subunit [Erwinia phage ENT90]	ADX32420.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QYW06322.1	QYW06322.1 small terminase subunit protein [Shewanella phage vB_SspM_M16-3]	QYW06322.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNA05968.1	UNA05968.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_201.16]	UNA05968.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNA05866.1	UNA05866.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_06.16-2]	UNA05866.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AGK86780.1	AGK86780.1 phage terminase endonuclease subunit [Burkholderia phage ST79]	AGK86780.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP08042.1	QBP08042.1 terminase [Klebsiella phage ST437-OXA245phi4.1]	QBP08042.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27770.1	QBP27770.1 terminase, endonuclease subunit [Klebsiella phage ST512-KPC3phi13.6]	QBP27770.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP27924.1	QBP27924.1 terminase, endonuclease subunit [Klebsiella phage ST258-KPC3phi16.1]	QBP27924.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ALF02294.1	ALF02294.1 terminase endonuclease subunit [Salmonella phage SEN4]	ALF02294.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ALF02343.1	ALF02343.1 terminase endonuclease subunit [Salmonella phage SEN5]	ALF02343.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAH0786523.1	CAH0786523.1 hypothetical protein P2AC1_00038 [Escherichia phage P2_AC1]	CAH0786523.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UGC97284.1	UGC97284.1 terminase, endonuclease subunit [Aeromonas phage vB_AsaM_LPM4]	UGC97284.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBQ71998.1	QBQ71998.1 small terminase subunit [Klebsiella phage ST15-OXA48phi14.1]	QBQ71998.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP07914.1	QBP07914.1 terminase [Klebsiella phage ST101-KPC2phi6.2]	QBP07914.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADQ92394.1	ADQ92394.1 terminase endonuclease subunit [Salmonella phage RE2010]	ADQ92394.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AQT27283.1	AQT27283.1 terminase endonuclease subunit [Salmonella phage SEN8]	AQT27283.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43108.1	CAC43108.1 small terminase subunit [Enterobacteria phage HK239]	CAC43108.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AKH49341.1	AKH49341.1 terminase [Escherichia phage pro147]	AKH49341.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UPI11503.1	UPI11503.1 hypothetical protein BFNKNBEH_00013 [Yersinia phage VB-YPM-18]	UPI11503.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WOZ56085.1	WOZ56085.1 hypothetical protein B476A_00005 [Yersinia phage vB_YpM_476A]	WOZ56085.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QKE55493.1	QKE55493.1 hypothetical protein vBYpM22_00008 [Yersinia phage vB_YpM_22]	QKE55493.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WOZ56125.1	WOZ56125.1 hypothetical protein B476B_00005 [Yersinia phage vB_YpM_476B]	WOZ56125.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC10094.1	URC10094.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-640R3]	URC10094.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URP83666.1	URP83666.1 terminase endonuclease subunit [Escherichia phage S164]	URP83666.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	API82940.1	API82940.1 Phage small terminase subunit [Salmonella phage STYP1]	API82940.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD37966.1	VUD37966.1 Phage terminase, endonuclease subunit [Peduovirus P22H1]	VUD37966.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43079.1	CAC43079.1 small terminase subunit [Enterobacteria phage 299]	CAC43079.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ULG00682.1	ULG00682.1 terminase, endonuclease subunit [Escherichia phage D8]	ULG00682.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD38862.1	VUD38862.1 Phage terminase, endonuclease subunit [Peduovirus P24E6b]	VUD38862.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ULG01142.1	ULG01142.1 terminase, endonuclease subunit [Escherichia phage 12W]	ULG01142.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WOZ55993.1	WOZ55993.1 hypothetical protein B115_00005 [Yersinia phage vB_YpM_115]	WOZ55993.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WOZ56039.1	WOZ56039.1 hypothetical protein B117_00005 [Yersinia phage vB_YpM_117]	WOZ56039.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AKH49377.1	AKH49377.1 terminase [Escherichia phage pro483]	AKH49377.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AGX84570.1	AGX84570.1 small terminase subunit [Enterobacteria phage fiAA91-ss]	AGX84570.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QDJ98467.1	QDJ98467.1 hypothetical protein LLFFHNDI_00040 [Escherichia phage vB_EcoM-12474II]	QDJ98467.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QDJ98599.1	QDJ98599.1 hypothetical protein OMJLAAIH_00040 [Escherichia phage vB_EcoM-12474V]	QDJ98599.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QDJ98555.1	QDJ98555.1 hypothetical protein PBINGOGM_00040 [Escherichia phage vB_EcoM-12474IV]	QDJ98555.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QDJ98514.1	QDJ98514.1 hypothetical protein BBAMJIOM_00043 [Escherichia phage vB_EcoM-12474III]	QDJ98514.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43113.1	CAC43113.1 small terminase subunit [Enterobacteria phage HK240]	CAC43113.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAG9593882.1	CAG9593882.1 hypothetical protein P2SIDE7_00036 [Peduovirus P2]	CAG9593882.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ULG01133.1	ULG01133.1 terminase, endonuclease subunit [Escherichia phage 10W]	ULG01133.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ULG00868.1	ULG00868.1 terminase, endonuclease subunit [Escherichia phage 11W]	ULG00868.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD39487.1	VUD39487.1 Phage terminase, endonuclease subunit [Peduovirus P24C9]	VUD39487.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAD03272.1	AAD03272.1 gpM [Bacteriophage P2]	AAD03272.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43093.1	CAC43093.1 small terminase subunit [Enterobacteria phage HK111]	CAC43093.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QYC52664.1	QYC52664.1 terminase endonuclease subunit [Salmonella phage BIS20]	QYC52664.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAC34151.1	AAC34151.1 R protein [Escherichia phage 186]	AAC34151.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43140.1	CAC43140.1 small terminase subunit [Enterobacteria phage PhiD160]	CAC43140.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AGG36521.1	AGG36521.1 phage terminase, endonuclease subunit [Escherichia phage P2]	AGG36521.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BAH15162.1	BAH15162.1 terminase [Serratia phage KSP20]	BAH15162.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAN08368.1	AAN08368.1 gp6 [Salmonella phage PSP3]	AAN08368.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43135.1	CAC43135.1 small terminase subunit [Enterobacteria phage PhiD145]	CAC43135.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UNA05741.1	UNA05741.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_42.18]	UNA05741.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ALF02244.1	ALF02244.1 terminase endonuclease subunit [Salmonella phage SEN1]	ALF02244.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43098.1	CAC43098.1 small terminase subunit [Enterobacteria phage HK113]	CAC43098.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBQ71549.1	QBQ71549.1 terminase [Klebsiella phage ST147-VIM1phi7.1]	QBQ71549.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WFG40973.1	WFG40973.1 terminase small subunit [Salmonella phage MET_P1_103_31]	WFG40973.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAG9593809.1	CAG9593809.1 hypothetical protein P2DC1_00005 [Peduovirus P2]	CAG9593809.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QKE55629.1	QKE55629.1 hypothetical protein vBYpM50_00008 [Yersinia phage vB_YpM_50]	QKE55629.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAG9593800.1	CAG9593800.1 hypothetical protein P2SIAC10_00039 [Peduovirus P2]	CAG9593800.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43118.1	CAC43118.1 small terminase subunit [Enterobacteria phage HK241]	CAC43118.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD38010.1	VUD38010.1 Phage terminase, endonuclease subunit [Peduovirus P24B2]	VUD38010.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UPI11453.1	UPI11453.1 hypothetical protein COILCCMC_00005 [Yersinia phage VB-YPM-4]	UPI11453.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QKE55585.1	QKE55585.1 hypothetical protein vBYpM46_00005 [Yersinia phage vB_YpM_46]	QKE55585.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ULG00984.1	ULG00984.1 terminase, endonuclease subunit [Escherichia phage 9W]	ULG00984.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD37923.1	VUD37923.1 Phage terminase, endonuclease subunit [Peduovirus P22H4]	VUD37923.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC09849.1	URC09849.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-720R8]	URC09849.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QDP43499.1	QDP43499.1 terminase, endonuclease subunit [Bacteriophage R18C]	QDP43499.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC10012.1	URC10012.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-473R3]	URC10012.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAP04442.1	AAP04442.1 gpM [Yersinia phage L-413C]	AAP04442.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QEI25345.1	QEI25345.1 terminase, endonuclease subunit [Salmonella phage SI22]	QEI25345.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QEI25390.1	QEI25390.1 terminase, endonuclease subunit [Salmonella phage SW9]	QEI25390.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43125.1	CAC43125.1 small terminase subunit [Enterobacteria phage PhiD5]	CAC43125.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QXF95271.1	QXF95271.1 terminase, endonuclease subunit [Yersinia phage HQ103]	QXF95271.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD39021.1	VUD39021.1 Phage terminase, endonuclease subunit [Peduovirus P24A7b]	VUD39021.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ARB15641.1	ARB15641.1 terminase, endonuclease subunit [Klebsiella phage 3LV2017]	ARB15641.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAN28223.1	AAN28223.1 gpM [Escherichia phage Wphi]	AAN28223.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43173.1	CAC43173.1 small terminase subunit [Peduovirus Wphi]	CAC43173.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43074.1	CAC43074.1 small terminase subunit [Enterobacteria phage 18]	CAC43074.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UYL85407.1	UYL85407.1 terminase, endonuclease subunit [Acidovorax phage Alfacinha3]	UYL85407.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UYL85508.1	UYL85508.1 terminase, endonuclease subunit [Acidovorax phage Alfacinha1]	UYL85508.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WYC18444.1	WYC18444.1 terminase endonuclease subunit [Yersinia phage vB_YpM_MHG38]	WYC18444.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WYC18376.1	WYC18376.1 terminase endonuclease subunit [Yersinia phage vB_YpM_MDG94-186]	WYC18376.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WXX18237.1	WXX18237.1 terminase endonuclease subunit [Yersinia phage GCS667]	WXX18237.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WYC18402.1	WYC18402.1 terminase endonuclease subunit [Yersinia phage vB_YpM_MDG45]	WYC18402.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URE76619.1	URE76619.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-613R3]	URE76619.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43150.1	CAC43150.1 small terminase subunit [Enterobacteria phage PhiD252]	CAC43150.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AGF88418.1	AGF88418.1 terminase endonuclease subunit [Salmonella phage FSLSP004]	AGF88418.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43103.1	CAC43103.1 small terminase subunit [Enterobacteria phage HK114]	CAC43103.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UTC25947.1	UTC25947.1 terminase endonuclease subunit [Salmonella phage vB_Sal_PHB48]	UTC25947.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43130.1	CAC43130.1 small terminase subunit [Enterobacteria phage PhiD124]	CAC43130.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43155.1	CAC43155.1 small terminase subunit [Enterobacteria phage PhiD266]	CAC43155.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WOZ57139.1	WOZ57139.1 terminase small subunit [Citrobacter phage Shae_phiSM]	WOZ57139.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43145.1	CAC43145.1 small terminase subunit [Phage PhiD218]	CAC43145.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AIZ95135.1	AIZ95135.1 terminase endonuclease subunit [Escherichia phage P88]	AIZ95135.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUD40168.1	VUD40168.1 TermS, terminase small subunit [Xuanwuvirus P884B11]	VUD40168.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43088.1	CAC43088.1 small terminase subunit [Enterobacteria phage HK109]	CAC43088.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UZV40209.1	UZV40209.1 terminase, endonuclease subunit [Acidovorax phage Acica]	UZV40209.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URE76768.1	URE76768.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-705R2]	URE76768.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WPJ53111.1	WPJ53111.1 hypothetical protein RCIP0057_00038 [Klebsiella phage RCIP0057]	WPJ53111.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QIW90060.1	QIW90060.1 putative small terminase subunit [Yersinia phage P37]	QIW90060.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ASD51182.1	ASD51182.1 terminase, endonuclease subunit [Erwinia phage EtG]	ASD51182.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AYD79792.1	AYD79792.1 hypothetical protein OGLPLLMI_00026 [Enterobacter phage phiT5282H]	AYD79792.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	CAC43160.1	CAC43160.1 small terminase subunit [Enterobacteria phage PK]	CAC43160.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC09570.1	URC09570.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-569R5]	URC09570.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AFJ75480.1	AFJ75480.1 phage terminase small subunit [Stenotrophomonas phage Smp131]	AFJ75480.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	URC09616.1	URC09616.1 terminase, endonuclease subunit [Escherichia phage vB_EcoM-569R9]	URC09616.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QBP07941.1	QBP07941.1 small terminase subunit [Klebsiella phage ST16-OXA48phi5.4]	QBP07941.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QGF21298.1	QGF21298.1 terminase small subunit [Vibrio phage vB_ValM-yong1]	QGF21298.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ALY08260.1	ALY08260.1 putative terminase endonuclease subunit [Pseudomonas phage phi3]	ALY08260.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AUR95201.1	AUR95201.1 hypothetical protein NVP1202O_23 [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95201.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WKV24006.1	WKV24006.1 terminase, endonuclease subunit [Pseudomonas phage PaBSM-2607-JFK]	WKV24006.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UYE91966.1	UYE91966.1 terminase [Aeromonas phage A051]	UYE91966.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QMP23896.1	QMP23896.1 terminase [Vibrio phage ValB1MD-2]	QMP23896.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WPJ21750.1	WPJ21750.1 terminase [Vibrio phage L9-1]	WPJ21750.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WGL39677.1	WGL39677.1 terminase small subunit [Aeromonas phage P05B]	WGL39677.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ABG73177.1	ABG73177.1 putative terminase small subunit [Aeromonas phage phiO18P]	ABG73177.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AGW43563.1	AGW43563.1 terminase endonuclease subunit [Vibrio phage VPUSM 8]	AGW43563.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ANA87657.1	ANA87657.1 terminase protein endunuclease subunit [Vibrio phage VcP032]	ANA87657.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	BAF98818.1	BAF98818.1 putative terminase endonuclease subunit [Vibrio phage Kappa]	BAF98818.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAL47518.1	AAL47518.1 orf19 [Bacteriophage K139]	AAL47518.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAB09204.1	AAB09204.1 hypothetical protein [Haemophilus phage HP1]	AAB09204.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	WBY65474.1	WBY65474.1 hypothetical protein FP3_000043 [Pasteurella phage vB_PmuM_CFP3]	WBY65474.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUF53407.1	VUF53407.1 Phage terminase small subunit, endonuclease [Escherichia phage ESSI2_ev239]	VUF53407.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAK37801.1	AAK37801.1 orf19 [Haemophilus phage HP2]	AAK37801.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AAZ93657.1	AAZ93657.1 unknown [Pasteurella phage F108]	AAZ93657.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUF53460.1	VUF53460.1 termS, terminase small subunit [Escherichia phage ESSI2_ev129]	VUF53460.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUF53433.1	VUF53433.1 termS, terminase small subunit [Escherichia phage ESSI2_ev040]	VUF53433.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	VUF53405.1	VUF53405.1 TermS, terminase small subunit [Escherichia phage ESSI2_ev015]	VUF53405.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	ADX32384.1	ADX32384.1 putative terminase endonuclease subunit [Cronobacter phage ESSI-2]	ADX32384.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	AOY11835.1	AOY11835.1 terminase endonuclease subunit [Salinivibrio phage SMHB1]	AOY11835.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	UKL54203.1	UKL54203.1 terminase, endonuclease subunit [Yersinia phage vB_YenM_324]	UKL54203.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QEI25525.1	QEI25525.1 terminase small subunit [Salmonella phage SW3]	QEI25525.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QEI25487.1	QEI25487.1 terminase small subunit [Salmonella phage SW5]	QEI25487.1	0
+40adbe0d-0e12-49bf-9c51-6e10fe6ccccb	QEI25434.1	QEI25434.1 terminase small subunit [Salmonella phage SI7]	QEI25434.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNY41725.1	UNY41725.1 head completion/stabilization protein [Burkholderia phage Milagro]	UNY41725.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADP02330.1	ADP02330.1 gp37 [Burkholderia phage KL3]	ADP02330.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNY41781.1	UNY41781.1 head completion/stabilization protein [Burkholderia phage Menos]	UNY41781.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNY41836.1	UNY41836.1 head completion/stabilization protein [Burkholderia phage Momento]	UNY41836.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UKM53768.1	UKM53768.1 head completion-stabilization protein [Burkholderia phage PhiBP82.2]	UKM53768.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ABO60712.1	ABO60712.1 gp48, phage head completion protein (GPL) [Burkholderia phage phiE202]	ABO60712.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAZ72641.2	AAZ72641.2 phage head completion protein [Burkholderia phage phiE52237]	AAZ72641.2	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ABO60749.1	ABO60749.1 gp50, phage head completion protein (GPL) [Burkholderia phage phiE12-2]	ABO60749.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WWY66148.1	WWY66148.1 head-tail adaptor aD1 [Burkholderia phage vB_HM387]	WWY66148.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UPI15560.1	UPI15560.1 head completion-stabilization protein [Burkholderia phage PhiBP82.3]	UPI15560.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AIP84268.1	AIP84268.1 phage head completion family protein [Burkholderia phage BEK]	AIP84268.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AFV51400.1	AFV51400.1 phage head completion protein [Burkholderia phage phiX216]	AFV51400.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QWY84951.1	QWY84951.1 head completion-stabilization protein [Burkholderia phage PK23]	QWY84951.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNY41665.1	UNY41665.1 head completion/stabilization protein [Burkholderia phage Musica]	UNY41665.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AVP40004.1	AVP40004.1 head completion/stabilization protein [Ralstonia phage RsoM1USA]	AVP40004.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BCB23210.1	BCB23210.1 capsid completion protein (L) [Burkholderia phage FLC5]	BCB23210.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADP02376.1	ADP02376.1 gp31 [Burkholderia phage KS14]	ADP02376.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BAF52387.1	BAF52387.1 head completion/stabilization protein L [Ralstonia phage RSA1]	BAF52387.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BAP28112.1	BAP28112.1 hypothetical protein [Ralstonia phage RSY1]	BAP28112.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BDD79921.1	BDD79921.1 hypothetical protein [Burkholderia phage FLC10]	BDD79921.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADP02285.1	ADP02285.1 gp38 [Burkholderia phage KS5]	ADP02285.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	USM11613.1	USM11613.1 capsid completion protein [Burkholderia phage Carl1]	USM11613.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AKA61132.1	AKA61132.1 putative head completion protein [Burkholderia phage AP3]	AKA61132.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QYW06321.1	QYW06321.1 head completion protein [Shewanella phage vB_SspM_M16-3]	QYW06321.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AJA73058.1	AJA73058.1 head completion protein L [Mannheimia phage vB_MhM_1127AP1]	AJA73058.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QPI18545.1	QPI18545.1 head completion protein [Burkholderia phage phiE094]	QPI18545.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ABD90607.1	ABD90607.1 head completion protein L [Mannheimia phage phiMhaA1-BAA410]	ABD90607.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ABD90558.1	ABD90558.1 head completion protein L [Mannheimia phage PHL101]	ABD90558.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AJA73110.1	AJA73110.1 head completion protein L [Mannheimia phage vB_MhM_2256AP1]	AJA73110.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AJA72879.1	AJA72879.1 head completion protein L [Mannheimia phage vB_MhM_535AP1]	AJA72879.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AJA72930.1	AJA72930.1 head completion protein L [Mannheimia phage vB_MhM_587AP1]	AJA72930.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AFL46454.1	AFL46454.1 head completion protein L [Mannheimia phage vB_MhM_1152AP]	AFL46454.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNA05743.1	UNA05743.1 head completion-stabilization protein [Yersinia phage vB_YenM_42.18]	UNA05743.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AFJ75481.1	AFJ75481.1 phage head completion/stabilization protein [Stenotrophomonas phage Smp131]	AFJ75481.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UGC97283.1	UGC97283.1 head completion protein [Aeromonas phage vB_AsaM_LPM4]	UGC97283.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UYL85408.1	UYL85408.1 head completion/stabilization protein [Acidovorax phage Alfacinha3]	UYL85408.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UYL85509.1	UYL85509.1 head completion/stabilization protein [Acidovorax phage Alfacinha1]	UYL85509.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UZV40210.1	UZV40210.1 head completion/stabilization protein [Acidovorax phage Acica]	UZV40210.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP08041.1	QBP08041.1 head completion-stabilization protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08041.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27769.1	QBP27769.1 head completion-stabilization protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27769.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27923.1	QBP27923.1 head completion-stabilization protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27923.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AGK86781.1	AGK86781.1 phage head completion/stabilization protein [Burkholderia phage ST79]	AGK86781.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAH1234684.1	CAH1234684.1 head completion/stabilization protein [Escherichia phage Cartapus]	CAH1234684.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WPJ21690.1	WPJ21690.1 head completion/stabilization protein [Bacillus phage vB_BpuM-ZY1]	WPJ21690.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBQ71999.1	QBQ71999.1 head completion-stabilization protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ71999.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC10474.1	URC10474.1 head completion-stabilization protein [Escherichia phage vB_EcoM-813R9]	URC10474.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27619.1	QBP27619.1 head completion-stabilization protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27619.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNI73729.1	UNI73729.1 head completion-stabilization protein [Klebsiella phage KP12]	UNI73729.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27420.1	QBP27420.1 head completion-stabilization protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27420.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP07821.1	QBP07821.1 head completion-stabilization protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07821.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27879.1	QBP27879.1 head completion-stabilization protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27879.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP08087.1	QBP08087.1 head completion-stabilization protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08087.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27660.1	QBP27660.1 head completion-stabilization protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27660.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ARB15688.1	ARB15688.1 head completion-stabilization protein [Klebsiella phage 4LV2017]	ARB15688.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP27976.1	QBP27976.1 head completion-stabilization protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27976.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBQ71728.1	QBQ71728.1 head completion-stabilization protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71728.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBQ71550.1	QBQ71550.1 head completion-stabilization protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71550.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC09618.1	URC09618.1 head completion-stabilization protein [Escherichia phage vB_EcoM-569R9]	URC09618.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAD03273.1	AAD03273.1 gpL [Bacteriophage P2]	AAD03273.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD38011.1	VUD38011.1 Ad1 Phage adapter protein [Peduovirus P24B2]	VUD38011.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AKH49378.1	AKH49378.1 head completion-stabilization protein [Escherichia phage pro483]	AKH49378.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WFG40972.1	WFG40972.1 head-tail adaptor [Salmonella phage MET_P1_103_31]	WFG40972.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD37967.1	VUD37967.1 Ad1 Phage adapter protein [Peduovirus P22H1]	VUD37967.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AGF88419.1	AGF88419.1 phage head protein [Salmonella phage FSLSP004]	AGF88419.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAN08369.1	AAN08369.1 gp7 [Salmonella phage PSP3]	AAN08369.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ALF02245.1	ALF02245.1 head completion-stabilization protein [Salmonella phage SEN1]	ALF02245.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADQ92395.1	ADQ92395.1 head completion-stabilization protein [Salmonella phage RE2010]	ADQ92395.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAP04443.1	AAP04443.1 gpL [Yersinia phage L-413C]	AAP04443.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AGG36522.1	AGG36522.1 phage head completion-stabilization protein [Escherichia phage P2]	AGG36522.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QEI25346.1	QEI25346.1 head completion/stabilization protein [Salmonella phage SI22]	QEI25346.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QEI25391.1	QEI25391.1 completion/stabilization protein [Salmonella phage SW9]	QEI25391.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC10011.1	URC10011.1 head completion-stabilization protein [Escherichia phage vB_EcoM-473R3]	URC10011.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAG9593799.1	CAG9593799.1 hypothetical protein P2SIAC10_00038 [Peduovirus P2]	CAG9593799.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UPI11454.1	UPI11454.1 hypothetical protein COILCCMC_00006 [Yersinia phage VB-YPM-4]	UPI11454.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	API82941.1	API82941.1 Phage head completion protein (GPL) [Salmonella phage STYP1]	API82941.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QDJ98466.1	QDJ98466.1 head completion/stabilization protein [Escherichia phage vB_EcoM-12474II]	QDJ98466.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAG9593881.1	CAG9593881.1 hypothetical protein P2SIDE7_00035 [Peduovirus P2]	CAG9593881.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD37924.1	VUD37924.1 Phage Ad1 adapter protein [Peduovirus P22H4]	VUD37924.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WOZ55994.1	WOZ55994.1 hypothetical protein B115_00006 [Yersinia phage vB_YpM_115]	WOZ55994.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UPI11504.1	UPI11504.1 hypothetical protein BFNKNBEH_00014 [Yersinia phage VB-YPM-18]	UPI11504.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WOZ56086.1	WOZ56086.1 hypothetical protein B476A_00006 [Yersinia phage vB_YpM_476A]	WOZ56086.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QDJ98598.1	QDJ98598.1 head completion/stabilization protein [Escherichia phage vB_EcoM-12474V]	QDJ98598.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QKE55586.1	QKE55586.1 hypothetical protein vBYpM46_00006 [Yersinia phage vB_YpM_46]	QKE55586.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAG9593810.1	CAG9593810.1 hypothetical protein P2DC1_00006 [Peduovirus P2]	CAG9593810.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ULG01132.1	ULG01132.1 head completion-stabilization protein [Escherichia phage 10W]	ULG01132.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAH0786522.1	CAH0786522.1 hypothetical protein P2AC1_00037 [Escherichia phage P2_AC1]	CAH0786522.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QKE55494.1	QKE55494.1 hypothetical protein vBYpM22_00009 [Yersinia phage vB_YpM_22]	QKE55494.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WOZ56040.1	WOZ56040.1 hypothetical protein B117_00006 [Yersinia phage vB_YpM_117]	WOZ56040.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QDJ98554.1	QDJ98554.1 head completion/stabilization protein [Escherichia phage vB_EcoM-12474IV]	QDJ98554.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WOZ56126.1	WOZ56126.1 hypothetical protein B476B_00006 [Yersinia phage vB_YpM_476B]	WOZ56126.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AGX84571.1	AGX84571.1 capsid completion protein [Enterobacteria phage fiAA91-ss]	AGX84571.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD39490.1	VUD39490.1 Phage Ad1 adapter protein [Peduovirus P24C9]	VUD39490.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URP83667.1	URP83667.1 head completion/stabilization protein [Escherichia phage S164]	URP83667.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QDJ98513.1	QDJ98513.1 head completion/stabilization protein [Escherichia phage vB_EcoM-12474III]	QDJ98513.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QKE55630.1	QKE55630.1 hypothetical protein vBYpM50_00009 [Yersinia phage vB_YpM_50]	QKE55630.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ULG00683.1	ULG00683.1 head completion-stabilization protein [Escherichia phage D8]	ULG00683.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD38864.1	VUD38864.1 Ad1 Phage adapter protein [Peduovirus P24E6b]	VUD38864.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ULG01143.1	ULG01143.1 head completion-stabilization protein [Escherichia phage 12W]	ULG01143.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QXF95272.1	QXF95272.1 head completion-stabilization protein [Yersinia phage HQ103]	QXF95272.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QDP43500.1	QDP43500.1 head completion-stabilization protein [Bacteriophage R18C]	QDP43500.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC09848.1	URC09848.1 head completion-stabilization protein [Escherichia phage vB_EcoM-720R8]	URC09848.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ULG00985.1	ULG00985.1 head completion-stabilization protein [Escherichia phage 9W]	ULG00985.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC10095.1	URC10095.1 head completion-stabilization protein [Escherichia phage vB_EcoM-640R3]	URC10095.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ULG00869.1	ULG00869.1 head completion-stabilization protein [Escherichia phage 11W]	ULG00869.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WWQ72089.1	WWQ72089.1 head completion-stabilization protein [Pseudomonas phage Sirocco]	WWQ72089.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ALF02295.1	ALF02295.1 head completion-stabilization protein [Salmonella phage SEN4]	ALF02295.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ALF02344.1	ALF02344.1 head completion-stabilization protein [Salmonella phage SEN5]	ALF02344.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BAA36232.1	BAA36232.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36232.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAN28224.1	AAN28224.1 gpL [Escherichia phage Wphi]	AAN28224.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AKH49340.1	AKH49340.1 head completion-stabilization protein [Escherichia phage pro147]	AKH49340.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QIW90059.1	QIW90059.1 head completion/stabilization protein [Yersinia phage P37]	QIW90059.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD39022.1	VUD39022.1 Phage Ad1 adapter protein [Peduovirus P24A7b]	VUD39022.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBI84115.1	QBI84115.1 head completion-stabilization protein [Pseudomonas phage vB_Pae_BR319a]	QBI84115.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AQT27284.1	AQT27284.1 head completion-stabilization protein [Salmonella phage SEN8]	AQT27284.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP07913.1	QBP07913.1 head completion-stabilization protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07913.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43109.1	CAC43109.1 head completion protein [Enterobacteria phage HK239]	CAC43109.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QYC52665.1	QYC52665.1 capsid completion protein [Salmonella phage BIS20]	QYC52665.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UTC25946.1	UTC25946.1 head completion/stabilization protein [Salmonella phage vB_Sal_PHB48]	UTC25946.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAC34152.1	AAC34152.1 Q protein [Escherichia phage 186]	AAC34152.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ARB15642.1	ARB15642.1 head completion-stabilization protein [Klebsiella phage 3LV2017]	ARB15642.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43089.1	CAC43089.1 head completion protein [Enterobacteria phage HK109]	CAC43089.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AZF87848.1	AZF87848.1 head completion-stabilization protein [Pseudomonas phage Dobby]	AZF87848.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43099.1	CAC43099.1 head completion protein [Enterobacteria phage HK113]	CAC43099.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WPJ53110.1	WPJ53110.1 head completion/stabilization protein [Klebsiella phage RCIP0057]	WPJ53110.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URE76618.1	URE76618.1 head completion-stabilization protein [Escherichia phage vB_EcoM-613R3]	URE76618.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URE76769.1	URE76769.1 head completion-stabilization protein [Escherichia phage vB_EcoM-705R2]	URE76769.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	URC09571.1	URC09571.1 adapter protein [Escherichia phage vB_EcoM-569R5]	URC09571.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNA05914.1	UNA05914.1 head completion-stabilization protein [Yersinia phage vB_YenM_56.17]	UNA05914.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43126.1	CAC43126.1 head completion protein [Enterobacteria phage PhiD5]	CAC43126.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43104.1	CAC43104.1 head completion protein [Enterobacteria phage HK114]	CAC43104.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43174.1	CAC43174.1 head completion protein [Peduovirus Wphi]	CAC43174.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43075.1	CAC43075.1 head completion protein [Enterobacteria phage 18]	CAC43075.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43141.1	CAC43141.1 head completion protein [Enterobacteria phage PhiD160]	CAC43141.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43161.1	CAC43161.1 head completion protein [Enterobacteria phage PK]	CAC43161.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43136.1	CAC43136.1 head completion protein [Enterobacteria phage PhiD145]	CAC43136.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43151.1	CAC43151.1 head completion protein [Enterobacteria phage PhiD252]	CAC43151.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43114.1	CAC43114.1 head completion protein [Enterobacteria phage HK240]	CAC43114.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43131.1	CAC43131.1 head completion protein [Enterobacteria phage PhiD124]	CAC43131.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43146.1	CAC43146.1 head completion protein [Phage PhiD218]	CAC43146.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43094.1	CAC43094.1 head completion protein [Enterobacteria phage HK111]	CAC43094.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43156.1	CAC43156.1 head completion protein [Enterobacteria phage PhiD266]	CAC43156.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UKL54249.1	UKL54249.1 head completion-stabilization protein [Yersinia phage vB_YenM_31.17]	UKL54249.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WYC18445.1	WYC18445.1 head completion-stabilization protein [Yersinia phage vB_YpM_MHG38]	WYC18445.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WYC18377.1	WYC18377.1 head completion-stabilization protein [Yersinia phage vB_YpM_MDG94-186]	WYC18377.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WXX18236.1	WXX18236.1 head completion-stabilization protein [Yersinia phage GCS667]	WXX18236.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WYC18403.1	WYC18403.1 head completion-stabilization protein [Yersinia phage vB_YpM_MDG45]	WYC18403.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43080.1	CAC43080.1 head completion protein [Enterobacteria phage 299]	CAC43080.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ASD51181.1	ASD51181.1 head completion-stabilization protein [Erwinia phage EtG]	ASD51181.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WOZ57138.1	WOZ57138.1 head completion/stabilization protein [Citrobacter phage Shae_phiSM]	WOZ57138.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AIZ95136.1	AIZ95136.1 head completion-stabilization protein [Escherichia phage P88]	AIZ95136.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	CAC43119.1	CAC43119.1 head completion protein [Enterobacteria phage HK241]	CAC43119.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUD40169.1	VUD40169.1 Ad1 Phage adapter protein [Xuanwuvirus P884B11]	VUD40169.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNA05867.1	UNA05867.1 head completion-stabilization protein [Yersinia phage vB_YenM_06.16-2]	UNA05867.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UNA05969.1	UNA05969.1 head completion-stabilization protein [Yersinia phage vB_YenM_201.16]	UNA05969.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QBP07942.1	QBP07942.1 head completion-stabilization protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07942.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AYD79793.1	AYD79793.1 hypothetical protein OGLPLLMI_00027 [Enterobacter phage phiT5282H]	AYD79793.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADX32436.1	ADX32436.1 phage head completion protein [Erwinia phage ENT90]	ADX32436.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BAH15163.1	BAH15163.1 head completion protein [Serratia phage KSP20]	BAH15163.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AGW43564.1	AGW43564.1 putative head completion protein [Vibrio phage VPUSM 8]	AGW43564.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ANA87658.1	ANA87658.1 head completion-stabilization protein [Vibrio phage VcP032]	ANA87658.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	BAF98819.1	BAF98819.1 putative head completion protein [Vibrio phage Kappa]	BAF98819.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAL47519.1	AAL47519.1 orf20 [Bacteriophage K139]	AAL47519.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUF53384.1	VUF53384.1 Ad1 adapter protein [Escherichia phage ESSI2_ev239]	VUF53384.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ADX32393.1	ADX32393.1 phage head completion protein [Cronobacter phage ESSI-2]	ADX32393.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WPJ21751.1	WPJ21751.1 head completion/stabilization protein [Vibrio phage L9-1]	WPJ21751.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	UKL54204.1	UKL54204.1 head completion-stabilization protein [Yersinia phage vB_YenM_324]	UKL54204.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	WKV24007.1	WKV24007.1 putative head completion/stabilization protein [Pseudomonas phage PaBSM-2607-JFK]	WKV24007.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	QMP23895.1	QMP23895.1 head completion/stabilization protein [Vibrio phage ValB1MD-2]	QMP23895.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	AAK37802.1	AAK37802.1 orf20 [Haemophilus phage HP2]	AAK37802.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	ALY08261.1	ALY08261.1 putative head completion/stabilization protein [Pseudomonas phage phi3]	ALY08261.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUF53411.1	VUF53411.1 Ad1 adapter protein [Escherichia phage ESSI2_ev129]	VUF53411.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUF53399.1	VUF53399.1 Ad1 adaptor protein [Escherichia phage ESSI2_ev040]	VUF53399.1	0
+6254ddb4-6445-49b4-846b-f46bd3b59f6f	VUF53362.1	VUF53362.1 Ad1 adapter protein [Escherichia phage ESSI2_ev015]	VUF53362.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNY41726.1	UNY41726.1 tail protein [Burkholderia phage Milagro]	UNY41726.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNY41666.1	UNY41666.1 baseplate protein [Burkholderia phage Musica]	UNY41666.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADP02329.1	ADP02329.1 gp36 [Burkholderia phage KL3]	ADP02329.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNY41783.1	UNY41783.1 baseplate protein [Burkholderia phage Menos]	UNY41783.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNY41838.1	UNY41838.1 baseplate protein [Burkholderia phage Momento]	UNY41838.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAZ72639.2	AAZ72639.2 putative bacteriophage tail protein X [Burkholderia phage phiE52237]	AAZ72639.2	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ABO60761.1	ABO60761.1 gp48, phage Tail Protein X [Burkholderia phage phiE12-2]	ABO60761.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WWY66150.1	WWY66150.1 tail protein X [Burkholderia phage vB_HM387]	WWY66150.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UPI15562.1	UPI15562.1 tail protein [Burkholderia phage PhiBP82.3]	UPI15562.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QPI18547.1	QPI18547.1 tail protein X [Burkholderia phage phiE094]	QPI18547.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AIP84304.1	AIP84304.1 phage Tail Protein X family protein [Burkholderia phage BEK]	AIP84304.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AFV51402.1	AFV51402.1 putative phage tail protein X [Burkholderia phage phiX216]	AFV51402.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QWY84953.1	QWY84953.1 tail protein [Burkholderia phage PK23]	QWY84953.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ABO60743.1	ABO60743.1 gp46, phage Tail Protein X [Burkholderia phage phiE202]	ABO60743.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UKM53770.1	UKM53770.1 tail protein [Burkholderia phage PhiBP82.2]	UKM53770.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AGK86782.1	AGK86782.1 phage tail protein X [Burkholderia phage ST79]	AGK86782.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QYC52666.1	QYC52666.1 tail protein [Salmonella phage BIS20]	QYC52666.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ASD51180.1	ASD51180.1 tail completion protein [Erwinia phage EtG]	ASD51180.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43095.1	CAC43095.1 tail component protein, partial [Enterobacteria phage HK111]	CAC43095.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43157.1	CAC43157.1 tail component protein, partial [Enterobacteria phage PhiD266]	CAC43157.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URE76617.1	URE76617.1 tail protein [Escherichia phage vB_EcoM-613R3]	URE76617.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WPJ53109.1	WPJ53109.1 baseplate protein X [Klebsiella phage RCIP0057]	WPJ53109.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43090.1	CAC43090.1 tail component protein, partial [Enterobacteria phage HK109]	CAC43090.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WYC18446.1	WYC18446.1 tail protein [Yersinia phage vB_YpM_MHG38]	WYC18446.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WYC18378.1	WYC18378.1 tail protein [Yersinia phage vB_YpM_MDG94-186]	WYC18378.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WYC18404.1	WYC18404.1 tail protein [Yersinia phage vB_YpM_MDG45]	WYC18404.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WXX18235.1	WXX18235.1 tail completion protein [Yersinia phage GCS667]	WXX18235.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAC34153.1	AAC34153.1 tail protein [Escherichia phage 186]	AAC34153.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27421.1	QBP27421.1 tail protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27421.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP07820.1	QBP07820.1 tail protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07820.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27878.1	QBP27878.1 tail protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27878.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP08088.1	QBP08088.1 tail protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08088.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27661.1	QBP27661.1 tail protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27661.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27975.1	QBP27975.1 tail protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27975.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBQ71727.1	QBQ71727.1 tail protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71727.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UTC25945.1	UTC25945.1 tail protein [Salmonella phage vB_Sal_PHB48]	UTC25945.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ALF02246.1	ALF02246.1 tail completion protein [Salmonella phage SEN1]	ALF02246.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAN28225.1	AAN28225.1 gpX [Escherichia phage Wphi]	AAN28225.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAG9593811.1	CAG9593811.1 hypothetical protein P2DC1_00007 [Peduovirus P2]	CAG9593811.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC09619.1	URC09619.1 tail protein [Escherichia phage vB_EcoM-569R9]	URC09619.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QIW90058.1	QIW90058.1 putative tail completion protein [Yersinia phage P37]	QIW90058.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AGX84572.1	AGX84572.1 tail protein [Enterobacteria phage fiAA91-ss]	AGX84572.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43175.1	CAC43175.1 tail component protein [Peduovirus Wphi]	CAC43175.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43127.1	CAC43127.1 tail component protein [Enterobacteria phage PhiD5]	CAC43127.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAP04444.1	AAP04444.1 gpX [Yersinia phage L-413C]	AAP04444.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43076.1	CAC43076.1 tail component protein, partial [Enterobacteria phage 18]	CAC43076.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43110.1	CAC43110.1 tail component protein, partial [Enterobacteria phage HK239]	CAC43110.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43142.1	CAC43142.1 tail component protein, partial [Enterobacteria phage PhiD160]	CAC43142.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43162.1	CAC43162.1 tail component protein, partial [Enterobacteria phage PK]	CAC43162.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43115.1	CAC43115.1 tail component protein, partial [Enterobacteria phage HK240]	CAC43115.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43105.1	CAC43105.1 tail component protein, partial [Enterobacteria phage HK114]	CAC43105.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43152.1	CAC43152.1 tail component protein, partial [Enterobacteria phage PhiD252]	CAC43152.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	API82942.1	API82942.1 Phage Tail Protein X [Salmonella phage STYP1]	API82942.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBQ72000.1	QBQ72000.1 tail protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72000.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43120.2	CAC43120.2 tail component protein, partial [Enterobacteria phage HK241]	CAC43120.2	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AGF88420.1	AGF88420.1 phage tail protein [Salmonella phage FSLSP004]	AGF88420.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAH0786521.1	CAH0786521.1 hypothetical protein P2AC1_00036 [Escherichia phage P2_AC1]	CAH0786521.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QDP43501.1	QDP43501.1 tail component protein [Bacteriophage R18C]	QDP43501.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC09847.1	URC09847.1 tail protein [Escherichia phage vB_EcoM-720R8]	URC09847.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UPI11455.1	UPI11455.1 hypothetical protein COILCCMC_00007 [Yersinia phage VB-YPM-4]	UPI11455.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAD03274.1	AAD03274.1 gpX [Bacteriophage P2]	AAD03274.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QDJ98465.1	QDJ98465.1 baseplate protein X [Escherichia phage vB_EcoM-12474II]	QDJ98465.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD38012.1	VUD38012.1 Phage protein [Peduovirus P24B2]	VUD38012.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ULG00986.1	ULG00986.1 tail protein [Escherichia phage 9W]	ULG00986.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAG9593880.1	CAG9593880.1 hypothetical protein P2SIDE7_00034 [Peduovirus P2]	CAG9593880.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AKH49379.1	AKH49379.1 tail completion protein [Escherichia phage pro483]	AKH49379.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD37925.1	VUD37925.1 Phage tail completion protein [Peduovirus P22H4]	VUD37925.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC10010.1	URC10010.1 tail protein [Escherichia phage vB_EcoM-473R3]	URC10010.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UPI11505.1	UPI11505.1 hypothetical protein BFNKNBEH_00015 [Yersinia phage VB-YPM-18]	UPI11505.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WOZ56087.1	WOZ56087.1 hypothetical protein B476A_00007 [Yersinia phage vB_YpM_476A]	WOZ56087.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QDJ98597.1	QDJ98597.1 baseplate protein X [Escherichia phage vB_EcoM-12474V]	QDJ98597.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QKE55587.1	QKE55587.1 hypothetical protein vBYpM46_00007 [Yersinia phage vB_YpM_46]	QKE55587.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD39023.1	VUD39023.1 Tail component protein (Fragment) [Peduovirus P24A7b]	VUD39023.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QKE55495.1	QKE55495.1 hypothetical protein vBYpM22_00010 [Yersinia phage vB_YpM_22]	QKE55495.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QXF95273.1	QXF95273.1 tail protein [Yersinia phage HQ103]	QXF95273.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QDJ98553.1	QDJ98553.1 baseplate protein X [Escherichia phage vB_EcoM-12474IV]	QDJ98553.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WOZ56127.1	WOZ56127.1 hypothetical protein B476B_00007 [Yersinia phage vB_YpM_476B]	WOZ56127.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WFG40971.1	WFG40971.1 baseplate hub [Salmonella phage MET_P1_103_31]	WFG40971.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD37968.1	VUD37968.1 Tail component protein (Fragment) [Peduovirus P22H1]	VUD37968.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URP83668.1	URP83668.1 tail protein [Escherichia phage S164]	URP83668.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QDJ98512.1	QDJ98512.1 baseplate protein X [Escherichia phage vB_EcoM-12474III]	QDJ98512.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QKE55631.1	QKE55631.1 hypothetical protein vBYpM50_00010 [Yersinia phage vB_YpM_50]	QKE55631.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAN08370.1	AAN08370.1 gp8 [Salmonella phage PSP3]	AAN08370.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43081.1	CAC43081.1 tail component protein, partial [Enterobacteria phage 299]	CAC43081.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AGG36523.1	AGG36523.1 phage tail completion protein [Escherichia phage P2]	AGG36523.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AQT27285.1	AQT27285.1 tail component protein [Salmonella phage SEN8]	AQT27285.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNA05915.1	UNA05915.1 tail protein [Yersinia phage vB_YenM_56.17]	UNA05915.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNA05970.1	UNA05970.1 tail protein [Yersinia phage vB_YenM_201.16]	UNA05970.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNA05868.1	UNA05868.1 tail protein [Yersinia phage vB_YenM_06.16-2]	UNA05868.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAG9593798.1	CAG9593798.1 hypothetical protein P2SIAC10_00037 [Peduovirus P2]	CAG9593798.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AKH49339.1	AKH49339.1 tail completion protein [Escherichia phage pro147]	AKH49339.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WOZ55995.1	WOZ55995.1 hypothetical protein B115_00007 [Yersinia phage vB_YpM_115]	WOZ55995.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WOZ56041.1	WOZ56041.1 hypothetical protein B117_00007 [Yersinia phage vB_YpM_117]	WOZ56041.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ULG01131.1	ULG01131.1 tail protein [Escherichia phage 10W]	ULG01131.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ULG00870.1	ULG00870.1 tail protein [Escherichia phage 11W]	ULG00870.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD39493.1	VUD39493.1 Phage tail completion protein [Peduovirus P24C9]	VUD39493.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43137.1	CAC43137.1 tail component protein, partial [Enterobacteria phage PhiD145]	CAC43137.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43147.1	CAC43147.1 tail component protein, partial [Phage PhiD218]	CAC43147.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UKL54250.1	UKL54250.1 tail protein [Yersinia phage vB_YenM_31.17]	UKL54250.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43100.1	CAC43100.1 tail component protein, partial [Enterobacteria phage HK113]	CAC43100.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27618.1	QBP27618.1 tail protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27618.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADQ92396.1	ADQ92396.1 tail component protein [Salmonella phage RE2010]	ADQ92396.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP08040.1	QBP08040.1 tail protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08040.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27768.1	QBP27768.1 tail protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27768.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP27922.1	QBP27922.1 tail protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27922.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ULG00684.1	ULG00684.1 tail protein [Escherichia phage D8]	ULG00684.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC10096.1	URC10096.1 tail protein [Escherichia phage vB_EcoM-640R3]	URC10096.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD38866.1	VUD38866.1 Tail component protein (Fragment) [Peduovirus P24E6b]	VUD38866.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ULG01144.1	ULG01144.1 tail protein [Escherichia phage 12W]	ULG01144.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UGC97282.1	UGC97282.1 tail protein X [Aeromonas phage vB_AsaM_LPM4]	UGC97282.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AZV00477.1	AZV00477.1 tail protein X [Paracoccus phage vB_PyeM_Pyei1]	AZV00477.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BAP28113.1	BAP28113.1 unnamed protein product [Ralstonia phage RSY1]	BAP28113.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BAF52388.1	BAF52388.1 phage tail X [Ralstonia phage RSA1]	BAF52388.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QEI25347.1	QEI25347.1 tail protein [Salmonella phage SI22]	QEI25347.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QEI25392.1	QEI25392.1 tail protein [Salmonella phage SW9]	QEI25392.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAC43132.1	CAC43132.1 tail component protein, partial [Enterobacteria phage PhiD124]	CAC43132.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AVP40005.1	AVP40005.1 tail protein [Ralstonia phage RsoM1USA]	AVP40005.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNA05744.1	UNA05744.1 tail protein [Yersinia phage vB_YenM_42.18]	UNA05744.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC10473.1	URC10473.1 tail protein [Escherichia phage vB_EcoM-813R9]	URC10473.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAH1234685.1	CAH1234685.1 tail protein X [Escherichia phage Cartapus]	CAH1234685.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBQ71551.1	QBQ71551.1 tail protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71551.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AYD79794.1	AYD79794.1 hypothetical protein OGLPLLMI_00028 [Enterobacter phage phiT5282H]	AYD79794.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UNI73728.1	UNI73728.1 tail protein [Klebsiella phage KP12]	UNI73728.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ARB15689.1	ARB15689.1 tail protein [Klebsiella phage 4LV2017]	ARB15689.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBI84116.1	QBI84116.1 unclassified tail protein [Pseudomonas phage vB_Pae_BR319a]	QBI84116.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WWQ72090.1	WWQ72090.1 tail protein [Pseudomonas phage Sirocco]	WWQ72090.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AZF87849.1	AZF87849.1 tail X protein [Pseudomonas phage Dobby]	AZF87849.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BAA36234.1	BAA36234.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36234.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WPJ21691.1	WPJ21691.1 baseplate protein X [Bacillus phage vB_BpuM-ZY1]	WPJ21691.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADP02375.1	ADP02375.1 gp30 [Burkholderia phage KS14]	ADP02375.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BDD79922.1	BDD79922.1 hypothetical protein [Burkholderia phage FLC10]	BDD79922.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WDE69804.1	WDE69804.1 tail protein X [Vibrio phage VPHZ6]	WDE69804.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BCB23209.1	BCB23209.1 tail protein (X) [Burkholderia phage FLC5]	BCB23209.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP07943.1	QBP07943.1 tail protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07943.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QPB09402.1	QPB09402.1 tail protein [Burkholderia phage Mana]	QPB09402.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADP02283.1	ADP02283.1 gp36 [Burkholderia phage KS5]	ADP02283.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	USM11615.1	USM11615.1 baseplate protein [Burkholderia phage Carl1]	USM11615.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QXF95211.1	QXF95211.1 tail protein GpX [Wolbachia phage WO]	QXF95211.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADW80173.1	ADW80173.1 tail protein X [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80173.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AOA49565.1	AOA49565.1 tail protein X family protein [Wolbachia phage WO]	AOA49565.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AKA61134.1	AKA61134.1 putative tail protein [Burkholderia phage AP3]	AKA61134.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URE76770.1	URE76770.1 tail component protein [Escherichia phage vB_EcoM-705R2]	URE76770.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AIZ95137.1	AIZ95137.1 tail component protein [Escherichia phage P88]	AIZ95137.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	URC09572.1	URC09572.1 tail component protein [Escherichia phage vB_EcoM-569R5]	URC09572.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WOZ57137.1	WOZ57137.1 tail protein X [Citrobacter phage Shae_phiSM]	WOZ57137.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADX32464.1	ADX32464.1 hypothetical protein [Erwinia phage ENT90]	ADX32464.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ADE87913.1	ADE87913.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87913.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ARM70439.1	ARM70439.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70439.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QHJ75475.1	QHJ75475.1 tail protein X [Wolbachia phage WO]	QHJ75475.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AIM50576.1	AIM50576.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50576.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QHJ75588.1	QHJ75588.1 tail protein X [Wolbachia phage WO]	QHJ75588.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QBP07912.1	QBP07912.1 tail protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07912.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	VUD40170.1	VUD40170.1 Tail component protein [Xuanwuvirus P884B11]	VUD40170.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ARB15643.1	ARB15643.1 tail component protein [Klebsiella phage 3LV2017]	ARB15643.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QIG65614.1	QIG65614.1 hypothetical protein [Salmonella phage PT1]	QIG65614.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QEA09548.1	QEA09548.1 tail protein [Wolbachia phage WO]	QEA09548.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QHJ75365.1	QHJ75365.1 tail protein X [Wolbachia phage WO]	QHJ75365.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QMP19187.1	QMP19187.1 tail protein [Pseudomonas phage Persinger]	QMP19187.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QYW06320.1	QYW06320.1 tail protein X [Shewanella phage vB_SspM_M16-3]	QYW06320.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UYL85510.1	UYL85510.1 tail protein X [Acidovorax phage Alfacinha1]	UYL85510.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UYL85409.1	UYL85409.1 tail protein X [Acidovorax phage Alfacinha3]	UYL85409.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ANN86133.1	ANN86133.1 putative tail protein X [Enterobacter phage Arya]	ANN86133.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WNY35843.1	WNY35843.1 baseplate hub [Vibrio phage Vb_VaM_Valp1]	WNY35843.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QOE32757.1	QOE32757.1 baseplate protein [Achromobacter phage Mano]	QOE32757.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ABD90608.1	ABD90608.1 tail synthesis protein X [Mannheimia phage phiMhaA1-BAA410]	ABD90608.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ABD90559.1	ABD90559.1 tail synthesis protein X [Mannheimia phage PHL101]	ABD90559.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AJA73111.1	AJA73111.1 tail synthesis protein X [Mannheimia phage vB_MhM_2256AP1]	AJA73111.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AJA72880.1	AJA72880.1 tail synthesis protein X [Mannheimia phage vB_MhM_535AP1]	AJA72880.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AJA72931.1	AJA72931.1 tail synthesis protein X [Mannheimia phage vB_MhM_587AP1]	AJA72931.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AJA73059.1	AJA73059.1 tail synthesis protein X [Mannheimia phage vB_MhM_1127AP1]	AJA73059.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AFL46455.1	AFL46455.1 tail synthesis protein X [Mannheimia phage vB_MhM_1152AP]	AFL46455.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	CAX65008.1	CAX65008.1 gp27 protein [Vibrio phage VP585]	CAX65008.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AAN12344.1	AAN12344.1 ORF45 [Vibrio phage VHML]	AAN12344.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AFV81367.1	AFV81367.1 putative tail protein [Vibrio phage vB_VpaM_MAR]	AFV81367.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ALF02296.1	ALF02296.1 tail component protein [Salmonella phage SEN4]	ALF02296.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ALF02345.1	ALF02345.1 tail component protein [Salmonella phage SEN5]	ALF02345.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UFZ21859.1	UFZ21859.1 baseplate wedge protein [Xanthomonas phage M29]	UFZ21859.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WID42140.1	WID42140.1 tail protein [Pseudomonas phage ZRG1]	WID42140.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QKN87921.1	QKN87921.1 baseplate protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87921.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	USZ80554.1	USZ80554.1 putative tail protein X [Serratia phage MQ-4]	USZ80554.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	BAO20623.1	BAO20623.1 putative tail protein X [Pseudomonas phage PPpW-3]	BAO20623.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QPB08639.1	QPB08639.1 baseplate spike protein [Burkholderia phage Mica]	QPB08639.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ARQ95326.1	ARQ95326.1 hypothetical protein [Bradyrhizobium phage BDU-MI-1]	ARQ95326.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AOT25335.1	AOT25335.1 tail protein [Ochrobactrum phage POA1180]	AOT25335.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UZV40211.1	UZV40211.1 tail protein X [Acidovorax phage Acica]	UZV40211.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WWY66205.1	WWY66205.1 tail protein X [Burkholderia phage vB_HM795]	WWY66205.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AFJ75482.1	AFJ75482.1 tail protein [Stenotrophomonas phage Smp131]	AFJ75482.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QXN68739.1	QXN68739.1 tail protein X [Hafnia phage yong2]	QXN68739.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	WEV89358.1	WEV89358.1 hypothetical protein H10PHJ05_57 [Aeromonas phage HJ05]	WEV89358.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	UOL51119.1	UOL51119.1 tail protein [Citrobacter phage Chris1]	UOL51119.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	APU00761.1	APU00761.1 hypothetical protein [Aeromonas phage Asp37]	APU00761.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AXF38231.1	AXF38231.1 putative tail protein [Ralstonia phage phiRSP]	AXF38231.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	APU00425.1	APU00425.1 hypothetical protein [Aeromonas phage 3]	APU00425.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ALN97544.1	ALN97544.1 tail protein X [Aeromonas phage phiARM81ld]	ALN97544.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	APU01177.1	APU01177.1 hypothetical protein [Aeromonas phage 32]	APU01177.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	APU00845.1	APU00845.1 hypothetical protein [Aeromonas phage 59.1]	APU00845.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	ANZ52218.1	ANZ52218.1 putative tail protein [Aeromonas phage Ahp2]	ANZ52218.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	AWH15038.1	AWH15038.1 hypothetical protein [Aeromonas phage 85AhydR10PP]	AWH15038.1	0
+e0bdcd44-b76a-45f1-b480-6ab99a5480c3	QIZ02638.1	QIZ02638.1 hypothetical protein AhyVDH1_033 [Aeromonas phage AhyVDH1]	QIZ02638.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UNY41667.1	UNY41667.1 antiholin/holin protein [Burkholderia phage Musica]	UNY41667.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UNY41727.1	UNY41727.1 antiholin/holin protein [Burkholderia phage Milagro]	UNY41727.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UNY41784.1	UNY41784.1 antiholin/holin protein [Burkholderia phage Menos]	UNY41784.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UNY41839.1	UNY41839.1 antiholin/holin protein [Burkholderia phage Momento]	UNY41839.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ADP02328.1	ADP02328.1 gp35 [Burkholderia phage KL3]	ADP02328.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UKM53771.1	UKM53771.1 hypothetical protein PhiBP822_13 [Burkholderia phage PhiBP82.2]	UKM53771.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ABO60710.1	ABO60710.1 gp45, putative bacteriophage membrane protein [Burkholderia phage phiE202]	ABO60710.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AAZ72638.1	AAZ72638.1 putative bacteriophage membrane protein [Burkholderia phage phiE52237]	AAZ72638.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ABO60777.1	ABO60777.1 gp47, putative bacteriophage membrane protein [Burkholderia phage phiE12-2]	ABO60777.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WWY66151.1	WWY66151.1 holin [Burkholderia phage vB_HM387]	WWY66151.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UPI15563.1	UPI15563.1 hypothetical protein PhiBP823_12 [Burkholderia phage PhiBP82.3]	UPI15563.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QPI18548.1	QPI18548.1 holin [Burkholderia phage phiE094]	QPI18548.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AIP84289.1	AIP84289.1 putative membrane protein [Burkholderia phage BEK]	AIP84289.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AFV51403.1	AFV51403.1 putative phage membrane protein [Burkholderia phage phiX216]	AFV51403.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QWY84954.1	QWY84954.1 putative membrane protein [Burkholderia phage PK23]	QWY84954.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	BCB23208.1	BCB23208.1 putative antiholin [Burkholderia phage FLC5]	BCB23208.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ADP02374.1	ADP02374.1 gp29 [Burkholderia phage KS14]	ADP02374.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	BDD79923.1	BDD79923.1 hypothetical protein [Burkholderia phage FLC10]	BDD79923.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AFJ75483.1	AFJ75483.1 phage-encoded membrane protein [Stenotrophomonas phage Smp131]	AFJ75483.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WNO49106.1	WNO49106.1 hypothetical protein [Achromobacter phage CF418P1]	WNO49106.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80569.1	QBI80569.1 holin [Pseudomonas phage vB_Pae_CF177c]	QBI80569.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80319.1	QBI80319.1 holin [Pseudomonas phage vB_Pae_CF118a]	QBI80319.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80656.1	QBI80656.1 holin [Pseudomonas phage vB_Pae_CF213a]	QBI80656.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI79917.1	QBI79917.1 holin [Pseudomonas phage vB_Pae_CF23a]	QBI79917.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80817.1	QBI80817.1 holin [Pseudomonas phage vB_Pae_BR161a]	QBI80817.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80517.1	QBI80517.1 holin [Pseudomonas phage vB_Pae_CF136b]	QBI80517.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80094.1	QBI80094.1 holin [Pseudomonas phage vB_Pae_CF65a]	QBI80094.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80005.1	QBI80005.1 holin [Pseudomonas phage vB_Pae_CF57a]	QBI80005.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80883.1	QBI80883.1 holin [Pseudomonas phage vB_Pae_BR243a]	QBI80883.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80955.1	QBI80955.1 holin [Pseudomonas phage vB_Pae_BR313c]	QBI80955.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80183.1	QBI80183.1 holin [Pseudomonas phage vB_Pae_CF74b]	QBI80183.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80232.1	QBI80232.1 holin [Pseudomonas phage vB_Pae_CF81a]	QBI80232.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ALY08150.1	ALY08150.1 hypothetical protein [Pseudomonas phage phi1]	ALY08150.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ALP47909.1	ALP47909.1 hypothetical protein BPPAER656_00880 [Pseudomonas phage YMC11/02/R656]	ALP47909.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ULG00174.1	ULG00174.1 holin [Pseudomonas phage PP9W2]	ULG00174.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AAF80841.1	AAF80841.1 conserved hypothetical protein [Pseudomonas phage D3]	AAF80841.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UVN14166.1	UVN14166.1 holin [Pseudomonas phage vB_PeaS_FBPa47]	UVN14166.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AEX55960.1	AEX55960.1 hypothetical protein PMG1_00089 [Pseudomonas phage PMG1]	AEX55960.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WNO24979.1	WNO24979.1 hypothetical protein FGKDOCBF_00050 [Pseudomonas phage LPPA56]	WNO24979.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WWQ71921.1	WWQ71921.1 holin family protein [Pseudomonas phage Lodos]	WWQ71921.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WWQ72217.1	WWQ72217.1 holin [Pseudomonas phage Turba]	WWQ72217.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QGF21344.1	QGF21344.1 putative holin 8 [Pseudomonas phage AUS531phi]	QGF21344.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AFQ22048.1	AFQ22048.1 hypothetical protein BPPAE11_00230 [Pseudomonas phage YMC/01/01/P52_PAE_BP]	AFQ22048.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AMO43592.1	AMO43592.1 hypothetical protein PAEP54_00410 [Pseudomonas phage YMC11/07/P54_PAE_BP]	AMO43592.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ADP02282.1	ADP02282.1 gp35 [Burkholderia phage KS5]	ADP02282.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80765.1	QBI80765.1 hypothetical protein [Pseudomonas phage vB_Pae_BR153a]	QBI80765.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AEX55840.1	AEX55840.1 hypothetical protein phi297_00038 [Pseudomonas phage phi297]	AEX55840.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI80989.1	QBI80989.1 holin [Pseudomonas phage vB_Pae_BR141b]	QBI80989.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AKA61135.1	AKA61135.1 putative antiholin [Burkholderia phage AP3]	AKA61135.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QPB09403.1	QPB09403.1 holin or antiholin class I [Burkholderia phage Mana]	QPB09403.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QSH74625.1	QSH74625.1 hypothetical protein pAN_51 [Pseudomonas phage vB_PstS-pAN]	QSH74625.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WEV90033.1	WEV90033.1 hypothetical protein [Pseudomonas phage PotUPM1]	WEV90033.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	USM11616.1	USM11616.1 LysA [Burkholderia phage Carl1]	USM11616.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QXN68777.1	QXN68777.1 holin [Hafnia phage yong2]	QXN68777.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QSJ04050.1	QSJ04050.1 antiholin/holin protein [Salmonella phage vB_SalP_TR2]	QSJ04050.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	UGO54372.1	UGO54372.1 putative membrane protein [Proteus phage vB_PmiP_Brookers]	UGO54372.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QPB12623.1	QPB12623.1 hypothetical protein [Providencia phage PSTCR7lys]	QPB12623.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBI84117.1	QBI84117.1 hypothetical protein [Pseudomonas phage vB_Pae_BR319a]	QBI84117.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WWQ72091.1	WWQ72091.1 hypothetical protein [Pseudomonas phage Sirocco]	WWQ72091.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AZF87850.1	AZF87850.1 membrane protein [Pseudomonas phage Dobby]	AZF87850.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	BAA36235.1	BAA36235.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36235.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WQY99641.1	WQY99641.1 putative holin [Pseudomonas phage MY01]	WQY99641.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	AYP69329.1	AYP69329.1 antiholin/holin protein [Klebsiella phage Pylas]	AYP69329.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QEA03338.1	QEA03338.1 antiholin/holin protein [Klebsiella phage KpCHEMY26]	QEA03338.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WVM05065.1	WVM05065.1 hypothetical protein vBPvuSPm34_00026 [Vibrio phage vB_PvuS_Pm34]	WVM05065.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ADZ13612.1	ADZ13612.1 putative prophage membrane protein [Cronobacter phage ENT39118]	ADZ13612.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QHI00833.1	QHI00833.1 antiholin/holin protein [Pectobacterium phage MA12]	QHI00833.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WOK01469.1	WOK01469.1 hypothetical protein [Pseudomonas phage UF_RH7]	WOK01469.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	WJN66864.1	WJN66864.1 hypothetical protein CFHODIGL_00049 [Edwardsiella phage EPP-1]	WJN66864.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	ALP46910.1	ALP46910.1 holin1 [Escherichia phage Rac-SA53]	ALP46910.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	CAC83546.1	CAC83546.1 putative holin [Enterobacteria phage phiP27]	CAC83546.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	QBP27561.1	QBP27561.1 membrane protein [Klebsiella phage ST13-OXA48phi12.2]	QBP27561.1	0
+ab89680c-5e54-4026-8b57-7a7aed499038	CAB93764.1	CAB93764.1 hypothetical protein [Enterobacteria phage phiP27]	CAB93764.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UNY41669.1	UNY41669.1 N-acetylmuramidase [Burkholderia phage Musica]	UNY41669.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UNY41729.1	UNY41729.1 N-acetylmuramidase [Burkholderia phage Milagro]	UNY41729.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADP02326.1	ADP02326.1 gp33 [Burkholderia phage KL3]	ADP02326.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UNY41786.1	UNY41786.1 N-acetylmuramidase [Burkholderia phage Menos]	UNY41786.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UNY41841.1	UNY41841.1 N-acetylmuramidase [Burkholderia phage Momento]	UNY41841.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UKM53773.1	UKM53773.1 putative peptidoglycan binding protein [Burkholderia phage PhiBP82.2]	UKM53773.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QWY84956.1	QWY84956.1 putative peptidoglycan binding protein [Burkholderia phage PK23]	QWY84956.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ABO60759.1	ABO60759.1 gp45, bacteriophage-acquired protein [Burkholderia phage phiE12-2]	ABO60759.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WWY66153.1	WWY66153.1 endolysin [Burkholderia phage vB_HM387]	WWY66153.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ABO60730.1	ABO60730.1 gp43, bacteriophage-acquired protein [Burkholderia phage phiE202]	ABO60730.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AAZ72636.1	AAZ72636.1 gp28-like protein [Burkholderia phage phiE52237]	AAZ72636.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIP84309.1	AIP84309.1 putative peptidoglycan binding domain protein [Burkholderia phage BEK]	AIP84309.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFV51405.1	AFV51405.1 gp28-like protein [Burkholderia phage phiX216]	AFV51405.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPI18550.1	QPI18550.1 peptidoglycan binding protein [Burkholderia phage phiE094]	QPI18550.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BCB23205.1	BCB23205.1 endolysin [Burkholderia phage FLC5]	BCB23205.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADP02372.1	ADP02372.1 gp27 [Burkholderia phage KS14]	ADP02372.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BDD79925.1	BDD79925.1 hypothetical protein [Burkholderia phage FLC10]	BDD79925.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPB09405.1	QPB09405.1 endolysin glycoside hydrolase [Burkholderia phage Mana]	QPB09405.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UPI15566.1	UPI15566.1 putative peptidoglycan binding protein [Burkholderia phage PhiBP82.3]	UPI15566.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AKA61137.1	AKA61137.1 endolysin [Burkholderia phage AP3]	AKA61137.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADP02280.1	ADP02280.1 gp33 [Burkholderia phage KS5]	ADP02280.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	USM11618.1	USM11618.1 endolysin [Burkholderia phage Carl1]	USM11618.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBI84119.1	QBI84119.1 putative peptidoglycan binding protein [Pseudomonas phage vB_Pae_BR319a]	QBI84119.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAP28116.1	BAP28116.1 hypothetical protein [Ralstonia phage RSY1]	BAP28116.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAF52391.1	BAF52391.1 phage-related protein [Ralstonia phage RSA1]	BAF52391.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AZF87852.1	AZF87852.1 DUF3380 domain-containing protein [Pseudomonas phage Dobby]	AZF87852.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAA36237.1	BAA36237.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36237.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ANN85968.1	ANN85968.1 putative peptidoglycan binding protein [Salmonella phage GG32]	ANN85968.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UCR92388.1	UCR92388.1 hypothetical protein LPEK22_00136 [Escherichia phage LPEK22]	UCR92388.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WZB37067.1	WZB37067.1 endolysin [Salmonella phage STP-4]	WZB37067.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ62159.1	QIQ62159.1 peptidoglycan binding protein [Salmonella phage kage]	QIQ62159.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD18387.1	APD18387.1 peptidoglycan binding protein [Salmonella phage STP07]	APD18387.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEN94175.1	AEN94175.1 peptidoglycan binding protein [Salmonella phage SFP10]	AEN94175.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXY85236.1	AXY85236.1 canonical endolysin [Salmonella phage Mooltan]	AXY85236.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUG88272.1	AUG88272.1 endolysin [Salmonella phage Mutine]	AUG88272.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAB5508956.1	CAB5508956.1 Putative phage-encoded peptidoglycan binding protein [Salmonella phage Se_EM3]	CAB5508956.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO89372.1	QQO89372.1 hypothetical protein HNKMKGGD_00166 [Salmonella phage vB_SenAc_BPS7]	QQO89372.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG60492.1	QIG60492.1 endolysin [Salmonella phage Chennai]	QIG60492.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ATW66849.1	ATW66849.1 putative peptidoglycan binding protein [Escherichia phage FEC14]	ATW66849.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXF41577.1	AXF41577.1 endolysin [Salmonella phage vB_SalM-LPST94]	AXF41577.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARB06319.1	ARB06319.1 putative peptidoglycan binding protein [Salmonella phage S8]	ARB06319.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QOE31895.1	QOE31895.1 endolysin [Salmonella phage ISTP3]	QOE31895.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEM91813.1	AEM91813.1 putative phage-encoded peptidoglycan binding protein [Escherichia phage Cba120]	AEM91813.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO86965.1	QQO86965.1 hypothetical protein PKNFJJPA_00010 [Salmonella phage vB_SenAc_BPS6]	QQO86965.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ANK36008.1	ANK36008.1 endolysin [Salmonella phage 10]	ANK36008.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXC40431.1	AXC40431.1 putative peptidoglycan binding protein [Salmonella phage S115]	AXC40431.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO89129.1	QQO89129.1 hypothetical protein AAMKOAHC_00125 [Salmonella phage vB_SenAc_BPS5]	QQO89129.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UNI71270.1	UNI71270.1 endolysin [Salmonella phage vB_SenA_SM5]	UNI71270.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXC40997.1	AXC40997.1 putative peptidoglycan hydrolase (endolysin) [Salmonella phage S118]	AXC40997.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEW24286.1	AEW24286.1 hypothetical protein [Escherichia phage PhaxI]	AEW24286.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO88916.1	QQO88916.1 hypothetical protein JHLACNCA_00185 [Salmonella phage vB_SenAc_BPS3]	QQO88916.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ANT44537.1	ANT44537.1 putative peptidoglycan binding protein [Salmonella phage vB_SenM-2]	ANT44537.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARM70010.1	ARM70010.1 peptidoglycan binding protein [Salmonella phage BSP101]	ARM70010.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AHV82426.1	AHV82426.1 putative peptidoglycan binding protein [Salmonella phage vB-SalM-SJ3]	AHV82426.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV34257.1	QMV34257.1 N-acetylmuramidase [Salmonella phage vB_SentM_sal1]	QMV34257.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPX74263.1	QPX74263.1 putative endolysin [Salmonella phage FrontPhageNews]	QPX74263.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXC40792.1	AXC40792.1 putative peptidoglycan binding protein [Salmonella phage S117]	AXC40792.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AER70200.1	AER70200.1 phage-encoded peptidoglycan binding protein [Salmonella typhimurium phage PhiSH19]	AER70200.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGL60116.1	UGL60116.1 endolysin [Salmonella phage vB_SenAc-pSC20]	UGL60116.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAB5509007.1	CAB5509007.1 Putative phage-encoded peptidoglycan binding protein [Salmonella phage Se_EM4]	CAB5509007.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXY86560.1	AXY86560.1 putative peptidoglycan binding protein [Salmonella phage SenASZ3]	AXY86560.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UPU15730.1	UPU15730.1 endolysin [Salmonella phage STP55]	UPU15730.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVP82707.1	WVP82707.1 peptidoglycan-binding protein [Escherichia phage vB_EcoM_JN03]	WVP82707.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QKE54729.1	QKE54729.1 endolysin [Escherichia phage vB_EcoA_4HA11]	QKE54729.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WPJ70501.1	WPJ70501.1 hypothetical protein orfRA148_00120c [Salmonella phage RA148]	WPJ70501.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WWQ70946.1	WWQ70946.1 endolysin [Salmonella phage SeKF_19]	WWQ70946.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ANO57757.1	ANO57757.1 putative peptidoglycan binding protein [Salmonella phage vB-SalM-PM10]	ANO57757.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AJQ20900.1	AJQ20900.1 N-terminus peptidoglycan binding domain protein [Salmonella phage Det7]	AJQ20900.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WID61860.1	WID61860.1 putative phage-encoded peptidoglycan binding protein [Salmonella phage SPTD1]	WID61860.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QFR58727.1	QFR58727.1 endolysin [Salmonella phage vB_SentM_Phi_10]	QFR58727.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXY86760.1	AXY86760.1 putative peptidoglycan binding protein [Salmonella phage SenALZ1]	AXY86760.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX99266.1	QAX99266.1 hypothetical protein SeSz1_84 [Salmonella phage SeSz-1]	QAX99266.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ61769.1	QIQ61769.1 peptidoglycan binding protein [Salmonella phage rabagast]	QIQ61769.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WYA83687.1	WYA83687.1 endolysin [Salmonella phage vB_SalM-ps4]	WYA83687.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBF04260.1	WBF04260.1 putative peptidoglycan binding protein [Salmonella phage PST-D24]	WBF04260.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WDS51398.1	WDS51398.1 endolysin [Salmonella phage SeF6a]	WDS51398.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASZ77627.1	ASZ77627.1 putative peptidoglycan binding protein [Salmonella phage SP1]	ASZ77627.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WAK45395.1	WAK45395.1 putative peptidoglycan binding protein [Salmonella phage 3384-D8]	WAK45395.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAB5494315.1	CAB5494315.1 Putative phage-encoded peptidoglycan binding protein [Salmonella phage Se_AO1]	CAB5494315.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AHK61394.1	AHK61394.1 peptidoglycan binding protein [Salmonella phage vB-SalM-SJ2]	AHK61394.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXF39283.1	AXF39283.1 peptidoglycan binding protein [Escherichia phage vB_EcoM_Sa157lw]	AXF39283.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UCR91132.1	UCR91132.1 peptidoglycan binding protein [Escherichia phage Sa157lw]	UCR91132.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO03101.1	QIO03101.1 peptidoglycan binding protein [Salmonella phage barely]	QIO03101.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WIL01868.1	WIL01868.1 endolysin [Salmonella phage D5lw]	WIL01868.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WWQ72093.1	WWQ72093.1 endolysin [Pseudomonas phage Sirocco]	WWQ72093.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UHS65583.1	UHS65583.1 N-acetylmuramidase [Escherichia phage vB_EcoM-RPN242]	UHS65583.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QFR58349.1	QFR58349.1 peptidoglycan-binding protein [Escherichia phage vB_EcoM_3HA11]	QFR58349.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ62371.1	QIQ62371.1 peptidoglycan binding protein [Salmonella phage moki]	QIQ62371.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVZ44932.1	AVZ44932.1 hypothetical protein [Escherichia phage EP75]	AVZ44932.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UMO77581.1	UMO77581.1 endolysin [Salmonella phage PLL1]	UMO77581.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WES09797.1	WES09797.1 putative peptidoglycan binding protein [Salmonella phage SWJM-01]	WES09797.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URQ08826.1	URQ08826.1 hypothetical protein BRM13312_00200 [Salmonella phage BRM 13312]	URQ08826.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WDR21366.1	WDR21366.1 endolysin [Salmonella phage vB_SenM_UTK0005]	WDR21366.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEI23492.1	QEI23492.1 peptidoglycan binding protein [Salmonella phage SE14]	QEI23492.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPI15289.1	QPI15289.1 endolysin [Salmonella phage GEC_vB_N6]	QPI15289.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CBW37954.1	CBW37954.1 phage-encoded peptidoglycan binding protein [Salmonella phage Vi01]	CBW37954.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UYL83703.1	UYL83703.1 peptidoglycan binding protein [Salmonella phage Guerrero]	UYL83703.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO02896.1	QIO02896.1 peptidoglycan binding protein [Salmonella phage dinky]	QIO02896.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEI24030.1	QEI24030.1 peptidoglycan binding protein [Salmonella phage SS3]	QEI24030.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGY47844.1	AGY47844.1 endolysin [Salmonella phage Maynard]	AGY47844.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UQS93130.1	UQS93130.1 hypothetical protein BRM13313_00204 [Salmonella phage BRM 13313]	UQS93130.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFU64181.1	AFU64181.1 hypothetical protein [Salmonella phage STML-13-1]	AFU64181.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WLI71548.1	WLI71548.1 N-acetylmuramidase [Salmonella phage vB_SenM-AKM_ssTn]	WLI71548.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGF88571.1	AGF88571.1 hypothetical protein SP063_00602 [Salmonella phage FSL SP-063]	AGF88571.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPX74435.1	QPX74435.1 putative peptidoglycan binding protein [Salmonella phage Sajous1]	QPX74435.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WWQ71359.1	WWQ71359.1 endolysin [Salmonella phage SeKF_64]	WWQ71359.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO02245.1	QIO02245.1 peptidoglycan binding protein [Salmonella phage heyday]	QIO02245.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGY47639.1	AGY47639.1 endolysin [Salmonella phage Marshall]	AGY47639.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WDS51167.1	WDS51167.1 endolysin [Salmonella phage SeF3a]	WDS51167.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFO10240.1	AFO10240.1 hypothetical protein [Escherichia phage ECML-4]	AFO10240.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEI24283.1	QEI24283.1 peptidoglycan binding protein [Salmonella phage SS9]	QEI24283.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPX74052.1	QPX74052.1 putative peptidoglycan binding protein [Salmonella phage AR2819]	QPX74052.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPI14414.1	QPI14414.1 endolysin [Salmonella phage GEC_vB_GOT]	QPI14414.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGF89070.1	AGF89070.1 hypothetical protein SP029_00440 [Salmonella phage FSL SP-029]	AGF89070.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UZV39341.1	UZV39341.1 hypothetical protein HERCULESSET_130 [Salmonella phage vB_Hercules_SET]	UZV39341.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WQZ19089.1	WQZ19089.1 endolysin [Escherichia phage 241]	WQZ19089.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AYJ73595.1	AYJ73595.1 endolysin [Salmonella phage PS5]	AYJ73595.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QOI58433.1	QOI58433.1 putative endolysin [Salmonella phage pSal-SNUABM-02]	QOI58433.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ61961.1	QIQ61961.1 peptidoglycan binding protein [Salmonella phage bering]	QIQ61961.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BBD52272.1	BBD52272.1 putative endolysin [Enterobacter phage EspM4VN]	BBD52272.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WRQ13294.1	WRQ13294.1 peptidoglycan binding protein [Salmonella phage vB_SenAc-pSK20]	WRQ13294.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEA10249.1	QEA10249.1 endolysin amidase [Salmonella phage Matapan]	QEA10249.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WOZ56585.1	WOZ56585.1 hypothetical protein GHCGIGKI_00680 [Klebsiella phage P01]	WOZ56585.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVP40008.1	AVP40008.1 peptidoglycan-binding protein [Ralstonia phage RsoM1USA]	AVP40008.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URQ09127.1	URQ09127.1 hypothetical protein BRM13314_00202 [Salmonella phage BRM 13314]	URQ09127.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBJ04420.1	QBJ04420.1 hypothetical protein MK13_00191 [Shigella phage MK-13]	QBJ04420.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFU64431.1	AFU64431.1 hypothetical protein [Salmonella phage SKML-39]	AFU64431.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UJD04823.1	UJD04823.1 endolysin N-acetylmuramidase [Klebsiella phage PWKp5]	UJD04823.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AHZ60246.1	AHZ60246.1 putative peptidoglycan binding domain protein [Dickeya phage RC-2014]	AHZ60246.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIM51628.1	AIM51628.1 putative peptidoglycan binding domain protein [Dickeya phage phiDP10.3]	AIM51628.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CCD57631.1	CCD57631.1 putative endolysin [Dickeya phage vB-DsoM-LIMEstone1]	CCD57631.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASD51454.1	ASD51454.1 putative endolysin [Dickeya phage XF4]	ASD51454.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AYN55450.1	AYN55450.1 putative endolysin [Dickeya phage Coodle]	AYN55450.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UHS64927.1	UHS64927.1 putative endolysin [Shigella phage vB_SboS_Gloob]	UHS64927.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WPH64484.1	WPH64484.1 hypothetical protein [Escherichia phage YX22]	WPH64484.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAB5508568.1	CAB5508568.1 Putative phage-encoded peptidoglycan binding protein [Salmonella phage Se_EM1]	CAB5508568.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUG88056.1	AUG88056.1 endolysin [Klebsiella phage May]	AUG88056.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAK6598013.1	CAK6598013.1 endolysin [Klebsiella phage vB_Ko_K5lambda5]	CAK6598013.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG62158.1	QIG62158.1 endolysin [Salmonella phage P46FS4]	QIG62158.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WKM80435.1	WKM80435.1 endolysin [Salmonella phage SW16-7]	WKM80435.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGO47058.1	UGO47058.1 putative endolysin [Shigella phage ChubbyThor]	UGO47058.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WJJ54056.1	WJJ54056.1 putative peptidoglycan binding protein [Escherichia phage AV101]	WJJ54056.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB42381.1	QHB42381.1 endolysin [Dickeya phage Ds23CZ]	QHB42381.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBQ78849.1	QBQ78849.1 hypothetical protein KWBSE43_00021 [Escherichia phage vB_EcoM_KWBSE43-6]	QBQ78849.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ACO94320.1	ACO94320.1 conserved hypothetical phage protein [Shigella phage Ag3]	ACO94320.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QVW27146.1	QVW27146.1 putative endolysin [Escherichia phage vB_EcoM-ZQ1]	QVW27146.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVX98345.1	WVX98345.1 hypothetical protein PLAPEKGO_00046 [Klebsiella phage KP6]	WVX98345.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URG17952.1	URG17952.1 endolysin [Klebsiella phage T765]	URG17952.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URG13632.1	URG13632.1 endolysin [Klebsiella phage T751]	URG13632.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WJJ58700.1	WJJ58700.1 endolysin [Klebsiella phage vB_KpnS_MDA2066]	WJJ58700.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UPW36096.1	UPW36096.1 endolysin [Klebsiella phage K751]	UPW36096.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QGF20537.1	QGF20537.1 putative peptidoglycan binding protein [Klebsiella phage UPM 2146]	QGF20537.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUG87844.1	AUG87844.1 endolysin [Klebsiella phage Menlow]	AUG87844.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIM51852.1	AIM51852.1 putative peptidoglycan binding domain protein [Dickeya phage phiDP23.1]	AIM51852.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AYN55647.1	AYN55647.1 putative endolysin [Dickeya phage Kamild]	AYN55647.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ATW62074.1	ATW62074.1 putative N-acetylmuramidase [Dickeya phage PP35]	ATW62074.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIM51349.1	AIM51349.1 putative peptidoglycan binding domain protein [Dickeya phage phiD3]	AIM51349.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB41575.1	QHB41575.1 endolysin [Dickeya phage Ds5CZ]	QHB41575.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB42183.1	QHB42183.1 endolysin [Dickeya phage Ds20CZ]	QHB42183.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB42578.1	QHB42578.1 endolysin [Dickeya phage Ds25CZ]	QHB42578.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB42808.1	QHB42808.1 endolysin [Dickeya phage Ds3CZ]	QHB42808.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB41980.1	QHB41980.1 endolysin [Dickeya phage Ds16CZ]	QHB41980.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASD51255.1	ASD51255.1 putative endolysin [Dickeya phage JA15]	ASD51255.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHB41777.1	QHB41777.1 endolysin [Dickeya phage Ds9CZ]	QHB41777.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URX65873.1	URX65873.1 hypothetical protein PC3_000086 [Escherichia phage PC3]	URX65873.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URX66064.1	URX66064.1 hypothetical protein PH4_000086 [Escherichia phage PH4]	URX66064.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WPJ48867.1	WPJ48867.1 hypothetical protein RCIP0012_00085 [Klebsiella phage RCIP0012]	WPJ48867.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ANM47294.1	ANM47294.1 putative peptidoglycan binding protein [Serratia phage vB_Sru_IME250]	ANM47294.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD20202.1	APD20202.1 putative peptidoglycan binding protein [Serratia phage vB_Sru_IME250]	APD20202.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO03500.1	QIO03500.1 peptidoglycan binding protein [Salmonella phage maane]	QIO03500.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO02428.1	QIO02428.1 peptidoglycan binding protein [Salmonella phage allotria]	QIO02428.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UTQ72630.1	UTQ72630.1 putative peptidoglycan binding protein [Escherichia phage A221]	UTQ72630.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WPJ72171.1	WPJ72171.1 hypothetical protein DEEACLCL_00154 [Salmonella phage CRW-SP2]	WPJ72171.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WDR21157.1	WDR21157.1 endolysin [Salmonella phage vB_SenM_UTK0004]	WDR21157.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUV59125.1	AUV59125.1 peptidoglycan binding protein [Klebsiella phage vB_KpnM_KpS110]	AUV59125.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEG08022.1	QEG08022.1 endolysin N-acetylmuramidase [Klebsiella phage Magnus]	QEG08022.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO03302.1	QIO03302.1 peptidoglycan binding protein [Salmonella phage pertopsoe]	QIO03302.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AKJ73774.1	AKJ73774.1 putative-encoded peptidoglycan binding protein [Salmonella phage 38]	AKJ73774.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	USL85894.1	USL85894.1 putative endolysin [Enterobacter phage fGh-Ecl02]	USL85894.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAN78362.1	BAN78362.1 phage-encoded peptidoglycan binding protein [Klebsiella phage 0507-KN2-1]	BAN78362.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIO02693.1	QIO02693.1 peptidoglycan binding protein [Salmonella phage aagejoakim]	QIO02693.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPX74828.1	QPX74828.1 putative DUF3380 domain-containing protein [Salmonella phage SilasIsHot]	QPX74828.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WNM70798.1	WNM70798.1 endolysin [Salmonella phage Mansal]	WNM70798.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ABY63058.1	ABY63058.1 virion structural protein [Pseudomonas phage 201phi2-1]	ABY63058.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXG67760.1	AXG67760.1 DUF3380 domain-containing protein [Ralstonia phage GP4]	AXG67760.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33192.1	QMV33192.1 hypothetical protein 23F_00030 [Ralstonia phage Gerry]	QMV33192.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32462.1	QMV32462.1 hypothetical protein 20A_00012 [Ralstonia phage Alix]	QMV32462.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33057.1	QMV33057.1 hypothetical protein 3Fb_00054 [Ralstonia phage Eline]	QMV33057.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QOQ37808.1	QOQ37808.1 hypothetical protein 9Ga_00046 [Ralstonia phage Gamede]	QOQ37808.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33269.1	QMV33269.1 hypothetical protein 1Ca_00031 [Ralstonia phage Gervaise]	QMV33269.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPD96388.1	QPD96388.1 hypothetical protein 20Ca_00071 [Ralstonia phage Claudette]	QPD96388.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32771.1	QMV32771.1 hypothetical protein 2A_00019 [Ralstonia phage Darius]	QMV32771.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QKW95399.1	QKW95399.1 DUF3380 domain-containing protein [Ralstonia phage RPZH6]	QKW95399.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WAX26317.1	WAX26317.1 putative peptidoglycan binding protein [Ralstonia phage p2110]	WAX26317.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33374.1	QMV33374.1 hypothetical protein F1_00010 [Ralstonia phage Heva]	QMV33374.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UAW01021.1	UAW01021.1 DUF3380 domain-containing protein [Ralstonia phage RPZH3]	UAW01021.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32639.1	QMV32639.1 hypothetical protein B2_00004 [Ralstonia phage Cimandef]	QMV32639.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARV77309.1	ARV77309.1 putative peptidoglycan-binding protein [Pseudomonas phage Noxifer]	ARV77309.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WRQ05456.1	WRQ05456.1 DUF3380 domain-containing protein [Ralstonia phage AhaGv]	WRQ05456.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVS23979.1	WVS23979.1 hypothetical protein QkW1_56 [Ralstonia phage QkW1]	WVS23979.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32879.1	QMV32879.1 hypothetical protein D1_00053 [Ralstonia phage Dimitile]	QMV32879.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AYP28388.1	AYP28388.1 putative peptidoglycan binding protein [Serratia phage vB_SmaA_3M]	AYP28388.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CAH0532154.1	CAH0532154.1 hypothetical protein UAM5_00037 [Ralstonia phage UAM5]	CAH0532154.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIX13070.1	AIX13070.1 putative peptidoglycan binding protein [Erwinia phage phiEa2809]	AIX13070.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVO22912.1	AVO22912.1 putative peptidoglycan binding protein [Erwinia phage vB_EamM-Bue1]	AVO22912.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGC97278.1	UGC97278.1 N-acetylmuramidase family protein [Aeromonas phage vB_AsaM_LPM4]	UGC97278.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFX93594.1	AFX93594.1 peptidoglycan binding protein [Serratia phage phiMAM1]	AFX93594.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASZ78903.1	ASZ78903.1 peptidoglycan binding protein [Serratia phage 2050H1]	ASZ78903.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QYW06317.1	QYW06317.1 putative peptidoglycan binding protein [Shewanella phage vB_SspM_M16-3]	QYW06317.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARV76848.1	ARV76848.1 virion structural protein [Pseudomonas phage Phabio]	ARV76848.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO00595.1	QNO00595.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa381]	QNO00595.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO00768.1	QNO00768.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa397]	QNO00768.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO00078.1	QNO00078.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa300]	QNO00078.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AHJ87343.1	AHJ87343.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa374]	AHJ87343.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO00421.1	QNO00421.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa347]	QNO00421.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNN99901.1	QNN99901.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa267]	QNN99901.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UAW53549.1	UAW53549.1 peptidoglycan hydrolase [Pseudomonas phage psageK4e]	UAW53549.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV71745.1	QXV71745.1 peptidoglycan hydrolase [Pseudomonas phage psageK4]	QXV71745.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO00248.1	QNO00248.1 putative peptidoglycan binding protein [Pseudomonas phage phiPsa315]	QNO00248.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPB10510.1	QPB10510.1 endolysin [Pseudomonas phage PN09]	QPB10510.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHZ60046.1	QHZ60046.1 hypothetical protein PJKIFABJ_00110 [Pseudomonas phage PE09]	QHZ60046.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UPW35891.1	UPW35891.1 lysozyme-type endolysin [Pseudomonas phage EM]	UPW35891.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WIC39276.1	WIC39276.1 hypothetical protein vFB297_0690 [Pseudomonas phage vFB297]	WIC39276.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADF58201.1	ADF58201.1 endolysin [Pseudomonas phage JG004]	ADF58201.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UOL47862.1	UOL47862.1 endolysin [Pseudomonas phage vB_Paer_PsCh]	UOL47862.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AZF89615.1	AZF89615.1 putative peptidoglycan binding protein [Pseudomonas phage vB_PaeM_LCK69]	AZF89615.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UCS82818.1	UCS82818.1 endolysin [Yersinia phage vB_YenS_P400]	UCS82818.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGS81746.1	AGS81746.1 hypothetical protein PAK_P100028 [Pseudomonas phage PAK_P1]	AGS81746.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBY52021.1	WBY52021.1 N-acetylmuramidase family protein [Pseudomonas phage vB_PaeM_B55]	WBY52021.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEK21612.1	AEK21612.1 endolysin [Pseudomonas phage PaP1]	AEK21612.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD20802.1	APD20802.1 putative peptidoglycan binding protein [Pseudomonas phage PA10]	APD20802.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QYC95310.1	QYC95310.1 endolysin [Pseudomonas phage PhL_UNISO_PA-DSM_ph0034]	QYC95310.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD19512.1	APD19512.1 lysozyme [Pseudomonas phage Zigelbrucke]	APD19512.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMD42897.1	AMD42897.1 endolysin [Pseudomonas phage K5]	AMD42897.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGR89148.1	AGR89148.1 hypothetical protein PAK_P200028 [Pseudomonas phage PAK_P2]	AGR89148.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WFP45963.1	WFP45963.1 endolysin [Pseudomonas phage vB_VIPPAEUMC01]	WFP45963.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX98140.1	QAX98140.1 N-acetylmuramidase family protein [Pseudomonas phage PaGz-1]	QAX98140.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGR89325.1	AGR89325.1 putative endolysin [Pseudomonas phage PAK_P4]	AGR89325.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVX91063.1	WVX91063.1 endolysin [Pseudomonas phage PJNP029]	WVX91063.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXY86931.1	AXY86931.1 putative peptidoglycan binding protein [Pseudomonas phage PaYy-2]	AXY86931.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ALF51400.1	ALF51400.1 endolysin [Pseudomonas phage K8]	ALF51400.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBM36204.1	WBM36204.1 putative peptidoglycan binding protein [Pseudomonas phage HJ01]	WBM36204.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAU05158.1	QAU05158.1 N-acetylmuramidase family protein [Pseudomonas phage Henu5]	QAU05158.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WJJ54480.1	WJJ54480.1 endolysin [Pseudomonas phage PT07]	WJJ54480.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ALJ97536.1	ALJ97536.1 endolysin [Pseudomonas phage C11]	ALJ97536.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UZV40393.1	UZV40393.1 tail fiber protein [Pseudomonas phage vB-PaeM-YQ78]	UZV40393.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXC34710.1	AXC34710.1 DUF3380 domain-containing protein [Pseudomonas phage SRT6]	AXC34710.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMQ66283.1	AMQ66283.1 hypothetical protein phiMK_95 [Pseudomonas phage phiMK]	AMQ66283.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ACZ55949.1	ACZ55949.1 endolysin [Pseudomonas phage PaP1]	ACZ55949.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WQZ01314.1	WQZ01314.1 endolysin [Pseudomonas phage Pae01]	WQZ01314.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WFG37171.1	WFG37171.1 putative endolysin [Pseudomonas phage bmx-p3]	WFG37171.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WFG37881.1	WFG37881.1 endolysin [Pseudomonas phage 20Sep418]	WFG37881.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CCM43618.1	CCM43618.1 hypothetical protein BN405_2-10_Ab1_orf_74 [Pseudomonas phage vB_PaeM_C2-10_Ab1]	CCM43618.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WFG74121.1	WFG74121.1 hypothetical protein DOEKDBNA_00080 [Pseudomonas phage SPA01]	WFG74121.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UZO33127.1	UZO33127.1 endolysin [Pseudomonas phage PseuPha1]	UZO33127.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WFG37644.1	WFG37644.1 endolysin [Pseudomonas phage 20Sep416]	WFG37644.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UQS93578.1	UQS93578.1 endolysin [Pseudomonas phage vB_Pae_Kat]	UQS93578.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WNV48764.1	WNV48764.1 endolysin [Pseudomonas phage Kat]	WNV48764.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVS24070.1	WVS24070.1 endolysin [Pseudomonas phage LPS-5]	WVS24070.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UOL47675.1	UOL47675.1 endolysin [Pseudomonas phage vB_Paer_Ps25]	UOL47675.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WEY17934.1	WEY17934.1 hypothetical protein OJIADAOI_00163 [Pseudomonas phage SPA05]	WEY17934.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CEF89008.1	CEF89008.1 Putative peptidoglycan binding protein [Pseudomonas phage vB_PaeM_C2-10_Ab02]	CEF89008.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QDF15554.1	QDF15554.1 endolysin [Pseudomonas phage vB_PaM_EPA1]	QDF15554.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBW48893.1	WBW48893.1 endolysin [Pseudomonas phage vB_PaeS_B8]	WBW48893.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UOL47487.1	UOL47487.1 endolysin [Pseudomonas phage vB_Paer_Ps12]	UOL47487.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ATI16068.1	ATI16068.1 hypothetical protein Y35_GM000095 [Pseudomonas phage YS35]	ATI16068.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CEF89392.1	CEF89392.1 Putative peptidoglycan binding protein [Pseudomonas phage vB_PaeM_C2-10_Ab08]	CEF89392.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBQ35150.1	WBQ35150.1 endolysin [Pseudomonas phage pPA-3099-2aT.2]	WBQ35150.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBW49201.1	WBW49201.1 endolysin [Pseudomonas phage vB_PaeM_B31]	WBW49201.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UOL48059.1	UOL48059.1 endolysin [Pseudomonas phage vB_Paer_PsIn]	UOL48059.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QGK90186.1	QGK90186.1 hypothetical protein [Pseudomonas phage vB_PA45_GUMS]	QGK90186.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGL61582.1	UGL61582.1 endolysin [Pseudomonas phage phipa10]	UGL61582.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX99820.1	QAX99820.1 endolysin [Pseudomonas phage PaZq-1]	QAX99820.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ALT58359.1	ALT58359.1 endolysin [Pseudomonas phage PaoP5]	ALT58359.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAU05350.1	QAU05350.1 putative endolysin [Pseudomonas phage vB_PaeM_SCUT-S2]	QAU05350.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAY01703.1	QAY01703.1 endolysin [Pseudomonas phage PaSzW-1]	QAY01703.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBJ04636.1	QBJ04636.1 hypothetical protein JHP_0005 [Pseudomonas phage JHP]	QBJ04636.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WKC57497.1	WKC57497.1 endolysin [Pseudomonas phage vB_PaM_EPA3]	WKC57497.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ALA12076.1	ALA12076.1 hypothetical protein vB_PaeM_MAG1_096 [Pseudomonas phage vB_PaeM_MAG1]	ALA12076.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBP28097.1	QBP28097.1 endolysin [Pseudomonas phage ITTPL]	QBP28097.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBQ72232.1	QBQ72232.1 endolysin [Serratia phage Parlo]	QBQ72232.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WPJ20650.1	WPJ20650.1 endolysin [Pseudomonas phage vB_PF_Y1-MI]	WPJ20650.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASV45028.1	ASV45028.1 endolysin [Klebsiella phage SopranoGao]	ASV45028.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW86703.1	QIW86703.1 endolysin [Klebsiella phage LASTA]	QIW86703.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW86779.1	QIW86779.1 endolysin [Klebsiella phage SJM3]	QIW86779.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BBK09361.1	BBK09361.1 DUF3380 domain-containing protein [Klebsiella phage 05F01]	BBK09361.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QRE00659.1	QRE00659.1 putative peptidoglycan binding protein [Pseudomonas phage Itty13]	QRE00659.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QTH79857.1	QTH79857.1 endolysin [Klebsiella phage vB_KpnP_ZX1]	QTH79857.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGO52713.1	UGO52713.1 putative endolysin [Serratia phage vB_SmaS_Opt-155]	UGO52713.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WOZ57498.1	WOZ57498.1 N-acetylmuramidase family protein [Pseudomonas phage PseuGes_254]	WOZ57498.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBQ72917.1	QBQ72917.1 endolysin [Serratia phage Serbin]	QBQ72917.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UGO51470.1	UGO51470.1 hypothetical protein TLACUACHE_56 [Serratia phage vB_SmaS_Tlacuache]	UGO51470.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEY69617.1	AEY69617.1 endolysin [Erwinia phage PEp14]	AEY69617.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UZV40802.1	UZV40802.1 putative endolysin [Erwinia phage Stean]	UZV40802.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QPZ53270.1	QPZ53270.1 N-acetylmuramidase family protein [Achromobacter phage vB_AchrS_AchV4]	QPZ53270.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WJJ58648.1	WJJ58648.1 endolysin muramidase [Klebsiella phage vB_KpnS_MAG26fr]	WJJ58648.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WMI32169.1	WMI32169.1 endolysin [Klebsiella phage SAKp02]	WMI32169.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AXF51456.1	AXF51456.1 putative lys protein [Erwinia phage Pavtok]	AXF51456.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASW27586.1	ASW27586.1 putative endolysin [Klebsiella phage YMC15/11/N53_KPN_BP]	ASW27586.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASW27354.1	ASW27354.1 endolysin [Klebsiella phage KPN U2874]	ASW27354.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASW27508.1	ASW27508.1 endolysin [Klebsiella phage KPN N54]	ASW27508.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ASW27274.1	ASW27274.1 hypothetical protein KPNN137_46 [Klebsiella phage KPN N137]	ASW27274.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUV62708.1	AUV62708.1 endolysin [Klebsiella phage KPN N98]	AUV62708.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEM42170.1	QEM42170.1 endolysin muramidase [Klebsiella phage Soft]	QEM42170.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CEF89189.1	CEF89189.1 putative peptidoglycan hydrolase, endolysin [Pseudomonas phage vB_PaeM_PAO1_Ab03]	CEF89189.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEM40954.1	QEM40954.1 endolysin [Pseudomonas phage PAP-JP]	QEM40954.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ65623.1	QIQ65623.1 hypothetical protein 26_00096 [Pseudomonas phage Epa26]	QIQ65623.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAJ09147.1	BAJ09147.1 putative endolysin [Pseudomonas phage KPP10]	BAJ09147.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIW01780.1	AIW01780.1 hypothetical protein vB_PaeM_PS2400078 [Pseudomonas phage vB_PaeM_PS24]	AIW01780.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARW57345.1	ARW57345.1 putative endolysin [Pseudomonas phage vB_PaeM_G1]	ARW57345.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UKM53943.1	UKM53943.1 endolysin [Pseudomonas phage vB_PaeM_VL12]	UKM53943.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGR89499.1	AGR89499.1 hypothetical protein PAK_P500029 [Pseudomonas phage PAK_P5]	AGR89499.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ64987.1	QIQ64987.1 hypothetical protein 16_00001 [Pseudomonas phage Epa16]	QIQ64987.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ64096.1	QIQ64096.1 hypothetical protein Epa17_00082 [Pseudomonas phage Epa17]	QIQ64096.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADX32215.1	ADX32215.1 hypothetical protein PAK_P30028 [Pseudomonas phage PAK_P3]	ADX32215.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGR88982.1	AGR88982.1 hypothetical protein CHA_P10028 [Pseudomonas phage CHA_P1]	AGR88982.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ63841.1	QIQ63841.1 hypothetical protein Epa24_00075 [Pseudomonas phage Epa24]	QIQ63841.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ADX32030.1	ADX32030.1 hypothetical protein P3_CHA0028 [Pseudomonas phage P3_CHA]	ADX32030.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIQ65148.1	QIQ65148.1 hypothetical protein 18_00078 [Pseudomonas phage Epa18]	QIQ65148.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UVD32698.1	UVD32698.1 endolysin [Pseudomonas phage PH826]	UVD32698.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	CEF89573.1	CEF89573.1 putative peptidoglycan hydrolase, endolysin [Pseudomonas phage vB_PaeM_PAO1_Ab17]	CEF89573.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WJJ54937.1	WJJ54937.1 N-acetylmuramidase family protein [Xanthomonas phage RTH11]	WJJ54937.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WKW88900.1	WKW88900.1 endolysin [Pseudomonas phage LSL4]	WKW88900.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QFP93502.1	QFP93502.1 peptidoglycan-binding domain-containing protein [Edwardsiella phage vB_EtaM_ET-ABTNL-9]	QFP93502.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QFR59726.1	QFR59726.1 endolysin [Acinetobacter phage VB_ApiP_XC38]	QFR59726.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGY48013.1	AGY48013.1 endolysin [Acinetobacter phage Petty]	AGY48013.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QGF21054.1	QGF21054.1 N-acetylmuramidase family protein [Pectobacterium phage MA11]	QGF21054.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QHI00834.1	QHI00834.1 endolysin muramidase [Pectobacterium phage MA12]	QHI00834.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WOK01470.1	WOK01470.1 endolysin [Pseudomonas phage UF_RH7]	WOK01470.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QVD49203.1	QVD49203.1 peptidoglycan hydrolase [Xanthomonas phage vB_XciM_LucasX]	QVD49203.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGH57465.1	AGH57465.1 peptidoglycan-binding domain-containing protein [Psychrobacter phage pOW20-A]	AGH57465.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BDD79372.1	BDD79372.1 hypothetical protein [Burkholderia phage FLC8]	BDD79372.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BCM95126.1	BCM95126.1 hypothetical protein [Burkholderia phage FLC6]	BCM95126.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAS04883.1	BAS04883.1 hypothetical protein [Ralstonia phage RSF1]	BAS04883.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WAW11624.1	WAW11624.1 endolysin [Acinetobacter phage nACB1]	WAW11624.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR58146.1	AMR58146.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL3b]	AMR58146.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR57327.1	AMR57327.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL1]	AMR57327.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR57486.1	AMR57486.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL2]	AMR57486.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR57977.1	AMR57977.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL5]	AMR57977.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR57808.1	AMR57808.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL4]	AMR57808.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMR57648.1	AMR57648.1 putative endolysin [Pseudomonas phage vB_PsyM_KIL3]	AMR57648.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO39020.1	QQO39020.1 N-acetylmuramoyl-L-alanine amidase [Salmonella phage SPHG3]	QQO39020.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UAV84556.1	UAV84556.1 peptidoglycan hydrolase [Pseudomonas phage PHB09]	UAV84556.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNO11467.1	QNO11467.1 endolysin [Acinetobacter phage Aristophanes]	QNO11467.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WKV20460.1	WKV20460.1 peptidoglycan hydrolase [Pseudomonas phage 16Q]	WKV20460.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAQ02612.1	BAQ02612.1 hypothetical protein [Ralstonia phage RSL2]	BAQ02612.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WBF05313.1	WBF05313.1 N-acetylmuramidase [Psychrobacter phage vB_PmaS_Y8A]	WBF05313.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAW19239.1	BAW19239.1 hypothetical protein [Ralstonia phage RP12]	BAW19239.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAW19525.1	BAW19525.1 hypothetical protein [Ralstonia phage RP31]	BAW19525.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVJ51852.1	AVJ51852.1 endolysin [Pantoea phage vB_PagS_Vid5]	AVJ51852.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVW77525.1	WVW77525.1 putative endolysin [Stenotrophomonas phage vB_SmaS_Bhz60]	WVW77525.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QZI85621.1	QZI85621.1 endolysin N-acetylmuramidase [Stenotrophomonas phage Suzuki]	QZI85621.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AHB12063.1	AHB12063.1 endolysin [Xylella phage Sano]	AHB12063.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WNO28852.1	WNO28852.1 endolysin [Clavibacter phage 33]	WNO28852.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ABR10561.1	ABR10561.1 endolysin [Burkholderia phage BcepNY3]	ABR10561.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AAR89318.2	AAR89318.2 gp27 [Burkholderia phage Bcep43]	AAR89318.2	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AAN38028.1	AAN38028.1 gp27 [Burkholderia phage Bcep781]	AAN38028.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QJI52992.1	QJI52992.1 endolysin [Xanthomonas phage FoX4]	QJI52992.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BDD79871.1	BDD79871.1 hypothetical protein [Burkholderia phage FLC9]	BDD79871.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AAQ73374.1	AAQ73374.1 gp28 [Burkholderia phage Bcep1]	AAQ73374.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQV91374.1	QQV91374.1 N-acetylmuramidase [Polaribacter phage Leef_1]	QQV91374.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQV90501.1	QQV90501.1 N-acetylmuramidase [Polaribacter phage Danklef_1]	QQV90501.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQV90731.1	QQV90731.1 N-acetylmuramidase [Polaribacter phage Danklef_4]	QQV90731.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQV90578.1	QQV90578.1 N-acetylmuramidase [Polaribacter phage Danklef_2]	QQV90578.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33523.1	QMV33523.1 hypothetical protein 30B_00016 [Ralstonia phage Jenny]	QMV33523.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32620.1	QMV32620.1 hypothetical protein 2B_00047 [Ralstonia phage Bakoly]	QMV32620.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33713.1	QMV33713.1 hypothetical protein R1_00011 [Ralstonia phage Simangalove]	QMV33713.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV33668.1	QMV33668.1 hypothetical protein S3_00024 [Ralstonia phage Sarlave]	QMV33668.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32956.1	QMV32956.1 hypothetical protein T2_00011 [Ralstonia phage Elie]	QMV32956.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QMV32328.1	QMV32328.1 hypothetical protein S1_00011 [Ralstonia phage Adzire]	QMV32328.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WWT39680.1	WWT39680.1 peptidoglycan binding protein [Microcystis phage Mae-JY04]	WWT39680.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QNR51710.1	QNR51710.1 peptidoglycan binding protein [Xanthomonas phage Xoo-sp14]	QNR51710.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AZV00224.1	AZV00224.1 peptidoglycan-binding protein [Paracoccus phage vB_PbeS_Pben1]	AZV00224.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AZV00489.1	AZV00489.1 peptidoglycan-binding protein [Paracoccus phage vB_PyeM_Pyei1]	AZV00489.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QDB71378.1	QDB71378.1 DUF3380 domain-containing protein [Microcystis phage Mic1]	QDB71378.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV73585.1	QXV73585.1 putative endolysin protein [Rhizobium phage RHph_X2_30]	QXV73585.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAP94485.1	BAP94485.1 lysozyme [Aurantimonas phage AmM-1]	BAP94485.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BAP94485.1	BAP94485.1 lysozyme [Aurantimonas phage AmM-1]	BAP94485.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WGH24480.1	WGH24480.1 endolysin [Acinetobacter phage EAb13]	WGH24480.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	URG13815.1	URG13815.1 hypothetical protein [Acinetobacter phage vB_AbaS_TCUP2199]	URG13815.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXN72654.1	QXN72654.1 lytic transglycosylase [Rhodobacter phage RcZahn]	QXN72654.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG76605.1	QIG76605.1 putative endolysin protein [Rhizobium phage RHph_I1_6]	QIG76605.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARB05723.1	ARB05723.1 peptidoglycan-binding domain 1 protein [Synechococcus virus S-ESS1]	ARB05723.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87402.1	QIW87402.1 putative structural protein [Agrobacterium phage OLIVR2]	QIW87402.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87402.1	QIW87402.1 putative structural protein [Agrobacterium phage OLIVR2]	QIW87402.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87509.1	QIW87509.1 putative structural protein [Agrobacterium phage OLIVR3]	QIW87509.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87509.1	QIW87509.1 putative structural protein [Agrobacterium phage OLIVR3]	QIW87509.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87295.1	QIW87295.1 putative structural protein [Agrobacterium phage OLIVR1]	QIW87295.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIW87295.1	QIW87295.1 putative structural protein [Agrobacterium phage OLIVR1]	QIW87295.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG68822.1	QIG68822.1 putative endolysin protein [Rhizobium phage RHph_Y2_6]	QIG68822.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG68822.1	QIG68822.1 putative endolysin protein [Rhizobium phage RHph_Y2_6]	QIG68822.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74389.1	QXV74389.1 putative endolysin protein [Rhizobium phage RHEph16]	QXV74389.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74389.1	QXV74389.1 putative endolysin protein [Rhizobium phage RHEph16]	QXV74389.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARQ95324.1	ARQ95324.1 peptidoglycan hydrolase [Bradyrhizobium phage BDU-MI-1]	ARQ95324.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG70546.1	QIG70546.1 putative endolysin protein [Rhizobium phage RHph_N38]	QIG70546.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG67788.1	QIG67788.1 putative endolysin protein [Rhizobium phage RHph_Y38]	QIG67788.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QIG67788.1	QIG67788.1 putative endolysin protein [Rhizobium phage RHph_Y38]	QIG67788.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74758.1	QXV74758.1 putative endolysin protein [Rhizobium phage RHEph22]	QXV74758.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74758.1	QXV74758.1 putative endolysin protein [Rhizobium phage RHEph22]	QXV74758.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74853.1	QXV74853.1 putative endolysin protein [Rhizobium phage RHEph24]	QXV74853.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXV74853.1	QXV74853.1 putative endolysin protein [Rhizobium phage RHEph24]	QXV74853.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AKU43570.1	AKU43570.1 endolysin [Caulobacter phage Seuss]	AKU43570.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AND75168.1	AND75168.1 peptidoglycan binding protein [Acinetobacter phage vB_AbaM_ME3]	AND75168.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WKV17027.1	WKV17027.1 endolysin [Nostoc phage NMeng1]	WKV17027.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	UXO93732.1	UXO93732.1 N-acetylmuramidase [Pseudanabaena phage Pan1]	UXO93732.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUZ94729.1	AUZ94729.1 peptidoglycan hydrolase [Agrobacterium phage Atu_ph02]	AUZ94729.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUZ94766.1	AUZ94766.1 peptidoglycan hydrolase [Agrobacterium phage Atu_ph03]	AUZ94766.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WVH05388.1	WVH05388.1 endolysin [Agrobacterium phage Alfirin]	WVH05388.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGH31480.1	AGH31480.1 hypothetical protein LOKG_00044 [Loktanella phage pCB2051-A]	AGH31480.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD20282.1	APD20282.1 endolysin [Acinetobacter phage AM24]	APD20282.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QVG64320.1	QVG64320.1 endolysin [Acinetobacter phage Bestia]	QVG64320.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	ARB12364.1	ARB12364.1 peptidoglycan hydrolase [Salmonella phage ST-W77]	ARB12364.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO39121.1	QQO39121.1 peptidoglycan hydrolase [Salmonella phage SPHG3]	QQO39121.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX97233.1	QAX97233.1 endolysin [Vibrio phage vB_VmeM-Yong MS32]	QAX97233.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX96292.1	QAX96292.1 endolysin [Vibrio phage vB_VmeM-Yong XC31]	QAX96292.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX96928.1	QAX96928.1 endolysin [Vibrio phage vB_VmeM-Yong MS31]	QAX96928.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QAX96610.1	QAX96610.1 endolysin [Vibrio phage vB_VmeM-Yong XC32]	QAX96610.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QVG63981.1	QVG63981.1 endolysin [Acinetobacter phage Mithridates]	QVG63981.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AAU85106.1	AAU85106.1 lysin [Bacillus phage BCASJ1c]	AAU85106.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AIW02802.1	AIW02802.1 lysozyme [Acinetobacter phage YMC13/03/R2096]	AIW02802.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WNT46126.1	WNT46126.1 lysozyme R [Acinetobacter phage P577]	WNT46126.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QVG64159.1	QVG64159.1 endolysin [Acinetobacter phage Herod]	QVG64159.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXU65800.1	QXU65800.1 PA90 endolysin [Pseudomonas phage PA90]	QXU65800.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BEG72413.1	BEG72413.1 hypothetical protein RVBP21_0410 [Pseudomonas phage BRkr]	BEG72413.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QEM41897.1	QEM41897.1 hypothetical protein [Pseudomonas phage vB_PaeM_PS119XW]	QEM41897.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBX32324.1	QBX32324.1 putative endolysin [Pseudomonas phage PA1C]	QBX32324.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AFK87692.1	AFK87692.1 glycoside hydrolase family 25 [Thermoanaerobacterium phage THSA-485A]	AFK87692.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUS03101.1	AUS03101.1 NLPC/P60 domain endopeptidase [Vibrio phage 3.058.O._10N.286.46.B8]	AUS03101.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AUS01949.1	AUS01949.1 NLPC/P60 domain endopeptidase [Vibrio phage 2.058.O._10N.286.46.B8]	AUS01949.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BBC28650.1	BBC28650.1 putative lysin A [Mycobacterium phage PR]	BBC28650.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BBC28560.1	BBC28560.1 putative lysin A [Mycobacterium phage D12]	BBC28560.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVO21346.1	AVO21346.1 lysin A [Mycobacterium phage Megabear]	AVO21346.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WRQ08218.1	WRQ08218.1 lysin A [Mycobacterium phage harman]	WRQ08218.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	APD19266.1	APD19266.1 lysin A [Mycobacterium phage Taptic]	APD19266.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBP31154.1	QBP31154.1 lysin A [Mycobacterium phage Argie]	QBP31154.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBP32610.1	QBP32610.1 lysin A [Mycobacterium phage GodPhather]	QBP32610.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AVO21739.1	AVO21739.1 lysin A [Mycobacterium phage Jeon]	AVO21739.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QBP32700.1	QBP32700.1 lysin A [Mycobacterium phage Cepens]	QBP32700.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AST99986.1	AST99986.1 N-acetylmuramoyl-L-alanine amidase [Bacillus phage PBS1]	AST99986.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QXN70195.1	QXN70195.1 putative N-acetylmuramoyl-L-alanine amidase [Bacillus phage vB_BspM_Internexus]	QXN70195.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	BDE75499.1	BDE75499.1 hypothetical protein [Bacillus phage PBS1]	BDE75499.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WCS68400.1	WCS68400.1 hypothetical protein Goe21_02910 [Bacillus phage vB_BsuM-Goe21]	WCS68400.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AMS01356.1	AMS01356.1 N-acetylmuramoyl-L-alanine amidase [Bacillus phage AR9]	AMS01356.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AGH31953.1	AGH31953.1 hypothetical protein VPIG_00095 [Vibrio phage PWH3a-P1]	AGH31953.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEI70929.1	AEI70929.1 peptidoglycan-binding domain protein [EBPR podovirus 2]	AEI70929.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	WDS52046.1	WDS52046.1 endolysin [Microbacterium phage Caron]	WDS52046.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO41433.1	QQO41433.1 lysin, L-alanyl-D-glutamate peptidase [Bacillus phage 015DV004]	QQO41433.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO40904.1	QQO40904.1 lysin, L-alanyl-D-glutamate peptidase [Bacillus phage 000TH009]	QQO40904.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	QQO41156.1	QQO41156.1 lysin, L-alanyl-D-glutamate peptidase [Bacillus phage 015DV002]	QQO41156.1	0
+f9143dad-2647-47fd-881b-7cf74466a9e0	AEH03586.1	AEH03586.1 hypothetical protein [Pseudomonas phage PhiPA3]	AEH03586.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNY41730.1	UNY41730.1 i-spanin [Burkholderia phage Milagro]	UNY41730.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNY41670.1	UNY41670.1 i-spanin [Burkholderia phage Musica]	UNY41670.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ADP02325.1	ADP02325.1 gp32 [Burkholderia phage KL3]	ADP02325.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNY41842.1	UNY41842.1 i-spanin [Burkholderia phage Momento]	UNY41842.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNY41787.1	UNY41787.1 i-spanin [Burkholderia phage Menos]	UNY41787.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ABO60731.1	ABO60731.1 gp42, protein LysB [Burkholderia phage phiE202]	ABO60731.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UKM53774.1	UKM53774.1 spanin [Burkholderia phage PhiBP82.2]	UKM53774.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAZ72635.1	AAZ72635.1 putative bacteriophage protein [Burkholderia phage phiE52237]	AAZ72635.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ABO60762.1	ABO60762.1 gp44, putative bacteriophage protein [Burkholderia phage phiE12-2]	ABO60762.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AFV51406.1	AFV51406.1 putative phage protein [Burkholderia phage phiX216]	AFV51406.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UPI15567.1	UPI15567.1 spanin [Burkholderia phage PhiBP82.3]	UPI15567.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WWY66154.1	WWY66154.1 Rz-like spanin [Burkholderia phage vB_HM387]	WWY66154.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QWY84957.1	QWY84957.1 spanin Rz [Burkholderia phage PK23]	QWY84957.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QPI18551.1	QPI18551.1 LysB protein [Burkholderia phage phiE094]	QPI18551.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ADP02371.1	ADP02371.1 gp26 [Burkholderia phage KS14]	ADP02371.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	BCB23204.1	BCB23204.1 Rz (LysB) [Burkholderia phage FLC5]	BCB23204.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	BDD79926.1	BDD79926.1 hypothetical protein [Burkholderia phage FLC10]	BDD79926.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AGK86786.1	AGK86786.1 protein LysB [Burkholderia phage ST79]	AGK86786.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNA05747.1	UNA05747.1 lysis regulatory protein [Yersinia phage vB_YenM_42.18]	UNA05747.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNA05918.1	UNA05918.1 lysis regulatory protein [Yersinia phage vB_YenM_56.17]	UNA05918.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UKL54253.1	UKL54253.1 lysis regulatory protein [Yersinia phage vB_YenM_31.17]	UKL54253.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ALF02249.1	ALF02249.1 lysis regulatory protein LysB [Salmonella phage SEN1]	ALF02249.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QEI25350.1	QEI25350.1 LysB family lysis regulatory protein [Salmonella phage SI22]	QEI25350.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QEI25395.1	QEI25395.1 LysB family lysis regulatory protein [Salmonella phage SW9]	QEI25395.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ADX32438.1	ADX32438.1 control of lysis protein [Erwinia phage ENT90]	ADX32438.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNA05871.1	UNA05871.1 lysis regulatory protein [Yersinia phage vB_YenM_06.16-2]	UNA05871.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAC34156.1	AAC34156.1 Orf27 [Escherichia phage 186]	AAC34156.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AGF88423.1	AGF88423.1 LysB [Salmonella phage FSLSP004]	AGF88423.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAN08373.1	AAN08373.1 gp11 [Salmonella phage PSP3]	AAN08373.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QDJ98461.1	QDJ98461.1 hypothetical protein LLFFHNDI_00034 [Escherichia phage vB_EcoM-12474II]	QDJ98461.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ULG00990.1	ULG00990.1 lysis regulatory protein [Escherichia phage 9W]	ULG00990.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD37929.1	VUD37929.1 Phage spanin Rz #LysB [Peduovirus P22H4]	VUD37929.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QDJ98593.1	QDJ98593.1 hypothetical protein OMJLAAIH_00034 [Escherichia phage vB_EcoM-12474V]	QDJ98593.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QDJ98549.1	QDJ98549.1 hypothetical protein PBINGOGM_00034 [Escherichia phage vB_EcoM-12474IV]	QDJ98549.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QDJ98508.1	QDJ98508.1 hypothetical protein BBAMJIOM_00037 [Escherichia phage vB_EcoM-12474III]	QDJ98508.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UTC25942.1	UTC25942.1 Rz-like lysis system protein [Salmonella phage vB_Sal_PHB48]	UTC25942.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UPI11459.1	UPI11459.1 hypothetical protein COILCCMC_00011 [Yersinia phage VB-YPM-4]	UPI11459.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QKE55591.1	QKE55591.1 hypothetical protein vBYpM46_00011 [Yersinia phage vB_YpM_46]	QKE55591.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QKE55635.1	QKE55635.1 hypothetical protein vBYpM50_00014 [Yersinia phage vB_YpM_50]	QKE55635.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNA05973.1	UNA05973.1 lysis regulatory protein [Yersinia phage vB_YenM_201.16]	UNA05973.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QYC52669.1	QYC52669.1 lysis regulatory protein [Salmonella phage BIS20]	QYC52669.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UGC97275.1	UGC97275.1 Rz-like lysis system protein [Aeromonas phage vB_AsaM_LPM4]	UGC97275.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ULG00688.1	ULG00688.1 lysis regulatory protein [Escherichia phage D8]	ULG00688.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD38874.1	VUD38874.1 Phage spanin Rz #LysB [Peduovirus P24E6b]	VUD38874.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ULG01148.1	ULG01148.1 lysis regulatory protein [Escherichia phage 12W]	ULG01148.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WPJ21694.1	WPJ21694.1 Rz-like spanin [Bacillus phage vB_BpuM-ZY1]	WPJ21694.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ASD51176.1	ASD51176.1 i-spanin [Erwinia phage EtG]	ASD51176.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URE76614.1	URE76614.1 lysis regulatory protein [Escherichia phage vB_EcoM-613R3]	URE76614.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WYC18449.1	WYC18449.1 lysis regulatory protein [Yersinia phage vB_YpM_MHG38]	WYC18449.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WYC18381.1	WYC18381.1 spanin Rz [Yersinia phage vB_YpM_MDG94-186]	WYC18381.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WYC18407.1	WYC18407.1 lysis regulatory protein [Yersinia phage vB_YpM_MDG45]	WYC18407.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WPJ53106.1	WPJ53106.1 hypothetical protein RCIP0057_00033 [Klebsiella phage RCIP0057]	WPJ53106.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBQ71554.1	QBQ71554.1 LysB family lysis regulatory protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71554.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WXX18232.1	WXX18232.1 spanin Rz [Yersinia phage GCS667]	WXX18232.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	CAG9593815.1	CAG9593815.1 hypothetical protein P2DC1_00011 [Peduovirus P2]	CAG9593815.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QDP43505.1	QDP43505.1 spanin [Bacteriophage R18C]	QDP43505.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAD03278.1	AAD03278.1 LysB [Bacteriophage P2]	AAD03278.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD39027.1	VUD39027.1 Phage spanin Rz #LysB [Peduovirus P24A7b]	VUD39027.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WOZ55999.1	WOZ55999.1 hypothetical protein B115_00011 [Yersinia phage vB_YpM_115]	WOZ55999.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WOZ56045.1	WOZ56045.1 hypothetical protein B117_00011 [Yersinia phage vB_YpM_117]	WOZ56045.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	CAH0786517.1	CAH0786517.1 hypothetical protein P2AC1_00032 [Escherichia phage P2_AC1]	CAH0786517.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AGX84603.1	AGX84603.1 lysin [Enterobacteria phage fiAA91-ss]	AGX84603.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD38016.1	VUD38016.1 Phage spanin Rz #LysB [Peduovirus P24B2]	VUD38016.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URP83672.1	URP83672.1 protein lysB [Escherichia phage S164]	URP83672.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ULG01127.1	ULG01127.1 lysis regulatory protein [Escherichia phage 10W]	ULG01127.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ULG00874.1	ULG00874.1 lysis regulatory protein [Escherichia phage 11W]	ULG00874.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD39505.1	VUD39505.1 Phage spanin Rz #LysB [Peduovirus P24C9]	VUD39505.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	API82946.1	API82946.1 putative phage lysin [Salmonella phage STYP1]	API82946.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URC09623.1	URC09623.1 lysis regulatory protein [Escherichia phage vB_EcoM-569R9]	URC09623.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AKH49335.1	AKH49335.1 spanin Rz [Escherichia phage pro147]	AKH49335.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URC10100.1	URC10100.1 lysis regulatory protein [Escherichia phage vB_EcoM-640R3]	URC10100.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	CAG9593876.1	CAG9593876.1 hypothetical protein P2SIDE7_00030 [Peduovirus P2]	CAG9593876.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAN28229.1	AAN28229.1 LysB [Escherichia phage Wphi]	AAN28229.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AGG36527.1	AGG36527.1 phage spanin Rz [Escherichia phage P2]	AGG36527.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QYW06316.1	QYW06316.1 Cys-tRNA(Pro) deacylase [Shewanella phage vB_SspM_M16-3]	QYW06316.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	CAG9593794.1	CAG9593794.1 hypothetical protein P2SIAC10_00033 [Peduovirus P2]	CAG9593794.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URC09843.1	URC09843.1 lysis regulatory protein [Escherichia phage vB_EcoM-720R8]	URC09843.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QIW90054.1	QIW90054.1 lysis regulatory protein [Yersinia phage P37]	QIW90054.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QXF95277.1	QXF95277.1 lysis regulatory protein [Yersinia phage HQ103]	QXF95277.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WFG40967.1	WFG40967.1 Rz-like spanin [Salmonella phage MET_P1_103_31]	WFG40967.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	VUD37972.1	VUD37972.1 Phage spanin Rz [Peduovirus P22H1]	VUD37972.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AKH49383.1	AKH49383.1 spanin Rz [Escherichia phage pro483]	AKH49383.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URC10006.1	URC10006.1 lysis regulatory protein [Escherichia phage vB_EcoM-473R3]	URC10006.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ARB15693.1	ARB15693.1 hypothetical protein [Klebsiella phage 4LV2017]	ARB15693.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	AAP04448.1	AAP04448.1 LysB [Yersinia phage L-413C]	AAP04448.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UPI11509.1	UPI11509.1 hypothetical protein BFNKNBEH_00019 [Yersinia phage VB-YPM-18]	UPI11509.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WOZ56091.1	WOZ56091.1 hypothetical protein B476A_00011 [Yersinia phage vB_YpM_476A]	WOZ56091.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QKE55499.1	QKE55499.1 hypothetical protein vBYpM22_00014 [Yersinia phage vB_YpM_22]	QKE55499.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	WOZ56131.1	WOZ56131.1 hypothetical protein B476B_00011 [Yersinia phage vB_YpM_476B]	WOZ56131.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP08036.1	QBP08036.1 LysB family lysis regulatory protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08036.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27764.1	QBP27764.1 LysB family lysis regulatory protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27764.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27918.1	QBP27918.1 LysB family lysis regulatory protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27918.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	URC10469.1	URC10469.1 lysis regulatory protein [Escherichia phage vB_EcoM-813R9]	URC10469.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBQ72004.1	QBQ72004.1 LysB family lysis regulatory protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72004.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	ADQ92399.1	ADQ92399.1 lysozyme subunit B [Salmonella phage RE2010]	ADQ92399.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	UNI73724.1	UNI73724.1 putative i-spanin [Klebsiella phage KP12]	UNI73724.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27425.1	QBP27425.1 LysB family lysis regulatory protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27425.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP07816.1	QBP07816.1 LysB family lysis regulatory protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07816.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27874.1	QBP27874.1 LysB family lysis regulatory protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27874.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP08092.1	QBP08092.1 LysB family lysis regulatory protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08092.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27665.1	QBP27665.1 LysB family lysis regulatory protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27665.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBP27971.1	QBP27971.1 LysB family lysis regulatory protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27971.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	QBQ71723.1	QBQ71723.1 LysB family lysis regulatory protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71723.1	0
+5e652863-49a2-45ed-9d9f-96d063d03a11	CAH1234689.1	CAH1234689.1 LysB [Escherichia phage Cartapus]	CAH1234689.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNY41732.1	UNY41732.1 tail completion protein [Burkholderia phage Milagro]	UNY41732.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNY41672.1	UNY41672.1 tail completion protein [Burkholderia phage Musica]	UNY41672.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ADP02323.1	ADP02323.1 gp30 [Burkholderia phage KL3]	ADP02323.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNY41789.1	UNY41789.1 tail completion protein [Burkholderia phage Menos]	UNY41789.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNY41844.1	UNY41844.1 tail completion protein [Burkholderia phage Momento]	UNY41844.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UKM53776.1	UKM53776.1 hypothetical protein PhiBP822_18 [Burkholderia phage PhiBP82.2]	UKM53776.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WWY66155.1	WWY66155.1 tail protein [Burkholderia phage vB_HM387]	WWY66155.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UPI15569.1	UPI15569.1 putative tail protein [Burkholderia phage PhiBP82.3]	UPI15569.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ABO60715.1	ABO60715.1 gp40, P2 phage tail completion protein R (GpR) [Burkholderia phage phiE202]	ABO60715.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QWY84959.1	QWY84959.1 unclassified tail protein [Burkholderia phage PK23]	QWY84959.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QPI18553.1	QPI18553.1 P2 tail completion R-like protein [Burkholderia phage phiE094]	QPI18553.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AIP84277.1	AIP84277.1 P2 phage tail completion R family protein [Burkholderia phage BEK]	AIP84277.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ADP02369.1	ADP02369.1 gp24 [Burkholderia phage KS14]	ADP02369.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	BCB23202.1	BCB23202.1 tail completion protein (R) [Burkholderia phage FLC5]	BCB23202.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	BDD79928.1	BDD79928.1 hypothetical protein [Burkholderia phage FLC10]	BDD79928.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	BAP28118.1	BAP28118.1 hypothetical protein [Ralstonia phage RSY1]	BAP28118.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	BAF52393.1	BAF52393.1 tail completion protein-like protein [Ralstonia phage RSA1]	BAF52393.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AVP40010.1	AVP40010.1 tail protein [Ralstonia phage RsoM1USA]	AVP40010.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UGC97274.1	UGC97274.1 tail protein [Aeromonas phage vB_AsaM_LPM4]	UGC97274.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNA05748.1	UNA05748.1 tail completion protein [Yersinia phage vB_YenM_42.18]	UNA05748.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	USM11621.1	USM11621.1 tail completion protein [Burkholderia phage Carl1]	USM11621.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ADP02277.1	ADP02277.1 gp30 [Burkholderia phage KS5]	ADP02277.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AZF87854.1	AZF87854.1 tail protein [Pseudomonas phage Dobby]	AZF87854.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	BAA36240.1	BAA36240.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36240.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WWQ72096.1	WWQ72096.1 tail completion protein [Pseudomonas phage Sirocco]	WWQ72096.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBI84121.1	QBI84121.1 tail completion protein [Pseudomonas phage vB_Pae_BR319a]	QBI84121.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QPB09408.1	QPB09408.1 tail completion protein [Burkholderia phage Mana]	QPB09408.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AGK86788.1	AGK86788.1 phage tail completion protein [Burkholderia phage ST79]	AGK86788.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AKA61139.1	AKA61139.1 putative tail completion protein [Burkholderia phage AP3]	AKA61139.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URC10467.1	URC10467.1 tail completion protein [Escherichia phage vB_EcoM-813R9]	URC10467.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNI73723.1	UNI73723.1 tail protein [Klebsiella phage KP12]	UNI73723.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ADQ92400.1	ADQ92400.1 tail protein [Salmonella phage RE2010]	ADQ92400.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ALF02300.1	ALF02300.1 tail protein [Salmonella phage SEN4]	ALF02300.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ALF02349.1	ALF02349.1 tail protein [Salmonella phage SEN5]	ALF02349.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ADX32435.1	ADX32435.1 phage tail completion protein [Erwinia phage ENT90]	ADX32435.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27613.1	QBP27613.1 tail protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27613.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	CAH1234691.1	CAH1234691.1 tail completion protein Tc1 [Escherichia phage Cartapus]	CAH1234691.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27427.1	QBP27427.1 tail protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27427.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBQ72005.1	QBQ72005.1 tail protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72005.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP07814.1	QBP07814.1 tail protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07814.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27872.1	QBP27872.1 tail protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27872.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP08094.1	QBP08094.1 tail protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08094.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27667.1	QBP27667.1 tail protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27667.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27969.1	QBP27969.1 tail protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27969.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBQ71721.1	QBQ71721.1 tail protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71721.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AQT27291.1	AQT27291.1 tail protein [Salmonella phage SEN8]	AQT27291.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ARB15694.1	ARB15694.1 tail completion protein [Klebsiella phage 4LV2017]	ARB15694.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP08035.1	QBP08035.1 tail protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08035.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27763.1	QBP27763.1 tail protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27763.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP27916.1	QBP27916.1 tail protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27916.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	CAG9593792.1	CAG9593792.1 hypothetical protein P2SIAC10_00031 [Peduovirus P2]	CAG9593792.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	CAH0786515.1	CAH0786515.1 hypothetical protein P2AC1_00030 [Escherichia phage P2_AC1]	CAH0786515.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QYW06314.1	QYW06314.1 tail completion protein [Shewanella phage vB_SspM_M16-3]	QYW06314.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WOZ56001.1	WOZ56001.1 hypothetical protein B115_00013 [Yersinia phage vB_YpM_115]	WOZ56001.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ULG01125.1	ULG01125.1 tail completion protein [Escherichia phage 10W]	ULG01125.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WOZ56047.1	WOZ56047.1 hypothetical protein B117_00013 [Yersinia phage vB_YpM_117]	WOZ56047.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ULG00876.1	ULG00876.1 tail completion protein [Escherichia phage 11W]	ULG00876.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD39511.1	VUD39511.1 Phage Tc1 tail completion protein [Peduovirus P24C9]	VUD39511.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QDJ98459.1	QDJ98459.1 hypothetical protein LLFFHNDI_00032 [Escherichia phage vB_EcoM-12474II]	QDJ98459.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QDJ98591.1	QDJ98591.1 hypothetical protein OMJLAAIH_00032 [Escherichia phage vB_EcoM-12474V]	QDJ98591.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QDJ98547.1	QDJ98547.1 hypothetical protein PBINGOGM_00032 [Escherichia phage vB_EcoM-12474IV]	QDJ98547.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QDJ98506.1	QDJ98506.1 hypothetical protein BBAMJIOM_00035 [Escherichia phage vB_EcoM-12474III]	QDJ98506.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AAD03279.1	AAD03279.1 gpR [Bacteriophage P2]	AAD03279.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URC10004.1	URC10004.1 tail completion protein [Escherichia phage vB_EcoM-473R3]	URC10004.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UPI11511.1	UPI11511.1 hypothetical protein BFNKNBEH_00021 [Yersinia phage VB-YPM-18]	UPI11511.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WOZ56093.1	WOZ56093.1 hypothetical protein B476A_00013 [Yersinia phage vB_YpM_476A]	WOZ56093.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QKE55501.1	QKE55501.1 hypothetical protein vBYpM22_00016 [Yersinia phage vB_YpM_22]	QKE55501.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QXF95279.1	QXF95279.1 tail completion protein [Yersinia phage HQ103]	QXF95279.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WOZ56133.1	WOZ56133.1 hypothetical protein B476B_00013 [Yersinia phage vB_YpM_476B]	WOZ56133.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ULG00690.1	ULG00690.1 tail completion protein [Escherichia phage D8]	ULG00690.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD39029.1	VUD39029.1 Phage Tc1 tail completion protein [Peduovirus P24A7b]	VUD39029.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD38879.1	VUD38879.1 Phage Tc1 tail completion protein [Peduovirus P24E6b]	VUD38879.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ULG01150.1	ULG01150.1 tail completion protein [Escherichia phage 12W]	ULG01150.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD38018.1	VUD38018.1 Phage Tc1 tail completion protein [Peduovirus P24B2]	VUD38018.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QIW90053.1	QIW90053.1 tail completion R family protein [Yersinia phage P37]	QIW90053.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QDP43507.1	QDP43507.1 putative phage tail protein [Bacteriophage R18C]	QDP43507.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AKH49333.1	AKH49333.1 tail protein [Escherichia phage pro147]	AKH49333.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URP83673.1	URP83673.1 tail protein [Escherichia phage S164]	URP83673.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	CAG9593874.1	CAG9593874.1 hypothetical protein P2SIDE7_00028 [Peduovirus P2]	CAG9593874.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBQ71556.1	QBQ71556.1 tail protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71556.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AAP04449.1	AAP04449.1 gpR [Yersinia phage L-413C]	AAP04449.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AKH49385.1	AKH49385.1 tail protein [Escherichia phage pro483]	AKH49385.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	CAG9593817.1	CAG9593817.1 hypothetical protein P2DC1_00013 [Peduovirus P2]	CAG9593817.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD37974.1	VUD37974.1 Phage Tc1 tail completion protein [Peduovirus P22H1]	VUD37974.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UPI11461.1	UPI11461.1 hypothetical protein COILCCMC_00013 [Yersinia phage VB-YPM-4]	UPI11461.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ULG00992.1	ULG00992.1 tail completion protein [Escherichia phage 9W]	ULG00992.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD37931.1	VUD37931.1 Phage Tc1 tail completion protein [Peduovirus P22H4]	VUD37931.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QKE55593.1	QKE55593.1 hypothetical protein vBYpM46_00013 [Yersinia phage vB_YpM_46]	QKE55593.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URC09841.1	URC09841.1 tail completion protein [Escherichia phage vB_EcoM-720R8]	URC09841.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QKE55637.1	QKE55637.1 hypothetical protein vBYpM50_00016 [Yersinia phage vB_YpM_50]	QKE55637.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	API82948.1	API82948.1 P2 phage tail completion protein R (GpR) [Salmonella phage STYP1]	API82948.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URC09625.1	URC09625.1 tail completion protein [Escherichia phage vB_EcoM-569R9]	URC09625.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WFG40965.1	WFG40965.1 tail terminator [Salmonella phage MET_P1_103_31]	WFG40965.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AAN28231.1	AAN28231.1 gpR [Escherichia phage Wphi]	AAN28231.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AGX84576.1	AGX84576.1 tail completion protein [Enterobacteria phage fiAA91-ss]	AGX84576.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URC10102.1	URC10102.1 tail completion protein [Escherichia phage vB_EcoM-640R3]	URC10102.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AGG36529.1	AGG36529.1 phage tail protein [Escherichia phage P2]	AGG36529.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	URE76612.1	URE76612.1 tail completion protein [Escherichia phage vB_EcoM-613R3]	URE76612.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ASD51174.1	ASD51174.1 tail protein [Erwinia phage EtG]	ASD51174.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WPJ53104.1	WPJ53104.1 hypothetical protein RCIP0057_00031 [Klebsiella phage RCIP0057]	WPJ53104.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AAC34158.1	AAC34158.1 N protein [Escherichia phage 186]	AAC34158.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AGF88425.1	AGF88425.1 phage tail protein [Salmonella phage FSLSP004]	AGF88425.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AAN08375.1	AAN08375.1 gp13 [Salmonella phage PSP3]	AAN08375.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ALF02251.1	ALF02251.1 tail protein [Salmonella phage SEN1]	ALF02251.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QEI25352.1	QEI25352.1 tail protein [Salmonella phage SI22]	QEI25352.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QEI25397.1	QEI25397.1 tail protein [Salmonella phage SW9]	QEI25397.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WYC18451.1	WYC18451.1 tail completion protein [Yersinia phage vB_YpM_MHG38]	WYC18451.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WXX18230.1	WXX18230.1 tail protein [Yersinia phage GCS667]	WXX18230.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WYC18409.1	WYC18409.1 tail completion protein [Yersinia phage vB_YpM_MDG45]	WYC18409.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UTC25940.1	UTC25940.1 tail protein [Salmonella phage vB_Sal_PHB48]	UTC25940.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QYC52671.1	QYC52671.1 tail completion protein [Salmonella phage BIS20]	QYC52671.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP07907.1	QBP07907.1 tail protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07907.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ARB15647.1	ARB15647.1 tail protein [Klebsiella phage 3LV2017]	ARB15647.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNA05919.1	UNA05919.1 tail completion protein [Yersinia phage vB_YenM_56.17]	UNA05919.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UYL85413.1	UYL85413.1 tail protein [Acidovorax phage Alfacinha3]	UYL85413.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UKL54254.1	UKL54254.1 tail completion protein [Yersinia phage vB_YenM_31.17]	UKL54254.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AYD79799.1	AYD79799.1 hypothetical protein OGLPLLMI_00033 [Enterobacter phage phiT5282H]	AYD79799.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	QBP07948.1	QBP07948.1 tail protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07948.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UYL85514.1	UYL85514.1 tail protein [Acidovorax phage Alfacinha1]	UYL85514.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AFJ75487.1	AFJ75487.1 tail completion protein [Stenotrophomonas phage Smp131]	AFJ75487.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AIZ95141.1	AIZ95141.1 tail completion protein [Escherichia phage P88]	AIZ95141.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	VUD40174.1	VUD40174.1 Tc1 Phage tail completion protein [Xuanwuvirus P884B11]	VUD40174.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WOZ57133.1	WOZ57133.1 tail protein S [Citrobacter phage Shae_phiSM]	WOZ57133.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNA05974.1	UNA05974.1 tail completion protein [Yersinia phage vB_YenM_201.16]	UNA05974.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ABD90613.1	ABD90613.1 tail completion protein R [Mannheimia phage phiMhaA1-BAA410]	ABD90613.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	ABD90564.1	ABD90564.1 tail completion protein R [Mannheimia phage PHL101]	ABD90564.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AJA73116.1	AJA73116.1 tail completion protein R [Mannheimia phage vB_MhM_2256AP1]	AJA73116.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AJA72885.1	AJA72885.1 tail completion protein R [Mannheimia phage vB_MhM_535AP1]	AJA72885.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AJA73064.1	AJA73064.1 tail completion protein R [Mannheimia phage vB_MhM_1127AP1]	AJA73064.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AFL46460.1	AFL46460.1 tail completion protein [Mannheimia phage vB_MhM_1152AP]	AFL46460.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UNA05872.1	UNA05872.1 tail completion protein [Yersinia phage vB_YenM_06.16-2]	UNA05872.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	UZV40215.1	UZV40215.1 tail protein [Acidovorax phage Acica]	UZV40215.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	AJA72936.1	AJA72936.1 tail completion protein R [Mannheimia phage vB_MhM_587AP1]	AJA72936.1	0
+0f466bf0-74c9-4a40-ac32-ac796cf9443d	WPJ21695.1	WPJ21695.1 tail completion R family protein [Bacillus phage vB_BpuM-ZY1]	WPJ21695.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNY41733.1	UNY41733.1 tail completion protein [Burkholderia phage Milagro]	UNY41733.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNY41673.1	UNY41673.1 tail completion protein [Burkholderia phage Musica]	UNY41673.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ADP02322.1	ADP02322.1 gp29 [Burkholderia phage KL3]	ADP02322.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNY41845.1	UNY41845.1 tail completion protein [Burkholderia phage Momento]	UNY41845.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNY41790.1	UNY41790.1 tail completion protein [Burkholderia phage Menos]	UNY41790.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WWY66156.1	WWY66156.1 tail completion protein [Burkholderia phage vB_HM387]	WWY66156.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UPI15570.1	UPI15570.1 tail completion protein [Burkholderia phage PhiBP82.3]	UPI15570.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AIP84262.1	AIP84262.1 phage virion morphogenesis protein [Burkholderia phage BEK]	AIP84262.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ABO60707.1	ABO60707.1 gp39, phage virion morphogenesis protein [Burkholderia phage phiE202]	ABO60707.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAZ72633.1	AAZ72633.1 phage tail completion protein [Burkholderia phage phiE52237]	AAZ72633.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AFV51408.1	AFV51408.1 phage tail completion protein [Burkholderia phage phiX216]	AFV51408.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QWY84960.1	QWY84960.1 tail completion protein [Burkholderia phage PK23]	QWY84960.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QPI18554.1	QPI18554.1 P2 tail completion S-like protein [Burkholderia phage phiE094]	QPI18554.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UKM53777.1	UKM53777.1 tail completion protein [Burkholderia phage PhiBP82.2]	UKM53777.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	BCB23201.1	BCB23201.1 tail completion protein (S) [Burkholderia phage FLC5]	BCB23201.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ADP02368.1	ADP02368.1 gp23 [Burkholderia phage KS14]	ADP02368.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	BDD79929.1	BDD79929.1 hypothetical protein [Burkholderia phage FLC10]	BDD79929.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AGK86789.1	AGK86789.1 phage virion morphogenesis protein [Burkholderia phage ST79]	AGK86789.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBI84122.1	QBI84122.1 tail completion protein [Pseudomonas phage vB_Pae_BR319a]	QBI84122.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WWQ72097.1	WWQ72097.1 virion morphogenesis protein [Pseudomonas phage Sirocco]	WWQ72097.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AZF87855.1	AZF87855.1 virion morphogenesis protein [Pseudomonas phage Dobby]	AZF87855.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	BAA36241.1	BAA36241.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36241.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	CAH1234693.1	CAH1234693.1 phage virion morphogenesis protein [Escherichia phage Cartapus]	CAH1234693.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AFJ75488.1	AFJ75488.1 tail completion protein [Stenotrophomonas phage Smp131]	AFJ75488.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBQ72006.1	QBQ72006.1 virion morphogenesis protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72006.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AQT27292.1	AQT27292.1 tail completion protein [Salmonella phage SEN8]	AQT27292.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27612.1	QBP27612.1 virion morphogenesis protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27612.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP08034.1	QBP08034.1 virion morphogenesis protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08034.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27762.1	QBP27762.1 virion morphogenesis protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27762.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27915.1	QBP27915.1 virion morphogenesis protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27915.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QPB09409.1	QPB09409.1 tail completion protein [Burkholderia phage Mana]	QPB09409.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	BAF52394.1	BAF52394.1 tail completion protein gpS [Ralstonia phage RSA1]	BAF52394.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AKA61140.1	AKA61140.1 putative virion morphogenesis protein [Burkholderia phage AP3]	AKA61140.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AVP40011.1	AVP40011.1 tail completion protein [Ralstonia phage RsoM1USA]	AVP40011.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URC10466.1	URC10466.1 tail completion protein [Escherichia phage vB_EcoM-813R9]	URC10466.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ADP02276.1	ADP02276.1 gp29 [Burkholderia phage KS5]	ADP02276.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ARB15695.1	ARB15695.1 tail completion protein [Klebsiella phage 4LV2017]	ARB15695.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	USM11622.1	USM11622.1 tail completion protein [Burkholderia phage Carl1]	USM11622.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27428.1	QBP27428.1 virion morphogenesis protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27428.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP07813.1	QBP07813.1 virion morphogenesis protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07813.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27871.1	QBP27871.1 virion morphogenesis protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27871.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP08095.1	QBP08095.1 virion morphogenesis protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08095.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27668.1	QBP27668.1 virion morphogenesis protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27668.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP27968.1	QBP27968.1 virion morphogenesis protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27968.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WPJ21696.1	WPJ21696.1 virion morphogenesis protein [Bacillus phage vB_BpuM-ZY1]	WPJ21696.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNI73722.1	UNI73722.1 tail completion protein [Klebsiella phage KP12]	UNI73722.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	BAP28119.1	BAP28119.1 hypothetical protein [Ralstonia phage RSY1]	BAP28119.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UYL85515.1	UYL85515.1 virion morphogenesis protein [Acidovorax phage Alfacinha1]	UYL85515.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UYL85414.1	UYL85414.1 virion morphogenesis protein [Acidovorax phage Alfacinha3]	UYL85414.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UZV40216.1	UZV40216.1 virion morphogenesis protein [Acidovorax phage Acica]	UZV40216.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ADQ92401.1	ADQ92401.1 tail completion protein [Salmonella phage RE2010]	ADQ92401.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBQ71557.1	QBQ71557.1 virion morphogenesis protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71557.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAC34159.1	AAC34159.1 O protein [Escherichia phage 186]	AAC34159.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WPJ53103.1	WPJ53103.1 hypothetical protein RCIP0057_00030 [Klebsiella phage RCIP0057]	WPJ53103.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WXX18229.1	WXX18229.1 tail completion protein [Yersinia phage GCS667]	WXX18229.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WYC18452.1	WYC18452.1 tail completion protein [Yersinia phage vB_YpM_MHG38]	WYC18452.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WYC18383.1	WYC18383.1 tail completion protein [Yersinia phage vB_YpM_MDG94-186]	WYC18383.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WYC18410.1	WYC18410.1 tail completion protein [Yersinia phage vB_YpM_MDG45]	WYC18410.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UTC25939.1	UTC25939.1 virion morphogenesis protein [Salmonella phage vB_Sal_PHB48]	UTC25939.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ASD51173.1	ASD51173.1 tail completion protein [Erwinia phage EtG]	ASD51173.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QYC52672.1	QYC52672.1 virion morphogenesis protein [Salmonella phage BIS20]	QYC52672.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URE76611.1	URE76611.1 tail completion protein [Escherichia phage vB_EcoM-613R3]	URE76611.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QDP43508.1	QDP43508.1 tail completion protein [Bacteriophage R18C]	QDP43508.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	API82949.1	API82949.1 Phage virion morphogenesis family protein [Salmonella phage STYP1]	API82949.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WOZ56002.1	WOZ56002.1 hypothetical protein B115_00014 [Yersinia phage vB_YpM_115]	WOZ56002.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WOZ56048.1	WOZ56048.1 hypothetical protein B117_00014 [Yersinia phage vB_YpM_117]	WOZ56048.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WFG40964.1	WFG40964.1 tail completion protein [Salmonella phage MET_P1_103_31]	WFG40964.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QXF95280.1	QXF95280.1 tail completion protein [Yersinia phage HQ103]	QXF95280.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UPI11512.1	UPI11512.1 hypothetical protein BFNKNBEH_00022 [Yersinia phage VB-YPM-18]	UPI11512.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WOZ56094.1	WOZ56094.1 hypothetical protein B476A_00014 [Yersinia phage vB_YpM_476A]	WOZ56094.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QKE55502.1	QKE55502.1 hypothetical protein vBYpM22_00017 [Yersinia phage vB_YpM_22]	QKE55502.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WOZ56134.1	WOZ56134.1 hypothetical protein B476B_00014 [Yersinia phage vB_YpM_476B]	WOZ56134.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QDJ98458.1	QDJ98458.1 hypothetical protein LLFFHNDI_00031 [Escherichia phage vB_EcoM-12474II]	QDJ98458.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QDJ98590.1	QDJ98590.1 hypothetical protein OMJLAAIH_00031 [Escherichia phage vB_EcoM-12474V]	QDJ98590.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QDJ98546.1	QDJ98546.1 hypothetical protein PBINGOGM_00031 [Escherichia phage vB_EcoM-12474IV]	QDJ98546.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QDJ98505.1	QDJ98505.1 hypothetical protein BBAMJIOM_00034 [Escherichia phage vB_EcoM-12474III]	QDJ98505.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QIW90052.1	QIW90052.1 virion morphogenesis protein [Yersinia phage P37]	QIW90052.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URC10003.1	URC10003.1 tail completion protein [Escherichia phage vB_EcoM-473R3]	URC10003.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	CAG9593818.1	CAG9593818.1 hypothetical protein P2DC1_00014 [Peduovirus P2]	CAG9593818.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AGG36530.1	AGG36530.1 phage tail completion protein [Escherichia phage P2]	AGG36530.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD38019.1	VUD38019.1 Phage Ne1 neck protein [Peduovirus P24B2]	VUD38019.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AKH49332.1	AKH49332.1 tail completion protein [Escherichia phage pro147]	AKH49332.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAP04450.1	AAP04450.1 gpS [Yersinia phage L-413C]	AAP04450.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AGX84569.1	AGX84569.1 tail completion protein [Enterobacteria phage fiAA91-ss]	AGX84569.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ULG00993.1	ULG00993.1 tail completion protein [Escherichia phage 9W]	ULG00993.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD37932.1	VUD37932.1 Phage Ne1 neck protein [Peduovirus P22H4]	VUD37932.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URC10103.1	URC10103.1 tail completion protein [Escherichia phage vB_EcoM-640R3]	URC10103.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UPI11462.1	UPI11462.1 hypothetical protein COILCCMC_00014 [Yersinia phage VB-YPM-4]	UPI11462.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QKE55594.1	QKE55594.1 hypothetical protein vBYpM46_00014 [Yersinia phage vB_YpM_46]	QKE55594.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD39030.1	VUD39030.1 Phage Ne1 neck protein [Peduovirus P24A7b]	VUD39030.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAD03280.1	AAD03280.1 gpS [Bacteriophage P2]	AAD03280.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	CAG9593791.1	CAG9593791.1 hypothetical protein P2SIAC10_00030 [Peduovirus P2]	CAG9593791.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URP83674.1	URP83674.1 virion morphogenesis protein [Escherichia phage S164]	URP83674.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	CAG9593873.1	CAG9593873.1 hypothetical protein P2SIDE7_00027 [Peduovirus P2]	CAG9593873.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ULG01124.1	ULG01124.1 tail completion protein [Escherichia phage 10W]	ULG01124.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ULG00877.1	ULG00877.1 tail completion protein [Escherichia phage 11W]	ULG00877.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD39514.1	VUD39514.1 Phage Ne1 neck protein [Peduovirus P24C9]	VUD39514.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AKH49386.1	AKH49386.1 tail completion protein [Escherichia phage pro483]	AKH49386.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAN28232.1	AAN28232.1 gpS [Escherichia phage Wphi]	AAN28232.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD37975.1	VUD37975.1 Phage Ne1 neck protein [Peduovirus P22H1]	VUD37975.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QKE55638.1	QKE55638.1 hypothetical protein vBYpM50_00017 [Yersinia phage vB_YpM_50]	QKE55638.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	CAH0786514.1	CAH0786514.1 hypothetical protein P2AC1_00029 [Escherichia phage P2_AC1]	CAH0786514.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URC09626.1	URC09626.1 tail completion protein [Escherichia phage vB_EcoM-569R9]	URC09626.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNA05749.1	UNA05749.1 tail completion protein [Yersinia phage vB_YenM_42.18]	UNA05749.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ALF02252.1	ALF02252.1 tail completion protein [Salmonella phage SEN1]	ALF02252.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ULG00691.1	ULG00691.1 tail completion protein [Escherichia phage D8]	ULG00691.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD38882.1	VUD38882.1 Phage Ne1 neck protein [Peduovirus P24E6b]	VUD38882.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ULG01151.1	ULG01151.1 tail completion protein [Escherichia phage 12W]	ULG01151.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AAN08376.1	AAN08376.1 gp14 [Salmonella phage PSP3]	AAN08376.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNA05975.1	UNA05975.1 tail completion protein [Yersinia phage vB_YenM_201.16]	UNA05975.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QEI25353.1	QEI25353.1 virion morphogenesis protein [Salmonella phage SI22]	QEI25353.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QEI25398.1	QEI25398.1 virion morphogenesis protein [Salmonella phage SW9]	QEI25398.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AGF88426.1	AGF88426.1 hypothetical protein SP004_00065 [Salmonella phage FSLSP004]	AGF88426.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UKL54255.1	UKL54255.1 tail completion protein [Yersinia phage vB_YenM_31.17]	UKL54255.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AYD79800.1	AYD79800.1 hypothetical protein OGLPLLMI_00034 [Enterobacter phage phiT5282H]	AYD79800.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ABD90614.1	ABD90614.1 tail synthesis protein S [Mannheimia phage phiMhaA1-BAA410]	ABD90614.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ABD90565.1	ABD90565.1 tail synthesis protein S [Mannheimia phage PHL101]	ABD90565.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AJA73117.1	AJA73117.1 tail synthesis protein S [Mannheimia phage vB_MhM_2256AP1]	AJA73117.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AJA72886.1	AJA72886.1 tail synthesis protein S [Mannheimia phage vB_MhM_535AP1]	AJA72886.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AJA73065.1	AJA73065.1 tail synthesis protein S [Mannheimia phage vB_MhM_1127AP1]	AJA73065.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AFL46461.1	AFL46461.1 phage tail completion protein [Mannheimia phage vB_MhM_1152AP]	AFL46461.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AJA72937.1	AJA72937.1 tail synthesis protein S [Mannheimia phage vB_MhM_587AP1]	AJA72937.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QYW06313.1	QYW06313.1 tail completion protein [Shewanella phage vB_SspM_M16-3]	QYW06313.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP07949.1	QBP07949.1 virion morphogenesis protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07949.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNA05920.1	UNA05920.1 tail completion protein [Yersinia phage vB_YenM_56.17]	UNA05920.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UNA05873.1	UNA05873.1 tail completion protein [Yersinia phage vB_YenM_06.16-2]	UNA05873.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	WOZ57132.1	WOZ57132.1 virion morphogenesis protein [Citrobacter phage Shae_phiSM]	WOZ57132.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	UGC97273.1	UGC97273.1 tail completion protein [Aeromonas phage vB_AsaM_LPM4]	UGC97273.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ADX32437.1	ADX32437.1 phage virion morphogenesis protein [Erwinia phage ENT90]	ADX32437.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	VUD40175.1	VUD40175.1 Ne1 Phage neck protein [Xuanwuvirus P884B11]	VUD40175.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ALF02301.1	ALF02301.1 tail completion protein [Salmonella phage SEN4]	ALF02301.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ALF02350.1	ALF02350.1 tail completion protein [Salmonella phage SEN5]	ALF02350.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	URC09840.1	URC09840.1 tail completion protein [Escherichia phage vB_EcoM-720R8]	URC09840.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	QBP07906.1	QBP07906.1 virion morphogenesis protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07906.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	ARB15648.1	ARB15648.1 tail completion protein [Klebsiella phage 3LV2017]	ARB15648.1	0
+194fb9c0-5213-4d96-86b6-960d98df4830	AIZ95142.1	AIZ95142.1 tail protein [Escherichia phage P88]	AIZ95142.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UNY41734.1	UNY41734.1 DNA methylase [Burkholderia phage Milagro]	UNY41734.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ADP02321.1	ADP02321.1 gp28 [Burkholderia phage KL3]	ADP02321.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UNY41791.1	UNY41791.1 DNA methylase [Burkholderia phage Menos]	UNY41791.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UNY41846.1	UNY41846.1 DNA methylase [Burkholderia phage Momento]	UNY41846.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UPI15573.1	UPI15573.1 type II, N6M-methyladenine DNA methyltransferase [Burkholderia phage PhiBP82.3]	UPI15573.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIP84280.1	AIP84280.1 DNA methylase family protein [Burkholderia phage BEK]	AIP84280.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AAZ72631.1	AAZ72631.1 DNA methylase [Burkholderia phage phiE52237]	AAZ72631.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFV51410.1	AFV51410.1 DNA methylase [Burkholderia phage phiX216]	AFV51410.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ABO60764.1	ABO60764.1 gp40, DNA methylase [Burkholderia phage phiE12-2]	ABO60764.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ABO60747.1	ABO60747.1 gp37, DNA methylase [Burkholderia phage phiE202]	ABO60747.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QWY84962.1	QWY84962.1 type II, N6M-methyladenine DNA methyltransferase (group beta) [Burkholderia phage PK23]	QWY84962.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UKM53780.1	UKM53780.1 type II, N6M-methyladenine DNA methyltransferase [Burkholderia phage PhiBP82.2]	UKM53780.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QPI18555.1	QPI18555.1 DNA methytransferase [Burkholderia phage phiE094]	QPI18555.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WWY66158.1	WWY66158.1 site-specific DNA-methyltransferase [Burkholderia phage vB_HM387]	WWY66158.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVP40026.1	AVP40026.1 site-specific DNA-methyltransferase [Ralstonia phage RsoM1USA]	AVP40026.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKA61150.1	AKA61150.1 putative DNA methylase N-4 [Burkholderia phage AP3]	AKA61150.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QPB09419.1	QPB09419.1 methyltransferase [Burkholderia phage Mana]	QPB09419.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	USM11630.1	USM11630.1 DNA methylase [Burkholderia phage Carl1]	USM11630.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ADP02267.1	ADP02267.1 gp20 [Burkholderia phage KS5]	ADP02267.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFJ75474.1	AFJ75474.1 site-specific DNA-methyltransferase [Stenotrophomonas phage Smp131]	AFJ75474.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVJ50279.1	AVJ50279.1 DNA methylase [Mycobacterium phage Mendokysei]	AVJ50279.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDM56411.1	QDM56411.1 methyltransferase [Gordonia phage Sidious]	QDM56411.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVO21846.1	AVO21846.1 DNA methylase [Mycobacterium phage Nairb]	AVO21846.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP28905.1	QBP28905.1 DNA methylase [Mycobacterium phage Ibrahim]	QBP28905.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASJ79146.1	ASJ79146.1 DNA methylase [Mycobacterium phage ZenTime222]	ASJ79146.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHY26975.1	AHY26975.1 DNA methylase [Mycobacterium phage Bernal13]	AHY26975.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIT13473.1	AIT13473.1 DNA methylase [Mycobacterium phage RonRayGun]	AIT13473.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB47464.1	QHB47464.1 DNA methylase [Mycobacterium phage Whitty]	QHB47464.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AAR97696.1	AAR97696.1 adenine DNA methyltransferase [Bordetella phage BPP-1]	AAR97696.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANH49905.1	ANH49905.1 DNA methylase [Propionibacterium phage PFR1]	ANH49905.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANH49964.1	ANH49964.1 DNA methylase [Propionibacterium phage PFR2]	ANH49964.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB41405.1	QHB41405.1 DNA methylase [Mycobacterium phage Megiddo]	QHB41405.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAK78941.1	WAK78941.1 type II, N6M-methyladenine DNA methyltransferase [Acutalibacter phage Fontainebleau]	WAK78941.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UYL94017.1	UYL94017.1 DNA-methyltransferase [Geobacillus phage vB_GthS_PK3.6]	UYL94017.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ57731.1	QNJ57731.1 methyltransferase [Gordonia phage Love]	QNJ57731.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH92030.1	QDH92030.1 methyltransferase [Gordonia phage Galadriel]	QDH92030.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ55413.1	QNJ55413.1 DNA methylase [Gordonia phage Paries]	QNJ55413.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNY14802.1	WNY14802.1 DNA methyltransferase [Gordonia phage MoontowerMania]	WNY14802.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUR91966.1	AUR91966.1 DNA methylase [Vibrio phage 1.168.O._10N.261.52.A10]	AUR91966.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGR47374.1	AGR47374.1 putative adenine-specific methyltransferase [Brevibacillus phage Emery]	AGR47374.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUV61538.1	AUV61538.1 DNA methyltransferase [Faecalibacterium phage FP_Mushu]	AUV61538.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGF89781.1	AGF89781.1 DNA methylase [Streptococcus phage phiD12]	AGF89781.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UYL93942.1	UYL93942.1 DNA methyltransferase [Geobacillus phage vB_GthS_PK3.5]	UYL93942.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIG65878.1	QIG65878.1 N6-adenine specific DNA methyltransferase [Ochrobactrum phage vB_OspM_OC]	QIG65878.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CBW38949.1	CBW38949.1 Cytosine specific DNA methyltransferase [Streptococcus phage V22]	CBW38949.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CBW39209.1	CBW39209.1 Cytosine specific DNA methyltransferase [Streptococcus phage 8140]	CBW39209.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CBW39062.1	CBW39062.1 Cytosine specific DNA methyltransferase [Streptococcus phage 34117]	CBW39062.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA47709.1	ALA47709.1 cytosine specific DNA methyltransferase [Streptococcus phage phiARI0468b-3]	ALA47709.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA47453.1	ALA47453.1 cytosine specific DNA methyltransferase [Streptococcus phage phiARI0004]	ALA47453.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIG62305.1	QIG62305.1 site-specific DNA-methyltransferase [Tenacibaculum phage JQ]	QIG62305.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APD22987.1	APD22987.1 adenine-specific methyltransferase [Streptococcus phage IPP35]	APD22987.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APD22921.1	APD22921.1 adenine-specific methyltransferase [Streptococcus phage IPP34]	APD22921.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QYC51676.1	QYC51676.1 DNA methyltransferase [Acinetobacter phage Abp95]	QYC51676.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UQS93207.1	UQS93207.1 S-adenosyl-L-methionine-dependent methyltransferase [Acinetobacter phage Brutus]	UQS93207.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BEU75351.1	BEU75351.1 site-specific DNA-methyltransferase [Staphylococcus phage phiRNIID]	BEU75351.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UMO76604.1	UMO76604.1 DNA methylase [Enterococcus phage phiSHEF11]	UMO76604.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASZ75607.1	ASZ75607.1 modification methylase [Enterococcus phage phiSHEF4]	ASZ75607.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVT34924.1	UVT34924.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM-V1SA20]	UVT34924.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QYC52025.1	QYC52025.1 adenine-specific DNA-methyltransferase [Staphylococcus phage vB_Sau-RP15]	QYC52025.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE02929.1	UXE02929.1 DNA methyltransferase [Staphylococcus phage Koomba-kaat_1]	UXE02929.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFV80942.1	AFV80942.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM_Remus]	AFV80942.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFV81116.1	AFV81116.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM_Romulus]	AFV81116.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QVD58905.1	QVD58905.1 adenine-specific methyltransferase [Staphylococcus phage Romulus]	QVD58905.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QVD58714.1	QVD58714.1 adenine-specific methyltransferase [Silviavirus remus]	QVD58714.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QVD57618.1	QVD57618.1 adenine-specific methyltransferase [Staphylococcus phage PM56]	QVD57618.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QVD58511.1	QVD58511.1 adenine-specific methyltransferase [Staphylococcus phage PM93]	QVD58511.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXF38282.1	AXF38282.1 site-specific DNA methyltransferase [Staphylococcus phage Quidividi]	AXF38282.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WBF47914.1	WBF47914.1 hypothetical protein SSP49_89 [Staphylococcus phage SSP49]	WBF47914.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHG23981.1	AHG23981.1 cytosine specific DNA methyltransferase [Staphylococcus phage vB_SepS_SEP9]	AHG23981.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUV56415.1	AUV56415.1 adenine-specific methyltransferase [Faecalibacterium phage FP_Lagaffe]	AUV56415.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC42946.1	APC42946.1 DNA methylase [Staphylococcus phage StAP1]	APC42946.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BEU75353.1	BEU75353.1 DNA methylase [Staphylococcus phage phiRNIID]	BEU75353.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVT34926.1	UVT34926.1 type II, N4M-methylcytosine DNA methyltransferase group beta [Staphylococcus phage vB_SauM-V1SA20]	UVT34926.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVD42580.1	UVD42580.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM-V1SA22]	UVD42580.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX23705.1	QBX23705.1 DNA modification methyltransferase [Streptococcus phage Javan146]	QBX23705.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QRI43997.1	QRI43997.1 DNA-cytosine methyltransferase [Mycoplasma phage sp.]	QRI43997.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUR81431.1	AUR81431.1 DNA methylase [Vibrio phage 1.005.O._10N.286.48.F2]	AUR81431.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARQ95610.1	ARQ95610.1 DNA methylase family protein [Lactococcus phage AM12]	ARQ95610.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM67243.1	ARM67243.1 DNA methylase family protein [Lactococcus phage AM9]	ARM67243.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM66335.1	ARM66335.1 DNA methylase family protein [Lactococcus phage AM2]	ARM66335.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM67065.1	ARM67065.1 DNA methylase family protein [Lactococcus phage AM8]	ARM67065.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM66157.1	ARM66157.1 DNA methylase family protein [Lactococcus phage AM1]	ARM66157.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM67422.1	ARM67422.1 DNA methylase family protein [Lactococcus phage AM11]	ARM67422.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM66512.1	ARM66512.1 DNA methylase family protein [Lactococcus phage AM3]	ARM66512.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BBM81494.1	BBM81494.1 putative adenine-specific methyltransferase [Staphylococcus phage KSAP11]	BBM81494.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BBM81307.1	BBM81307.1 putative adenine-specific methyltransferase [Staphylococcus phage KSAP7]	BBM81307.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKA61314.1	AKA61314.1 cytosine specific DNA methyltransferase [Staphylococcus phage Stau2]	AKA61314.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX14982.1	QBX14982.1 DNA modification methyltransferase [Streptococcus phage Javan163]	QBX14982.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARM67604.1	ARM67604.1 DNA methyltransferase [Lactococcus phage LW81]	ARM67604.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKA61316.1	AKA61316.1 adenine-specific methyltransferase [Staphylococcus phage Stau2]	AKA61316.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFO70693.1	AFO70693.1 hypothetical protein [Staphylococcus phage SA11]	AFO70693.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WCO82409.1	WCO82409.1 DNA replication/modification protein [Staphylococcus phage PBSA08]	WCO82409.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WJZ48751.1	WJZ48751.1 DNA methyltranseferase [Staphylococcus phage SAC]	WJZ48751.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UGL60744.1	UGL60744.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM-HM01]	UGL60744.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WBF47912.1	WBF47912.1 replication protein [Staphylococcus phage SSP49]	WBF47912.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAX23322.1	WAX23322.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauM_VL10]	WAX23322.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXF38280.1	AXF38280.1 site-specific DNA methyltransferase [Staphylococcus phage Quidividi]	AXF38280.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC42948.1	APC42948.1 adenine-specific methyltransferase [Staphylococcus phage StAP1]	APC42948.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QLF87526.1	QLF87526.1 modification methylase [Staphylococcus phage vB_SepM_BE07]	QLF87526.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QLF87610.1	QLF87610.1 modification methylase [Staphylococcus phage vB_SepM_BE08]	QLF87610.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QLF87800.1	QLF87800.1 modification methylase [Staphylococcus phage vB_SepM_BE09]	QLF87800.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WEU70276.1	WEU70276.1 DNA methyltransferase [Staphylococcus phage vB_SepM_BE24]	WEU70276.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QLF87171.1	QLF87171.1 DpnA [Staphylococcus phage vB_SepM_BE06]	QLF87171.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX28589.1	QBX28589.1 DNA modification methyltransferase [Streptococcus phage Javan458]	QBX28589.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX20268.1	QBX20268.1 DNA modification methyltransferase [Streptococcus phage Javan513]	QBX20268.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX20008.1	QBX20008.1 DNA modification methyltransferase [Streptococcus phage Javan505]	QBX20008.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX30136.1	QBX30136.1 DNA modification methyltransferase [Streptococcus phage Javan524]	QBX30136.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYM00340.1	AYM00340.1 DNA methylase N-4/N-6 domain protein [Halobacterium phage phiH]	AYM00340.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDS61229.1	WDS61229.1 DNA adenine methylase [Synechococcus phage S-BM3]	WDS61229.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AJK28059.1	AJK28059.1 DNA methyltransferase [Paenibacillus phage Sitara]	AJK28059.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UOF77587.1	UOF77587.1 adenine specific methyltransferase mboiiA [Caudoviricetes sp.]	UOF77587.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AAF04014.1	AAF04014.1 adenine methyltransferase [Natrialba phage PhiCh1]	AAF04014.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBJ01272.1	QBJ01272.1 adenine methyltransferase [Natrialba phage PhiCh1]	QBJ01272.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ARQ95884.1	ARQ95884.1 adenine-specific methyltransferase [Staphylococcus phage qdsa001]	ARQ95884.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX15256.1	QBX15256.1 chromosome partitioning protein [Streptococcus phage Javan179]	QBX15256.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXF38487.1	AXF38487.1 site-specific DNA methyltransferase [Staphylococcus phage Twillingate]	AXF38487.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UUW39725.1	UUW39725.1 putative site-specific DNA-methyltransferase [Vibrio phage VPMCC14]	UUW39725.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEG08844.1	QEG08844.1 DNA (cytosine-5-)-methyltransferase [Aeromonas phage 4L372XY]	QEG08844.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGH31487.1	AGH31487.1 DNA methylase [Loktanella phage pCB2051-A]	AGH31487.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ58056.1	QNJ58056.1 DNA methylase [Gordonia phage JKSyngboy]	QNJ58056.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUR89489.1	AUR89489.1 DNA methylase [Vibrio phage 1.123.O._10N.286.48.F3]	AUR89489.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH92105.1	QDH92105.1 DNA methylase [Gordonia phage Galadriel]	QDH92105.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXH46662.1	AXH46662.1 DNA methylase [Gordonia phage Rofo]	AXH46662.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATN90278.1	ATN90278.1 DNA methylase [Gordonia phage Lennon]	ATN90278.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV61092.1	AOV61092.1 DNA methylase [Synechococcus phage S-CAM22]	AOV61092.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV61306.1	AOV61306.1 DNA methylase [Synechococcus phage S-CAM22]	AOV61306.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV60878.1	AOV60878.1 DNA methylase [Synechococcus phage S-CAM22]	AOV60878.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UBF23509.1	UBF23509.1 N6-adenine methyltransferase [Halorubrum tailed virus 28]	UBF23509.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYR02636.1	AYR02636.1 DNA methylase [Gordonia phage Bibwit]	AYR02636.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWT50582.1	AWT50582.1 DNA methylase [Gordonia phage Sitar]	AWT50582.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYR03550.1	AYR03550.1 DNA methylase [Gordonia phage Stultus]	AYR03550.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WWT39434.1	WWT39434.1 hypothetical protein [Microcystis phage Mel-JY01]	WWT39434.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDF19509.1	QDF19509.1 DNA methylase [Gordonia phage McKinley]	QDF19509.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWY09473.1	AWY09473.1 metal dependent phosphohydrolase [Ruegeria phage vB_RpoS-V16]	AWY09473.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOO19186.1	AOO19186.1 putative DNA modification methylase [Cyanophage S-RIM12_WH_05_0310]	AOO19186.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOO15966.1	AOO15966.1 putative DNA modification methylase [Cyanophage S-RIM12_RW_04_0310]	AOO15966.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOO19399.1	AOO19399.1 putative DNA modification methylase [Cyanophage S-RIM12_WH_07_0310]	AOO19399.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOO15326.1	AOO15326.1 putative DNA modification methylase [Cyanophage S-RIM12_Np_15_0310]	AOO15326.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNR52561.1	QNR52561.1 adenine-specific methyltransferase [Enterococcus phage AE4_2]	QNR52561.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	VUE37464.1	VUE37464.1 methyltransferase [Roseburia phage Shimadzu]	VUE37464.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHR69794.1	QHR69794.1 hypothetical protein inny_124 [Escherichia phage inny]	QHR69794.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHR75394.1	QHR75394.1 hypothetical protein outra_73 [Escherichia phage outra]	QHR75394.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOI68089.1	QOI68089.1 site-specific DNA-methyltransferase [Escherichia phage VEcB]	QOI68089.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UPW37463.1	UPW37463.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage vB_EcoM_ESCO8]	UPW37463.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UGL62139.1	UGL62139.1 putative site-specific DNA-methyltransferase [Escherichia phage JLBYU50]	UGL62139.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UPW38665.1	UPW38665.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage vB_EcoM_ESCO32]	UPW38665.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXY81515.1	AXY81515.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage vB_vPM_PD114]	AXY81515.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UIS31524.1	UIS31524.1 putative site-specific DNA-methyltransferase [Salmonella phage UAB_1]	UIS31524.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMM43489.1	AMM43489.1 putative site-specific DNA-methyltransferase or methylase [Enterobacteria phage ECGD1]	AMM43489.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WWP17713.1	WWP17713.1 Type III restriction-modification system methylation subunit [Escherichia phage ALITA]	WWP17713.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UPW37666.1	UPW37666.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage vB_EcoM_ESCO9]	UPW37666.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXV78166.1	QXV78166.1 Dam-like N6-adenine methyltransferase [Escherichia phage EmilieFrey]	QXV78166.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WPK37343.1	WPK37343.1 type III restriction-modification system methylation subunit [Escherichia phage AV123]	WPK37343.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHR73749.1	QHR73749.1 hypothetical protein alia_35 [Escherichia phage alia]	QHR73749.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UES35865.1	UES35865.1 hypothetical protein sKKP3263_000101 [Serratia phage KKP_3264]	UES35865.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYD85011.1	AYD85011.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage vB_vPM_PD06]	AYD85011.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHR66009.1	QHR66009.1 hypothetical protein muut_212 [Escherichia phage muut]	QHR66009.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVF09806.1	UVF09806.1 type III restriction-modification system methylation subunit [Escherichia phage pEC-M2929-1AR.1]	UVF09806.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BDU13033.1	BDU13033.1 methyltransferase [Escherichia phage phiWec187]	BDU13033.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHR67464.1	QHR67464.1 hypothetical protein arall_20 [Escherichia phage arall]	QHR67464.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WQN06863.1	WQN06863.1 type III restriction-modification system methylation subunit [Escherichia phage vB-Eco-KMB37]	WQN06863.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WBF54163.1	WBF54163.1 adenine-specific methyltransferase [Escherichia phage EC_OE_11]	WBF54163.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXV81383.1	QXV81383.1 Dam-like N6-adenine methyltransferase [Escherichia phage JohannJBalmer]	QXV81383.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CAH7774714.1	CAH7774714.1 adenine-specific methyltransferase [Escherichiaphage vB_EcoM_PHB05] [Escherichia phage vB_Eco_PATM]	CAH7774714.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXV83774.1	QXV83774.1 Dam-like N6-adenine methyltransferase [Escherichia phage PaulScherrer]	QXV83774.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CBY99584.1	CBY99584.1 Phi92_gp155 [Escherichia phage phi92]	CBY99584.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	CAD2070386.1	CAD2070386.1 putative site-specific DNA-methyltransferase or methylase [Escherichia phage Paula]	CAD2070386.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXV86332.1	QXV86332.1 adenine-specific methyltransferase [Staphylococcus phage SAPYZU_15]	QXV86332.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIT13269.1	AIT13269.1 DNA methylase [Ruegeria phage DSS3-P1]	AIT13269.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWY08738.1	AWY08738.1 DNA methylase [Ruegeria phage vB_RpoS-V7]	AWY08738.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWY08910.1	AWY08910.1 DNA methylase [Ruegeria phage vB_RpoS-V18]	AWY08910.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWY09074.1	AWY09074.1 DNA methylase [Ruegeria phage vB_RpoS-V11]	AWY09074.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UAW08544.1	UAW08544.1 DNA methylase [Mycobacterium phage MadMen]	UAW08544.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK58904.1	UVK58904.1 DNA methyltransferase [Mycobacterium phage Leozinho]	UVK58904.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUR93354.1	AUR93354.1 DNA methylase [Vibrio phage 1.187.O._10N.286.49.F1]	AUR93354.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOO18759.1	AOO18759.1 putative DNA modification methylase [Cyanophage S-RIM12_W1_12_0610]	AOO18759.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UOF77827.1	UOF77827.1 adenine specific methyltransferase mboiiA [Bacteriophage sp.]	UOF77827.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATI15890.1	ATI15890.1 adenine-specific methyltransferase [Escherichia phage vB_EcoM_PHB05]	ATI15890.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BAP28136.1	BAP28136.1 hypothetical protein [Ralstonia phage RSY1]	BAP28136.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ57811.1	QNJ57811.1 DNA methylase [Gordonia phage Love]	QNJ57811.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WPJ30544.1	WPJ30544.1 DNA methyltransferase [Pseudoalteromonas phage vB_PalP_Y7]	WPJ30544.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WEW53670.1	WEW53670.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauH_SPJ2]	WEW53670.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	USZ62928.1	USZ62928.1 adenine-specific methyltransferase [Staphylococcus phage LSA2311]	USZ62928.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QQO38102.1	QQO38102.1 adenine-specific methyltransferase [Staphylococcus phage LSA2308]	QQO38102.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV58673.1	AOV58673.1 DNA methylase [Synechococcus phage S-CAM3]	AOV58673.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WRQ08047.1	WRQ08047.1 adenine-specific methyltransferase [Phage nd4]	WRQ08047.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFC22692.1	AFC22692.1 putative methylase [Vibrio phage vB_VchM-138]	AFC22692.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGH75019.1	QGH75019.1 putative methylase [Vibrio phage Rostov M3]	QGH75019.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX15461.1	QBX15461.1 chromosome partitioning protein [Streptococcus phage Javan187]	QBX15461.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	URP21218.1	URP21218.1 methyltransferase [Gordonia phage Francois]	URP21218.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV59152.1	AOV59152.1 DNA methylase [Synechococcus phage S-CAM3]	AOV59152.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOV58913.1	AOV58913.1 DNA methylase [Synechococcus phage S-CAM3]	AOV58913.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYR02806.1	AYR02806.1 DNA methylase [Gordonia phage Fosterous]	AYR02806.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFP94525.1	QFP94525.1 DNA methylase [Gordonia phage Keitabear]	QFP94525.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXN73743.1	QXN73743.1 DNA methylase [Gordonia phage Fitzgerald]	QXN73743.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVF60773.1	UVF60773.1 DNA methylase [Gordonia phage BobBob]	UVF60773.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QWT30213.1	QWT30213.1 DNA methylase [Gordonia phage Sedona]	QWT30213.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFP94139.1	QFP94139.1 DNA methylase [Gordonia phage Jabberwocky]	QFP94139.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAW12199.1	WAW12199.1 adenine-specific methyltransferase [Staphylococcus phage SAP6]	WAW12199.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAW11984.1	WAW11984.1 adenine-specific methyltransferase [Staphylococcus phage StAP1]	WAW11984.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QST90739.1	QST90739.1 DNA methylase [Mycobacterium phage prophiGD13-2]	QST90739.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QPB08407.1	QPB08407.1 DNA methylase [Synechococcus phage S-H9-2]	QPB08407.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIA08752.1	AIA08752.1 putative methylase [Vibrio phage 24]	AIA08752.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFC22395.1	AFC22395.1 putative methylase [Vibrio phage CP-T1]	AFC22395.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUX81925.1	AUX81925.1 DNA methylase [Gordonia phage Brandonk123]	AUX81925.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QUE25958.1	QUE25958.1 DNA methylase [Gordonia phage Sanjuju]	QUE25958.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYR02551.1	AYR02551.1 DNA methylase [Gordonia phage Ailee]	AYR02551.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGT12482.1	AGT12482.1 modification methylase RSRI [Mycobacterium phage Hamulus]	AGT12482.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AWH13776.1	AWH13776.1 methyltransferase [Mycobacterium phage DillTech15]	AWH13776.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QPL13940.1	QPL13940.1 methyltransferase [Gordonia phage NancyRae]	QPL13940.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIG68706.1	QIG68706.1 modification DNA-methylase protein [Rhizobium phage RHph_TM3_3_14B]	QIG68706.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QKY80214.1	QKY80214.1 methyltransferase [Mycobacterium phage Jung]	QKY80214.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AZS11233.1	AZS11233.1 DNA methylase [Gordonia phage WheatThin]	AZS11233.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY06522.1	QAY06522.1 DNA methylase [Gordonia phage Parada]	QAY06522.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMS03701.1	AMS03701.1 DNA methyltransferase [Gordonia phage BetterKatz]	AMS03701.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX92561.1	QAX92561.1 DNA methyltransferase [Gordonia phage Mulch]	QAX92561.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXC38144.1	AXC38144.1 DNA methylase [Gordonia phage Nadeem]	AXC38144.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXO14209.1	QXO14209.1 DNA methylase [Gordonia phage Bock]	QXO14209.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAU06863.1	QAU06863.1 methyltransferase [Gordonia phage Brylie]	QAU06863.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UBF22738.1	UBF22738.1 N6-adenine methyltransferase [Halorubrum tailed virus 27]	UBF22738.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ94171.1	QGJ94171.1 hypothetical protein SEA_EMIROSE_39 [Corynebacterium phage EmiRose]	QGJ94171.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ94171.1	QGJ94171.1 hypothetical protein SEA_EMIROSE_39 [Corynebacterium phage EmiRose]	QGJ94171.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMO43224.1	AMO43224.1 DNA methylase [Cyanophage S-RIM32]	AMO43224.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR84917.1	ASR84917.1 DNA methylase [Mycobacterium phage StevieRay]	ASR84917.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASZ73061.1	ASZ73061.1 hypothetical protein SEA_GERALT_67 [Mycobacterium phage Geralt]	ASZ73061.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC46650.1	APC46650.1 DNA methylase [Mycobacterium phage Empress]	APC46650.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ61706.1	AXQ61706.1 DNA methylase [Mycobacterium phage Nimbo]	AXQ61706.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGT12380.1	AGT12380.1 DNA methylase [Mycobacterium phage Daenerys]	AGT12380.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QWY82566.1	QWY82566.1 DNA methylase [Mycobacterium phage Sassafras]	QWY82566.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ61809.1	AXQ61809.1 DNA methylase [Mycobacterium phage PHappiness]	AXQ61809.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QCW22156.1	QCW22156.1 DNA methylase [Mycobacterium phage Polka14]	QCW22156.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ61208.1	AXQ61208.1 DNA methylase [Mycobacterium phage JoeyJr]	AXQ61208.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASZ73847.1	ASZ73847.1 DNA methylase [Mycobacterium phage RitaG]	ASZ73847.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX92632.1	QAX92632.1 DNA methylase [Mycobacterium phage Poenanya]	QAX92632.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEQ94469.1	QEQ94469.1 DNA methylase [Mycobacterium phage KingMidas]	QEQ94469.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QYC53892.1	QYC53892.1 methyltransferase [Mycobacterium phage Leperchaun]	QYC53892.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFP96089.1	QFP96089.1 DNA methylase [Mycobacterium phage Doomphist]	QFP96089.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIK67687.1	AIK67687.1 DNA methylase [Mycobacterium phage Inventum]	AIK67687.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB47533.1	QHB47533.1 DNA methylase [Mycobacterium phage Scottish]	QHB47533.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUV60573.1	AUV60573.1 DNA methylase [Mycobacterium phage OldBen]	AUV60573.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXL91343.1	UXL91343.1 methyltransferase [Gordonia phage GrandSlam]	UXL91343.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	URP21295.1	URP21295.1 methyltransferase [Gordonia phage Chop]	URP21295.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WEV89998.1	WEV89998.1 adenine-specific methyltransferase [Pseudomonas phage PotUPM1]	WEV89998.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QSL99930.1	QSL99930.1 methyltransferase [Gordonia phage Ayotoya]	QSL99930.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP31929.1	QBP31929.1 DNA methylase [Mycobacterium phage GreaseLightnin]	QBP31929.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR84987.1	ASR84987.1 DNA methylase [Mycobacterium phage Ksquared]	ASR84987.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDK01248.1	QDK01248.1 DNA methylase [Mycobacterium phage Bunnies]	QDK01248.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOT24895.1	AOT24895.1 DNA methylase [Mycobacterium phage Nazo]	AOT24895.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVJ50717.1	AVJ50717.1 DNA methylase [Mycobacterium phage Ogopogo]	AVJ50717.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UOF78816.1	UOF78816.1 adenine specific DNA methyltransferase [Caudoviricetes sp.]	UOF78816.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKY02588.1	AKY02588.1 DNA methylase [Mycobacterium phage Brusacoram]	AKY02588.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ88640.1	QGJ88640.1 DNA methylase [Mycobacterium phage Atcoo]	QGJ88640.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATW59191.1	ATW59191.1 DNA methylase [Mycobacterium phage Thespis]	ATW59191.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX98754.1	ASX98754.1 DNA methylase [Arthrobacter phage Colucci]	ASX98754.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AEL98218.1	AEL98218.1 DNA methylase [Mycobacterium phage BigNuz]	AEL98218.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AAN07995.1	AAN07995.1 DNA methylase [Mycobacterium phage Che9d]	AAN07995.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOZ64634.1	AOZ64634.1 DNA methylase [Arthrobacter phage Chubster]	AOZ64634.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOZ64634.1	AOZ64634.1 DNA methylase [Arthrobacter phage Chubster]	AOZ64634.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX98977.1	ASX98977.1 DNA methylase [Arthrobacter phage RosiePosie]	ASX98977.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX98977.1	ASX98977.1 DNA methylase [Arthrobacter phage RosiePosie]	ASX98977.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIZ01756.1	AIZ01756.1 DNA methylase [Arthrobacter phage vB_ArtM-ArV1]	AIZ01756.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIZ01756.1	AIZ01756.1 DNA methylase [Arthrobacter phage vB_ArtM-ArV1]	AIZ01756.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIR93494.1	AIR93494.1 putative DNA modification methylase [Prochlorococcus phage P-TIM68]	AIR93494.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALY09927.1	ALY09927.1 DNA methylase [Arthrobacter phage PrincessTrina]	ALY09927.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALY09927.1	ALY09927.1 DNA methylase [Arthrobacter phage PrincessTrina]	ALY09927.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WXX03085.1	WXX03085.1 DNA methyltransferase [Staphylococcus phage LJLAME001]	WXX03085.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX95315.1	QAX95315.1 DNA methylase [Gordonia phage Hello]	QAX95315.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANA85817.1	ANA85817.1 DNA methylase [Gordonia phage Woes]	ANA85817.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX95407.1	QAX95407.1 DNA methylase [Gordonia phage Neoevie]	QAX95407.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC44876.1	APC44876.1 DNA methylase [Arthrobacter phage HumptyDumpty]	APC44876.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEQ94582.1	QEQ94582.1 DNA methylase [Arthrobacter phage Linus]	QEQ94582.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASZ73293.1	ASZ73293.1 DNA methylase [Arthrobacter phage JayCookie]	ASZ73293.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANU79682.1	ANU79682.1 DNA methylase [Arthrobacter phage Conboy]	ANU79682.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANU79682.1	ANU79682.1 DNA methylase [Arthrobacter phage Conboy]	ANU79682.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP30454.1	QBP30454.1 DNA methylase [Arthrobacter phage Chipper1996]	QBP30454.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP30454.1	QBP30454.1 DNA methylase [Arthrobacter phage Chipper1996]	QBP30454.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEQ94188.1	QEQ94188.1 DNA methylase [Arthrobacter phage Mordred]	QEQ94188.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEQ94188.1	QEQ94188.1 DNA methylase [Arthrobacter phage Mordred]	QEQ94188.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX98866.1	ASX98866.1 DNA methylase [Arthrobacter phage Kabreeze]	ASX98866.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX98866.1	ASX98866.1 DNA methylase [Arthrobacter phage Kabreeze]	ASX98866.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC44764.1	APC44764.1 DNA methylase [Arthrobacter phage EdgarPoe]	APC44764.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	APC44764.1	APC44764.1 DNA methylase [Arthrobacter phage EdgarPoe]	APC44764.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX99090.1	ASX99090.1 DNA methylase [Arthrobacter phage Scavito]	ASX99090.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX99090.1	ASX99090.1 DNA methylase [Arthrobacter phage Scavito]	ASX99090.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOZ64745.1	AOZ64745.1 DNA methylase [Arthrobacter phage Chocolat]	AOZ64745.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AOZ64745.1	AOZ64745.1 DNA methylase [Arthrobacter phage Chocolat]	AOZ64745.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX99202.1	ASX99202.1 DNA methylase [Arthrobacter phage Tophat]	ASX99202.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASX99202.1	ASX99202.1 DNA methylase [Arthrobacter phage Tophat]	ASX99202.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGZ17178.1	QGZ17178.1 DNA methylase [Arthrobacter phage DrYang]	QGZ17178.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGZ17178.1	QGZ17178.1 DNA methylase [Arthrobacter phage DrYang]	QGZ17178.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFG14880.1	QFG14880.1 DNA methylase [Arthrobacter phage Lymara]	QFG14880.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFG14880.1	QFG14880.1 DNA methylase [Arthrobacter phage Lymara]	QFG14880.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKJ71946.1	AKJ71946.1 DNA methylase [Tsukamurella phage TIN4]	AKJ71946.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKJ71837.1	AKJ71837.1 DNA methylase [Tsukamurella phage TIN3]	AKJ71837.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ87312.1	QGJ87312.1 DNA methylase [Gordonia phage Wocket]	QGJ87312.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXH47287.1	AXH47287.1 methyltransferase [Gordonia phage DelRio]	AXH47287.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY04007.1	QAY04007.1 DNA methylase [Gordonia phage Sombrero]	QAY04007.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFR56901.1	QFR56901.1 DNA methylase [Mycobacterium phage Juice456]	QFR56901.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UEM46037.1	UEM46037.1 DNA methylase [Mycobacterium phage JalFarm20]	UEM46037.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVD99556.1	AVD99556.1 DNA methylase [Gordonia phage Boneham]	AVD99556.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY16975.1	QAY16975.1 DNA methylase [Gordonia phage Butterball]	QAY16975.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY16687.1	QAY16687.1 DNA methylase [Gordonia phage FelixAlejandro]	QAY16687.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFL48017.1	AFL48017.1 DNA methylase [Mycobacterium phage Avani]	AFL48017.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYD81575.1	AYD81575.1 DNA methylase [Arthrobacter phage KBurrousTX]	AYD81575.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANA85279.1	ANA85279.1 DNA methylase [Gordonia phage BritBrat]	ANA85279.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVD42582.1	UVD42582.1 type II, N4M-methylcytosine DNA methyltransferase group beta [Staphylococcus phage vB_SauM-V1SA22]	UVD42582.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QYC52053.1	QYC52053.1 DNA methylase [Staphylococcus phage vB_Sau-RP15]	QYC52053.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFG09605.1	QFG09605.1 methyltransferase [Arthrobacter phage TripleJ]	QFG09605.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE02931.1	UXE02931.1 DNA methyltransferase [Staphylococcus phage Koomba-kaat_1]	UXE02931.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WCO82410.1	WCO82410.1 DNA replication/modification protein [Staphylococcus phage PBSA08]	WCO82410.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WJZ48752.1	WJZ48752.1 methyltransferase [Staphylococcus phage SAC]	WJZ48752.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UGL60743.1	UGL60743.1 DNA methyltransferase [Staphylococcus phage vB_SauM-HM01]	UGL60743.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AFO70695.1	AFO70695.1 DNA methylase family protein [Staphylococcus phage SA11]	AFO70695.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAA19580.1	WAA19580.1 DNA methyltransferase [Gordonia phage GalacticEye]	WAA19580.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVF60818.1	UVF60818.1 DNA methylase [Gordonia phage Sticker17]	UVF60818.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH48293.1	QDH48293.1 DNA methylase [Gordonia phage Luker]	QDH48293.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX94652.1	QAX94652.1 DNA methylase [Gordonia phage Harambe]	QAX94652.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAX94329.1	QAX94329.1 DNA methylase [Gordonia phage Guillaume]	QAX94329.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP30323.1	QBP30323.1 DNA methylase [Gordonia phage Jormungandr]	QBP30323.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVP43230.1	AVP43230.1 DNA methylase [Gordonia phage Hail2Pitt]	AVP43230.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP30618.1	QBP30618.1 DNA methylase [Gordonia phage Lahirium]	QBP30618.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATW61141.1	ATW61141.1 DNA methylase [Gordonia phage Anamika]	ATW61141.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ57410.1	QNJ57410.1 DNA methyltransferase [Pseudomonas phage Dolphis]	QNJ57410.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNJ57410.1	QNJ57410.1 DNA methyltransferase [Pseudomonas phage Dolphis]	QNJ57410.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNO26643.1	WNO26643.1 DNA methyltransferase [Mycobacterium phage Juniormint]	WNO26643.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDB74302.1	QDB74302.1 DNA methylase [Mycobacterium phage Phineas]	QDB74302.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ADD80822.1	ADD80822.1 DNA methylase [Rhodococcus phage ReqiDocB7]	ADD80822.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH92339.1	QDH92339.1 DNA methylase [Gordonia phage Spooky]	QDH92339.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	BCK59810.1	BCK59810.1 adenine-specific methyltransferase [Staphylococcus phage vB_SauH_DELF3]	BCK59810.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOC56007.1	QOC56007.1 methyltransferase [Gordonia phage Clown]	QOC56007.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOR56191.1	QOR56191.1 DNA methylase [Gordonia phage Linetti]	QOR56191.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE04928.1	UXE04928.1 DNA methyltransferase [Gordonia phage Jams]	UXE04928.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK61752.1	UVK61752.1 DNA methyltransferase [Gordonia phage MrWormie]	UVK61752.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK62773.1	UVK62773.1 DNA methyltransferase [Gordonia phage Lidong]	UVK62773.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH48691.1	QDH48691.1 DNA methylase [Gordonia phage Newt]	QDH48691.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK60774.1	UVK60774.1 DNA methyltransferase [Gordonia phage Bianmat]	UVK60774.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK60284.1	UVK60284.1 DNA methyltransferase [Gordonia phage Shelley]	UVK60284.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBP31821.1	QBP31821.1 DNA methylase [Gordonia phage Nimi13]	QBP31821.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UYL87217.1	UYL87217.1 DNA methyltransferase [Gordonia phage Minos]	UYL87217.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDF16905.1	QDF16905.1 DNA methylase [Gordonia phage Teal]	QDF16905.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ88633.1	QGJ88633.1 DNA methylase [Mycobacterium phage Atcoo]	QGJ88633.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UEM46046.1	UEM46046.1 DNA methylase [Mycobacterium phage JalFarm20]	UEM46046.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB47367.1	QHB47367.1 DNA methylase [Mycobacterium phage Hegedechwinu]	QHB47367.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFP96515.1	QFP96515.1 DNA methylase [Mycobacterium phage Smooch]	QFP96515.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AER49487.1	AER49487.1 hypothetical protein SG4_77 [Mycobacterium phage SG4]	AER49487.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBQ71286.1	QBQ71286.1 DNA methylase [Mycobacterium phage Daegal]	QBQ71286.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX16245.1	QBX16245.1 adenine-specific methyltransferase [Streptococcus phage Javan239]	QBX16245.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA48610.1	ALA48610.1 DNA methylase [Mycobacterium phage PopTart]	ALA48610.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AQY55570.1	AQY55570.1 DNA methylase [Mycobacterium phage SassyB]	AQY55570.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYJ75797.1	AYJ75797.1 putative DNA methylase [Bacillus phage BSP18]	AYJ75797.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYJ75797.1	AYJ75797.1 putative DNA methylase [Bacillus phage BSP18]	AYJ75797.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGH79203.1	QGH79203.1 DNA methylase [Mycobacterium phage Flathead]	QGH79203.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR86432.1	ASR86432.1 DNA methylase [Mycobacterium phage Bartholomew]	ASR86432.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK59455.1	UVK59455.1 DNA methyltransferase [Mycobacterium phage Venti]	UVK59455.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ64126.1	AXQ64126.1 DNA methylase [Mycobacterium phage KristaRAM]	AXQ64126.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAW12198.1	WAW12198.1 hypothetical protein [Staphylococcus phage SAP6]	WAW12198.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAW11983.1	WAW11983.1 hypothetical protein [Staphylococcus phage StAP1]	WAW11983.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNL29835.1	QNL29835.1 DNA methylase [Mycobacterium phage Webster2]	QNL29835.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ60768.1	AXQ60768.1 DNA methylase [Mycobacterium phage EleanorGeorge]	AXQ60768.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QST89954.1	QST89954.1 DNA methylase [Mycobacterium phage prophi108-1]	QST89954.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QST89612.1	QST89612.1 DNA methylase [Mycobacterium phage prophi62-3]	QST89612.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AGM12945.1	AGM12945.1 DNA methylase [Mycobacterium phage Fishburne]	AGM12945.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKJ71730.1	AKJ71730.1 DNA methylase [Tsukamurella phage TIN2]	AKJ71730.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKQ07841.1	AKQ07841.1 methyltransferase [Mycobacterium phage Kinbote]	AKQ07841.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALF00287.1	ALF00287.1 DNA methylase [Mycobacterium phage Evanesce]	ALF00287.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QUE25463.1	QUE25463.1 DNA methylase [Mycobacterium phage Luna22]	QUE25463.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE03496.1	UXE03496.1 DNA methylase [Mycobacterium phage Amymech]	UXE03496.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH48807.1	QDH48807.1 DNA methylase [Mycobacterium phage DeepSoil15]	QDH48807.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ51497.1	AXQ51497.1 DNA methylase [Mycobacterium phage Amochick]	AXQ51497.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNN98819.1	QNN98819.1 DNA methylase [Mycobacterium phage Hadrien]	QNN98819.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QZD99113.1	QZD99113.1 DNA methylase [Mycobacterium phage Forge]	QZD99113.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOC58806.1	QOC58806.1 DNA methylase [Mycobacterium phage Luke]	QOC58806.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIQ62686.1	QIQ62686.1 DNA methylase [Mycobacterium phage Ein37]	QIQ62686.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WVX89057.1	WVX89057.1 DNA methyltransferase [Mycobacterium phage Wishmaker]	WVX89057.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA06711.1	ALA06711.1 DNA methyltransferase [Mycobacterium phage OBUpride]	ALA06711.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHY84251.1	AHY84251.1 DNA methylase [Mycobacterium phage HH92]	AHY84251.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QXO13818.1	QXO13818.1 DNA methylase [Mycobacterium phage Hail]	QXO13818.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATN90451.1	ATN90451.1 DNA methyltransferase [Mycobacterium phage LilHazelnut]	ATN90451.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ABW88457.1	ABW88457.1 putative DNA methylase [Mycobacterium phage Giles]	ABW88457.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAA19518.1	WAA19518.1 DNA methylase [Mycobacterium phage Dewey]	WAA19518.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAB10172.1	WAB10172.1 DNA methyltransferase [Mycobacterium phage Gravaillia]	WAB10172.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY16436.1	QAY16436.1 DNA methylase [Gordonia phage Msay19]	QAY16436.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AAT72375.1	AAT72375.1 DNA methylase [Streptococcus phage phi1207.3]	AAT72375.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW19891.1	WDW19891.1 DNA methylase [Mycobacterium phage LOCV4]	WDW19891.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW19821.1	WDW19821.1 DNA methylase [Mycobacterium phage LOCV3]	WDW19821.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW20123.1	WDW20123.1 DNA methylase [Mycobacterium phage Nix22]	WDW20123.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW19959.1	WDW19959.1 DNA methylase [Mycobacterium phage LOCV5]	WDW19959.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW19751.1	WDW19751.1 DNA methylase [Mycobacterium phage LOCV2]	WDW19751.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WDW19681.1	WDW19681.1 DNA methylase [Mycobacterium phage LOCV1]	WDW19681.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QJD49555.1	QJD49555.1 adenine-specific methyltransferase [Streptococcus phage phi29961]	QJD49555.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QKN61651.1	QKN61651.1 adenine-specific methyltransferase [Streptococcus phage phi29862]	QKN61651.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UYL87579.1	UYL87579.1 DNA methyltransferase [Mycobacterium phage Dynamo]	UYL87579.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH85011.1	QDH85011.1 DNA methylase [Mycobacterium phage HUHilltop]	QDH85011.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVD98091.1	AVD98091.1 DNA methylase [Mycobacterium phage Jebeks]	AVD98091.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH92933.1	QDH92933.1 DNA methylase [Mycobacterium phage Necropolis]	QDH92933.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WXW92862.1	WXW92862.1 DNA methyltransferase [Mycobacterium phage Sonah]	WXW92862.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AJF40409.1	AJF40409.1 DNA methylase [Mycobacterium phage Malithi]	AJF40409.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASD53684.1	ASD53684.1 DNA methylase [Mycobacterium phage Bogie]	ASD53684.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMW63876.1	AMW63876.1 DNA methylase [Mycobacterium phage Shipwreck]	AMW63876.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX14866.1	QBX14866.1 adenine-specific methyltransferase [Streptococcus phage Javan159]	QBX14866.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX19782.1	QBX19782.1 adenine-specific methyltransferase [Streptococcus phage Javan499]	QBX19782.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QJD49494.1	QJD49494.1 adenine-specific methyltransferase [Streptococcus phage phi29854]	QJD49494.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QPX61818.1	QPX61818.1 DNA methylase [Mycobacterium phage Camster]	QPX61818.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOP64492.1	QOP64492.1 DNA methylase [Gordonia phage Sam12]	QOP64492.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QAY16867.1	QAY16867.1 DNA methylase [Gordonia phage Exiguo]	QAY16867.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QRI45521.1	QRI45521.1 DNA methylase [Gordonia phage Ekhein]	QRI45521.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WVX88382.1	WVX88382.1 DNA methyltransferase [Gordonia phage RemRem]	WVX88382.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGH76191.1	QGH76191.1 DNA methylase [Gordonia phage Jellybones]	QGH76191.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUV60341.1	AUV60341.1 DNA methylase [Gordonia phage Flakey]	AUV60341.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUE22163.1	AUE22163.1 DNA methylase [Gordonia phage BirksAndSocks]	AUE22163.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDM56864.1	QDM56864.1 DNA methylase [Gordonia phage Beaver]	QDM56864.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIQ62750.1	QIQ62750.1 DNA methylase [Gordonia phage Breezic]	QIQ62750.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVD99144.1	AVD99144.1 DNA methylase [Gordonia phage Adgers]	AVD99144.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WGH19728.1	WGH19728.1 DNA methyltransferase [Gordonia phage Lizzo]	WGH19728.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WVX87721.1	WVX87721.1 DNA methyltransferase [Gordonia phage PierreThree]	WVX87721.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIG61926.1	QIG61926.1 DNA methylase [Gordonia phage John316]	QIG61926.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOP64699.1	QOP64699.1 DNA methylase [Gordonia phage GourdThymes]	QOP64699.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ANA85909.1	ANA85909.1 DNA methylase [Gordonia phage Monty]	ANA85909.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDF17891.1	QDF17891.1 DNA methylase [Gordonia phage Gorko]	QDF17891.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDF18260.1	QDF18260.1 DNA methylase [Gordonia phage Chelms]	QDF18260.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WIC40033.1	WIC40033.1 DNA methylase [Gordonia phage Dakiti]	WIC40033.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QRI45631.1	QRI45631.1 DNA methylase [Gordonia phage RoyalG]	QRI45631.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AUV60648.1	AUV60648.1 DNA methylase [Gordonia phage SteveFrench]	AUV60648.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WPM94372.1	WPM94372.1 DNA methyltransferase [Arthrobacter phage Cupello]	WPM94372.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHI61232.1	AHI61232.1 Modification methylase BamHII [Vibrio phage SHOU24]	AHI61232.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGH74534.1	QGH74534.1 DNA methylase [Arthrobacter phage Kuleana]	QGH74534.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QST89822.1	QST89822.1 DNA methylase [Mycobacterium phage prophiGD53-3]	QST89822.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WWT40050.1	WWT40050.1 hypothetical protein [Nostoc phage Nsp-JY10]	WWT40050.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UPT53100.1	UPT53100.1 DNA methylase [Synechococcus phage Yong-M3-232]	UPT53100.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ86694.1	QGJ86694.1 adenine-specific methyltransferase [Streptococcus phage phi-SsuZKB4_rum]	QGJ86694.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ86295.1	QGJ86295.1 adenine-specific methyltransferase [Streptococcus phage phi-SsuSC05017_rum]	QGJ86295.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA07093.1	ALA07093.1 adenine-specific methyltransferase [Streptococcus phage phiSC070807]	ALA07093.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVR77234.1	AVR77234.1 methyltransferase [Mycobacterium phage OwlsT2W]	AVR77234.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMS02338.1	AMS02338.1 DNA methylase [Gordonia phage Hotorobo]	AMS02338.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AZF89940.1	AZF89940.1 DNA modification methylase [Methanosarcina virus MetMV]	AZF89940.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AZF89939.1	AZF89939.1 DNA modification methylase [Methanosarcina virus MetMV]	AZF89939.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX23264.1	QBX23264.1 adenine-specific methyltransferase [Streptococcus phage Javan122]	QBX23264.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AXQ64983.1	AXQ64983.1 DNA methylase [Mycobacterium phage Renaud18]	AXQ64983.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QNO12383.1	QNO12383.1 DNA methylase [Mycobacterium phage Royals2015]	QNO12383.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ABQ86135.1	ABQ86135.1 hypothetical protein PBI_TWEETY_66 [Mycobacterium phage Tweety]	ABQ86135.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ86053.1	QGJ86053.1 adenine-specific methyltransferase [Streptococcus phage phi-SsuHCJ3_rum]	QGJ86053.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ85903.1	QGJ85903.1 adenine-specific methyltransferase [Streptococcus phage phi-SsuFJZZ39_rum]	QGJ85903.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QGJ85824.1	QGJ85824.1 adenine-specific methyltransferase [Streptococcus phage phi-SsuFJZZ32_rum]	QGJ85824.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QEM40844.1	QEM40844.1 adenine-specific methyltransferase or lactate dehydrogenase [Streptococcus phage phi-SC181]	QEM40844.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOP65376.1	QOP65376.1 DNA methylase [Gordonia phage Diabla]	QOP65376.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALA48715.1	ALA48715.1 DNA methylase [Mycobacterium phage Seagreen]	ALA48715.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAX25121.1	WAX25121.1 lactate dehydrogenase [Streptococcus phage YS387]	WAX25121.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNM72834.1	WNM72834.1 DNA methyltransferase [Arthrobacter phage RedFox]	WNM72834.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QST89206.1	QST89206.1 DNA methylase [Mycobacterium phage prophiGD44-1]	QST89206.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB37291.1	QHB37291.1 methyltransferase [Gordonia phage Gudmit]	QHB37291.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKY02704.1	AKY02704.1 DNA methylase [Rhodobacter phage RcSaxon]	AKY02704.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKU43324.1	AKU43324.1 DNA methylase [Rhodobacter phage RcCronus]	AKU43324.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AKU43280.1	AKU43280.1 DNA methylase [Rhodobacter phage RcRhea]	AKU43280.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AEJ93043.1	AEJ93043.1 DNA methylase [Mycobacterium phage Shauna1]	AEJ93043.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIQ63760.1	QIQ63760.1 DNA methylase [Mycobacterium phage Phanphagia]	QIQ63760.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR83216.1	ASR83216.1 DNA methylase [Arthrobacter phage Abidatro]	ASR83216.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR83216.1	ASR83216.1 DNA methylase [Arthrobacter phage Abidatro]	ASR83216.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	URM87011.1	URM87011.1 DNA methylase [Arthrobacter phage Basilisk]	URM87011.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	URM87011.1	URM87011.1 DNA methylase [Arthrobacter phage Basilisk]	URM87011.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ADW80203.1	ADW80203.1 putative DNA methylase [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80203.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ADW80149.1	ADW80149.1 putative DNA methylase [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80149.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYN56862.1	AYN56862.1 DNA methylase [Arthrobacter phage Andrew]	AYN56862.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYN56862.1	AYN56862.1 DNA methylase [Arthrobacter phage Andrew]	AYN56862.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ATN87203.1	ATN87203.1 DNA methylase [Mycobacterium phage Arib1]	ATN87203.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QRI45454.1	QRI45454.1 DNA methylase [Arthrobacter phage Leona]	QRI45454.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDP43680.1	QDP43680.1 methyltransferase [Gordonia phage PhorbesPhlower]	QDP43680.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UYE95851.1	UYE95851.1 hypothetical protein KNLIENLN_00038 [Sinorhizobium phage NV1.1.1]	UYE95851.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFP96173.1	QFP96173.1 hypothetical protein DOBBYSSOCK_SEA_52 [Gordonia phage DobbysSock]	QFP96173.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AMS02143.1	AMS02143.1 DNA methylase [Mycobacterium phage Xeno]	AMS02143.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AER26580.1	AER26580.1 DNA methylase [Gordonia phage GTE7]	AER26580.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYB69407.1	AYB69407.1 DNA methylase [Mycobacterium phage Gancho]	AYB69407.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WPM94296.1	WPM94296.1 DNA methyltransferase [Arthrobacter phage Marchesin]	WPM94296.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHJ86311.1	QHJ86311.1 DNA methylase [Mycobacterium phage CactusJack]	QHJ86311.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB41477.1	QHB41477.1 DNA methylase [Mycobacterium phage Glaske]	QHB41477.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHN83037.1	AHN83037.1 modification methylase DpnIIB [Campylobacter phage CJIE4-5]	AHN83037.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHN82803.1	AHN82803.1 modification methylase DpnIIB [Campylobacter phage CJIE4-1]	AHN82803.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIG57646.1	QIG57646.1 DNA methylase [Mycobacterium phage StressBall]	QIG57646.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB41320.1	QHB41320.1 DNA methylase [Mycobacterium phage Phalm]	QHB41320.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHN82919.1	AHN82919.1 modification methylase DpnIIB [Campylobacter phage CJIE4-3]	AHN82919.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHN82861.1	AHN82861.1 modification methylase DpnIIB [Campylobacter phage CJIE4-2]	AHN82861.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UWJ04533.1	UWJ04533.1 modification methylase [Campylobacter phage PC10]	UWJ04533.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QWY83279.1	QWY83279.1 modification DNA-methylase protein [Rhizobium phage RHph_X2_25]	QWY83279.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVO21670.1	AVO21670.1 DNA methylase [Mycobacterium phage MooMoo]	AVO21670.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX22722.1	QBX22722.1 adenine-specific methyltransferase [Streptococcus phage Javan95]	QBX22722.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBX22199.1	QBX22199.1 adenine-specific methyltransferase [Streptococcus phage Javan639]	QBX22199.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHJ86484.1	QHJ86484.1 DNA methylase [Mycobacterium phage KilKor]	QHJ86484.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QIN94275.1	QIN94275.1 DNA methylase [Mycobacterium phage Willsammy]	QIN94275.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ULG00209.1	ULG00209.1 adenine-specific methyltransferase [Pseudomonas phage PP9W2]	ULG00209.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ULG00209.1	ULG00209.1 adenine-specific methyltransferase [Pseudomonas phage PP9W2]	ULG00209.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHB41399.1	QHB41399.1 DNA methylase [Mycobacterium phage Megiddo]	QHB41399.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ABF71361.1	ABF71361.1 p097 [Rhizobium phage 16-3]	ABF71361.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AVJ50711.1	AVJ50711.1 hypothetical protein SEA_OGOPOGO_72 [Mycobacterium phage Ogopogo]	AVJ50711.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFG13097.1	QFG13097.1 DNA methylase [Arthrobacter phage Amelia]	QFG13097.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QFG13097.1	QFG13097.1 DNA methylase [Arthrobacter phage Amelia]	QFG13097.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASR84910.1	ASR84910.1 DNA methylase [Mycobacterium phage StevieRay]	ASR84910.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHJ75445.1	QHJ75445.1 DNA methylase [Wolbachia phage WO]	QHJ75445.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QHJ75561.1	QHJ75561.1 DNA methylase [Wolbachia phage WO]	QHJ75561.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK62584.1	UVK62584.1 DNA methyltransferase [Arthrobacter phage TaylorSipht]	UVK62584.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVK62584.1	UVK62584.1 DNA methyltransferase [Arthrobacter phage TaylorSipht]	UVK62584.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AEJ93638.1	AEJ93638.1 DNA methylase [Mycobacterium phage Doom]	AEJ93638.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AER47627.1	AER47627.1 DNA methyltransferase [Mycobacterium phage DS6A]	AER47627.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AER47627.1	AER47627.1 DNA methyltransferase [Mycobacterium phage DS6A]	AER47627.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WAX25556.1	WAX25556.1 lactate dehydrogenase [Streptococcus phage YS43]	WAX25556.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AIX28392.1	AIX28392.1 DNA adenine methylase [Synechococcus phage ACG-2014j]	AIX28392.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WYX89494.1	WYX89494.1 methyltransferase [Mycobacterium phage MKC-IRE-01]	WYX89494.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ASZ75322.1	ASZ75322.1 DNA methylase [Mycobacterium phage Majeke]	ASZ75322.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	URP21047.1	URP21047.1 DNA methylase [Mycobacterium phage Phegasus]	URP21047.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYQ99896.1	AYQ99896.1 DNA methylase [Mycobacterium phage Mangethe]	AYQ99896.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UVT30961.1	UVT30961.1 DNA methyltransferase [Mycobacterium phage Langerak]	UVT30961.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNM65715.1	WNM65715.1 DNA methyltransferase [Arthrobacter phage Vulpecula]	WNM65715.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNM65715.1	WNM65715.1 DNA methyltransferase [Arthrobacter phage Vulpecula]	WNM65715.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOP64941.1	QOP64941.1 DNA methylase [Arthrobacter phage Brynnie]	QOP64941.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QOP64941.1	QOP64941.1 DNA methylase [Arthrobacter phage Brynnie]	QOP64941.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AYQ98437.1	AYQ98437.1 hypothetical protein KIMCHI1738_46 [Corynebacterium phage Kimchi1738]	AYQ98437.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNM69491.1	WNM69491.1 DNA methyltransferase [Arthrobacter phage Ruchi]	WNM69491.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WNM69491.1	WNM69491.1 DNA methyltransferase [Arthrobacter phage Ruchi]	WNM69491.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE05397.1	UXE05397.1 DNA methyltransferase [Arthrobacter phage Renna12]	UXE05397.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QKY78967.1	QKY78967.1 methyltransferase [Arthrobacter phage Jinkies]	QKY78967.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALY08887.1	ALY08887.1 DNA methylase [Arthrobacter phage Galaxy]	ALY08887.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	ALY08887.1	ALY08887.1 DNA methylase [Arthrobacter phage Galaxy]	ALY08887.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QDH48626.1	QDH48626.1 DNA methylase [Mycobacterium phage Techage]	QDH48626.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	QBI98015.1	QBI98015.1 DNA methylase [Mycobacterium phage Zilizebeth]	QBI98015.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WJJ56369.1	WJJ56369.1 DNA methyltransferase [Mycobacterium phage CCUG48898T-2]	WJJ56369.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WKW35071.1	WKW35071.1 N6M-methyladenine DNA methyltransferase [Mycobacterium phage KanikaMF1]	WKW35071.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WLG15508.1	WLG15508.1 DNA methyltransferase [Mycobacterium phage MTBP1]	WLG15508.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	WRQ08412.1	WRQ08412.1 DNA methylase [Mycobacterium phage juyeon]	WRQ08412.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	AHG23761.1	AHG23761.1 DNA methylase [Mycobacterium phage Donovan]	AHG23761.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE05190.1	UXE05190.1 DNA methyltransferase [Arthrobacter phage Jamun]	UXE05190.1	0
+13002e53-8da7-4f5d-87da-844476208d5d	UXE05190.1	UXE05190.1 DNA methyltransferase [Arthrobacter phage Jamun]	UXE05190.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNY41735.1	UNY41735.1 baseplate protein [Burkholderia phage Milagro]	UNY41735.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNY41676.1	UNY41676.1 baseplate assembly protein [Burkholderia phage Musica]	UNY41676.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNY41792.1	UNY41792.1 baseplate assembly protein [Burkholderia phage Menos]	UNY41792.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNY41848.1	UNY41848.1 baseplate assembly protein [Burkholderia phage Momento]	UNY41848.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADP02320.1	ADP02320.1 gp27 [Burkholderia phage KL3]	ADP02320.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UKM53781.1	UKM53781.1 baseplate assembly protein [Burkholderia phage PhiBP82.2]	UKM53781.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAZ72630.1	AAZ72630.1 phage baseplate assembly protein [Burkholderia phage phiE52237]	AAZ72630.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AFV51411.1	AFV51411.1 baseplate assembly protein [Burkholderia phage phiX216]	AFV51411.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABO60756.1	ABO60756.1 gp39, phage baseplate assembly protein [Burkholderia phage phiE12-2]	ABO60756.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UPI15575.1	UPI15575.1 baseplate assembly protein [Burkholderia phage PhiBP82.3]	UPI15575.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AIP84267.1	AIP84267.1 phage baseplate assembly V family protein [Burkholderia phage BEK]	AIP84267.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QWY84963.1	QWY84963.1 baseplate assembly protein [Burkholderia phage PK23]	QWY84963.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WWY66159.1	WWY66159.1 baseplate assembly protein V [Burkholderia phage vB_HM387]	WWY66159.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QPI18556.1	QPI18556.1 baseplate assembly V-like protein [Burkholderia phage phiE094]	QPI18556.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABO60711.1	ABO60711.1 gp36, gpV [Burkholderia phage phiE202]	ABO60711.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BDD79930.1	BDD79930.1 hypothetical protein [Burkholderia phage FLC10]	BDD79930.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AGK86790.1	AGK86790.1 phage baseplate assembly protein V [Burkholderia phage ST79]	AGK86790.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADP02367.1	ADP02367.1 gp22 [Burkholderia phage KS14]	ADP02367.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QPB09411.1	QPB09411.1 tail spike protein [Burkholderia phage Mana]	QPB09411.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AKA61142.1	AKA61142.1 putative basteplate assembly protein [Burkholderia phage AP3]	AKA61142.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BCB23200.1	BCB23200.1 baseplate assembly protein (V) [Burkholderia phage FLC5]	BCB23200.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WWY66193.1	WWY66193.1 baseplate assembly protein V [Burkholderia phage vB_HM795]	WWY66193.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AXF38221.1	AXF38221.1 putative baseplate assembly protein [Ralstonia phage phiRSP]	AXF38221.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	USZ80540.1	USZ80540.1 baseplate assembly protein [Serratia phage MQ-4]	USZ80540.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QOE32743.1	QOE32743.1 baseplate spike protein [Achromobacter phage Mano]	QOE32743.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADP02274.1	ADP02274.1 gp27 [Burkholderia phage KS5]	ADP02274.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	USM11623.1	USM11623.1 tail spike protein [Burkholderia phage Carl1]	USM11623.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QJB21914.1	QJB21914.1 baseplate assembly protein V [Xanthomonas phage FoX3]	QJB21914.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WNL50849.1	WNL50849.1 baseplate spike [Xanthomonas phage Murka]	WNL50849.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QJB21752.1	QJB21752.1 baseplate assembly protein V [Xanthomonas phage FoX1]	QJB21752.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QWY14230.2	QWY14230.2 baseplate assembly protein [Xanthomonas phage M29]	QWY14230.2	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QJB21992.1	QJB21992.1 baseplate assembly protein V [Xanthomonas phage FoX5]	QJB21992.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QJB21833.1	QJB21833.1 baseplate assembly protein V [Xanthomonas phage FoX2]	QJB21833.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAF52396.1	BAF52396.1 baseplate assembly protein V [Ralstonia phage RSA1]	BAF52396.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAA36243.1	BAA36243.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36243.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AZF87857.1	AZF87857.1 baseplate assembly protein V [Pseudomonas phage Dobby]	AZF87857.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAO20611.1	BAO20611.1 putative baseplate assembly protein V [Pseudomonas phage PPpW-3]	BAO20611.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBI84124.1	QBI84124.1 baseplate assembly protein V [Pseudomonas phage vB_Pae_BR319a]	QBI84124.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WWQ72100.1	WWQ72100.1 baseplate assembly protein [Pseudomonas phage Sirocco]	WWQ72100.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QMP19174.1	QMP19174.1 baseplate protein [Pseudomonas phage Persinger]	QMP19174.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AVP40014.1	AVP40014.1 baseplate assembly protein [Ralstonia phage RsoM1USA]	AVP40014.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QIG65660.1	QIG65660.1 hypothetical protein [Salmonella phage PT1]	QIG65660.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QPB08623.1	QPB08623.1 baseplate spike protein [Burkholderia phage Mica]	QPB08623.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAP28122.1	BAP28122.1 hypothetical protein [Ralstonia phage RSY1]	BAP28122.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AIM50563.1	AIM50563.1 hypothetical protein ep3_0037 [Escherichia phage vB_EcoM-ep3]	AIM50563.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ARM70451.1	ARM70451.1 hypothetical protein vBEcoMECOO78_46 [Escherichia phage vB_EcoM_ECOO78]	ARM70451.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WPJ21697.1	WPJ21697.1 baseplate assembly protein V [Bacillus phage vB_BpuM-ZY1]	WPJ21697.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADE87926.1	ADE87926.1 conserved phage protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87926.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75405.1	QHJ75405.1 hypothetical protein [Wolbachia phage WO]	QHJ75405.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAA89649.1	BAA89649.1 gp24 [Wolbachia phage WO]	BAA89649.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AGF88427.1	AGF88427.1 phage baseplate assembly protein [Salmonella phage FSLSP004]	AGF88427.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75556.1	QHJ75556.1 hypothetical protein [Wolbachia phage WO]	QHJ75556.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADW80195.1	ADW80195.1 baseplate V [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80195.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADW80136.1	ADW80136.1 baseplate V [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80136.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AOA49553.1	AOA49553.1 phage baseplate assembly protein V family protein [Wolbachia phage WO]	AOA49553.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAN08377.1	AAN08377.1 gp15 [Salmonella phage PSP3]	AAN08377.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27431.1	QBP27431.1 baseplate assembly protein V [Klebsiella phage ST512-KPC3phi13.2]	QBP27431.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP07811.1	QBP07811.1 baseplate assembly protein V [Klebsiella phage ST11-VIM1phi8.4]	QBP07811.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27869.1	QBP27869.1 baseplate assembly protein V [Klebsiella phage ST11-OXA48phi15.3]	QBP27869.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP08097.1	QBP08097.1 baseplate assembly protein V [Klebsiella phage ST11-OXA245phi3.1]	QBP08097.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27670.1	QBP27670.1 baseplate assembly protein V [Klebsiella phage ST340-VIM1phi10.2]	QBP27670.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27966.1	QBP27966.1 baseplate assembly protein V [Klebsiella phage ST258-KPC3phi16.2]	QBP27966.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAC34160.1	AAC34160.1 baseplate protein [Escherichia phage 186]	AAC34160.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UTC25938.1	UTC25938.1 baseplate assembly protein V [Salmonella phage vB_Sal_PHB48]	UTC25938.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ALF02253.1	ALF02253.1 baseplate assembly protein V [Salmonella phage SEN1]	ALF02253.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QYC52673.1	QYC52673.1 baseplate assembly protein [Salmonella phage BIS20]	QYC52673.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABD90619.1	ABD90619.1 baseplate assembly protein V [Mannheimia phage phiMhaA1-BAA410]	ABD90619.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABD90570.1	ABD90570.1 baseplate assembly protein V [Mannheimia phage PHL101]	ABD90570.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AJA73122.1	AJA73122.1 baseplate assembly protein V [Mannheimia phage vB_MhM_2256AP1]	AJA73122.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AJA72890.1	AJA72890.1 baseplate assembly protein V [Mannheimia phage vB_MhM_535AP1]	AJA72890.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AJA72941.1	AJA72941.1 baseplate assembly protein V [Mannheimia phage vB_MhM_587AP1]	AJA72941.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AJA73069.1	AJA73069.1 baseplate assembly protein V [Mannheimia phage vB_MhM_1127AP1]	AJA73069.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AFL46465.1	AFL46465.1 baseplate assembly protein V [Mannheimia phage vB_MhM_1152AP]	AFL46465.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ALF02303.1	ALF02303.1 baseplate assembly protein V [Salmonella phage SEN4]	ALF02303.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ALF02352.1	ALF02352.1 baseplate assembly protein V [Salmonella phage SEN5]	ALF02352.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBQ72007.1	QBQ72007.1 baseplate assembly protein V [Klebsiella phage ST15-OXA48phi14.1]	QBQ72007.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27611.1	QBP27611.1 baseplate assembly protein V [Klebsiella phage ST13-OXA48phi12.1]	QBP27611.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AFJ75493.1	AFJ75493.1 baseplate assembly protein [Stenotrophomonas phage Smp131]	AFJ75493.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEI25354.1	QEI25354.1 baseplate assembly protein [Salmonella phage SI22]	QEI25354.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEI25399.1	QEI25399.1 baseplate assembly protein V [Salmonella phage SW9]	QEI25399.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QXF95179.1	QXF95179.1 baseplate assembly protein V [Wolbachia phage WO]	QXF95179.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP08032.1	QBP08032.1 baseplate assembly protein V [Klebsiella phage ST437-OXA245phi4.1]	QBP08032.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27760.1	QBP27760.1 baseplate assembly protein V [Klebsiella phage ST512-KPC3phi13.6]	QBP27760.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP27913.1	QBP27913.1 baseplate assembly protein V [Klebsiella phage ST258-KPC3phi16.1]	QBP27913.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WYC18453.1	WYC18453.1 baseplate assembly protein [Yersinia phage vB_YpM_MHG38]	WYC18453.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AUV47165.1	AUV47165.1 baseplate assembly protein V [Erwinia phage EtG]	AUV47165.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABM73389.1	ABM73389.1 phage baseplate assembly protein V [Vibrio phage VP882]	ABM73389.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ULG00692.1	ULG00692.1 baseplate assembly protein [Escherichia phage D8]	ULG00692.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD38886.1	VUD38886.1 Baseplate assembly protein V [Peduovirus P24E6b]	VUD38886.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ULG01152.1	ULG01152.1 baseplate assembly protein [Escherichia phage 12W]	ULG01152.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URE76609.1	URE76609.1 baseplate assembly protein [Escherichia phage vB_EcoM-613R3]	URE76609.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WPJ53102.1	WPJ53102.1 spike protein [Klebsiella phage RCIP0057]	WPJ53102.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC10104.1	URC10104.1 baseplate assembly protein [Escherichia phage vB_EcoM-640R3]	URC10104.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNA05754.1	UNA05754.1 baseplate assembly protein [Yersinia phage vB_YenM_42.18]	UNA05754.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAD03282.1	AAD03282.1 gpV [Bacteriophage P2]	AAD03282.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDJ98456.1	QDJ98456.1 spike protein [Escherichia phage vB_EcoM-12474II]	QDJ98456.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDJ98588.1	QDJ98588.1 spike protein [Escherichia phage vB_EcoM-12474V]	QDJ98588.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDJ98544.1	QDJ98544.1 spike protein [Escherichia phage vB_EcoM-12474IV]	QDJ98544.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDJ98503.1	QDJ98503.1 spike protein [Escherichia phage vB_EcoM-12474III]	QDJ98503.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ULG00994.1	ULG00994.1 baseplate assembly protein [Escherichia phage 9W]	ULG00994.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD37933.1	VUD37933.1 Baseplate assembly protein V [Peduovirus P22H4]	VUD37933.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAX64992.1	CAX64992.1 gp11 protein [Vibrio phage VP585]	CAX64992.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QXN68732.1	QXN68732.1 baseplate assembly protein [Hafnia phage yong2]	QXN68732.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AKH49387.1	AKH49387.1 baseplate assembly protein V [Escherichia phage pro483]	AKH49387.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAG9593789.1	CAG9593789.1 hypothetical protein P2SIAC10_00028 [Peduovirus P2]	CAG9593789.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAG9593820.1	CAG9593820.1 hypothetical protein P2DC1_00016 [Peduovirus P2]	CAG9593820.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNA05875.1	UNA05875.1 baseplate assembly protein [Yersinia phage vB_YenM_06.16-2]	UNA05875.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC09839.1	URC09839.1 baseplate assembly protein [Escherichia phage vB_EcoM-720R8]	URC09839.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAN12330.1	AAN12330.1 ORF30 [Vibrio phage VHML]	AAN12330.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QKE55639.1	QKE55639.1 hypothetical protein vBYpM50_00018 [Yersinia phage vB_YpM_50]	QKE55639.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AGX84577.1	AGX84577.1 baseplate protein [Enterobacteria phage fiAA91-ss]	AGX84577.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAH0786512.1	CAH0786512.1 hypothetical protein P2AC1_00027 [Escherichia phage P2_AC1]	CAH0786512.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UPI11464.1	UPI11464.1 hypothetical protein COILCCMC_00016 [Yersinia phage VB-YPM-4]	UPI11464.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QKE55596.1	QKE55596.1 hypothetical protein vBYpM46_00016 [Yersinia phage vB_YpM_46]	QKE55596.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNA05976.1	UNA05976.1 baseplate assembly protein [Yersinia phage vB_YenM_201.16]	UNA05976.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAP04451.1	AAP04451.1 gpV [Yersinia phage L-413C]	AAP04451.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AGG36531.1	AGG36531.1 baseplate assembly protein V [Escherichia phage P2]	AGG36531.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEA09565.1	QEA09565.1 hypothetical protein [Wolbachia phage WO]	QEA09565.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC09627.1	URC09627.1 baseplate assembly protein [Escherichia phage vB_EcoM-569R9]	URC09627.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AFV81350.1	AFV81350.1 baseplate protein [Vibrio phage vB_VpaM_MAR]	AFV81350.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAN28233.1	AAN28233.1 gpV [Escherichia phage Wphi]	AAN28233.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNA05924.1	UNA05924.1 baseplate assembly protein [Yersinia phage vB_YenM_56.17]	UNA05924.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	API82950.1	API82950.1 Phage-related baseplate assembly protein [Salmonella phage STYP1]	API82950.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AKH49331.1	AKH49331.1 baseplate assembly protein V [Escherichia phage pro147]	AKH49331.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ56004.1	WOZ56004.1 hypothetical protein B115_00016 [Yersinia phage vB_YpM_115]	WOZ56004.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ56050.1	WOZ56050.1 hypothetical protein B117_00016 [Yersinia phage vB_YpM_117]	WOZ56050.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD37976.1	VUD37976.1 Baseplate assembly protein V [Peduovirus P22H1]	VUD37976.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAG9593872.1	CAG9593872.1 hypothetical protein P2SIDE7_00026 [Peduovirus P2]	CAG9593872.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ANN86119.1	ANN86119.1 putative baseplate assembly protein V [Enterobacter phage Arya]	ANN86119.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAD16793.1	BAD16793.1 similar to GPV of phage P2 [Wolbachia phage WOcauB1]	BAD16793.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ULG01123.1	ULG01123.1 baseplate assembly protein [Escherichia phage 10W]	ULG01123.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QXF95281.1	QXF95281.1 baseplate assembly protein [Yersinia phage HQ103]	QXF95281.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ULG00878.1	ULG00878.1 baseplate assembly protein [Escherichia phage 11W]	ULG00878.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD39517.1	VUD39517.1 Baseplate assembly protein V [Peduovirus P24C9]	VUD39517.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD38020.1	VUD38020.1 Baseplate assembly protein V [Peduovirus P24B2]	VUD38020.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75391.1	QHJ75391.1 hypothetical protein [Wolbachia phage WO]	QHJ75391.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD39032.1	VUD39032.1 Baseplate assembly protein V [Peduovirus P24A7b]	VUD39032.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QIW90051.1	QIW90051.1 baseplate assembly V family protein [Yersinia phage P37]	QIW90051.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBQ71559.1	QBQ71559.1 baseplate assembly protein V [Klebsiella phage ST147-VIM1phi7.1]	QBQ71559.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UKL54257.1	UKL54257.1 baseplate assembly protein [Yersinia phage vB_YenM_31.17]	UKL54257.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AFU62887.1	AFU62887.1 phage baseplate assembly protein gpV [Acidithiobacillus phage AcaML1]	AFU62887.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WFG40963.1	WFG40963.1 baseplate assembly protein [Salmonella phage MET_P1_103_31]	WFG40963.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADX32423.1	ADX32423.1 baseplate assembly protein [Erwinia phage ENT90]	ADX32423.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNI73721.1	UNI73721.1 prophage baseplate assembly protein V [Klebsiella phage KP12]	UNI73721.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ADQ92403.1	ADQ92403.1 baseplate assembly protein V [Salmonella phage RE2010]	ADQ92403.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ARB15696.1	ARB15696.1 hypothetical protein [Klebsiella phage 4LV2017]	ARB15696.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CAH1234697.1	CAH1234697.1 baseplate protein V [Escherichia phage Cartapus]	CAH1234697.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URP83675.1	URP83675.1 baseplate assembly protein [Escherichia phage S164]	URP83675.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDP43510.1	QDP43510.1 baseplate assembly protein V [Bacteriophage R18C]	QDP43510.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AQT27294.1	AQT27294.1 baseplate assembly protein V [Salmonella phage SEN8]	AQT27294.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC10463.1	URC10463.1 baseplate assembly protein [Escherichia phage vB_EcoM-813R9]	URC10463.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QKN87908.1	QKN87908.1 baseplate central spike [Acinetobacter phage vB_AbaP_Alexa]	QKN87908.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UPI11513.1	UPI11513.1 hypothetical protein BFNKNBEH_00023 [Yersinia phage VB-YPM-18]	UPI11513.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ56095.1	WOZ56095.1 hypothetical protein B476A_00015 [Yersinia phage vB_YpM_476A]	WOZ56095.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QKE55503.1	QKE55503.1 hypothetical protein vBYpM22_00018 [Yersinia phage vB_YpM_22]	QKE55503.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ56135.1	WOZ56135.1 hypothetical protein B476B_00015 [Yersinia phage vB_YpM_476B]	WOZ56135.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	VUD40176.1	VUD40176.1 Baseplate assembly protein V [Xuanwuvirus P884B11]	VUD40176.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WYC18384.1	WYC18384.1 baseplate assembly protein [Yersinia phage vB_YpM_MDG94-186]	WYC18384.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WXX18228.1	WXX18228.1 baseplate assembly protein [Yersinia phage GCS667]	WXX18228.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AIZ95143.1	AIZ95143.1 baseplate assembly protein V [Escherichia phage P88]	AIZ95143.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABY90377.1	ABY90377.1 putative baseplate assembly protein V [Halomonas phage phiHAP-1]	ABY90377.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ57131.1	WOZ57131.1 baseplate assembly protein [Citrobacter phage Shae_phiSM]	WOZ57131.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QYW06307.1	QYW06307.1 baseplate assembly protein V [Shewanella phage vB_SspM_M16-3]	QYW06307.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WNY35856.1	WNY35856.1 baseplate assembly protein [Vibrio phage Vb_VaM_Valp1]	WNY35856.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AWY03260.1	AWY03260.1 baseplate assembly protein [Pasteurella phage AFS-2018a]	AWY03260.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC09744.1	URC09744.1 baseplate assembly protein [Escherichia phage vB_EcoM-720R5]	URC09744.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC09440.1	URC09440.1 baseplate assembly protein [Escherichia phage vB_EcoM-569R10]	URC09440.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC10616.1	URC10616.1 baseplate assembly protein [Escherichia phage vB_EcoM-705R4]	URC10616.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC10682.1	URC10682.1 baseplate assembly protein [Escherichia phage vB_EcoM-783R5]	URC10682.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UOL51113.1	UOL51113.1 baseplate protein [Citrobacter phage Chris1]	UOL51113.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WID42126.1	WID42126.1 baseplate assembly protein V [Pseudomonas phage ZRG1]	WID42126.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP07905.1	QBP07905.1 baseplate assembly protein V [Klebsiella phage ST101-KPC2phi6.2]	QBP07905.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UZV40217.1	UZV40217.1 baseplate assembly protein V [Acidovorax phage Acica]	UZV40217.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AYD79801.1	AYD79801.1 hypothetical protein OGLPLLMI_00035 [Enterobacter phage phiT5282H]	AYD79801.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ55803.1	WOZ55803.1 hypothetical protein P39_00019 [Yersinia phage vB_YpM_39]	WOZ55803.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URE76660.1	URE76660.1 baseplate assembly protein V [Escherichia phage vB_EcoM-473R2]	URE76660.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	URC09218.1	URC09218.1 baseplate assembly protein V [Escherichia phage vB_EcoM-613R2]	URC09218.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ55873.1	WOZ55873.1 hypothetical protein P41_00019 [Yersinia phage vB_YpM_41]	WOZ55873.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WOZ55940.1	WOZ55940.1 hypothetical protein P44_00019 [Yersinia phage vB_YpM_44]	WOZ55940.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AWH14523.1	AWH14523.1 baseplate assembly protein V [Aeromonas phage 13AhydR10PP]	AWH14523.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ANZ52205.1	ANZ52205.1 putative baseplate assembly protein V [Aeromonas phage Ahp2]	ANZ52205.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ARB15649.1	ARB15649.1 baseplate assembly protein [Klebsiella phage 3LV2017]	ARB15649.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UGC97272.1	UGC97272.1 baseplate assembly protein [Aeromonas phage vB_AsaM_LPM4]	UGC97272.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	APU00832.1	APU00832.1 baseplate assembly protein V [Aeromonas phage 59.1]	APU00832.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AWH15321.1	AWH15321.1 baseplate assembly protein V [Aeromonas phage 14AhydR10PP]	AWH15321.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	APU01164.1	APU01164.1 baseplate assembly protein V [Aeromonas phage 32]	APU01164.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WDE69791.1	WDE69791.1 baseplate assembly protein V [Vibrio phage VPHZ6]	WDE69791.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QIZ02625.1	QIZ02625.1 baseplate assembly protein V [Aeromonas phage AhyVDH1]	QIZ02625.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	APU00412.1	APU00412.1 baseplate assembly protein V [Aeromonas phage 3]	APU00412.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AWH15051.1	AWH15051.1 baseplate assembly protein V [Aeromonas phage 85AhydR10PP]	AWH15051.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WEV89341.1	WEV89341.1 hypothetical protein H10PHJ05_40 [Aeromonas phage HJ05]	WEV89341.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNY40539.1	UNY40539.1 baseplate assembly protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40539.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABO60674.1	ABO60674.1 gp22 [Burkholderia phage phiE255]	ABO60674.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	APU00748.1	APU00748.1 baseplate assembly protein V [Aeromonas phage Asp37]	APU00748.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UNI73665.1	UNI73665.1 baseplate assembly protein V [Klebsiella phage KP12]	UNI73665.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QBP07950.1	QBP07950.1 baseplate assembly protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07950.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WKW83142.1	WKW83142.1 baseplate assembly protein [Campylobacter phage CAM-P21]	WKW83142.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AAS47887.1	AAS47887.1 gp48 [Burkholderia phage BcepMu]	AAS47887.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AUV56469.1	AUV56469.1 baseplate protein [Faecalibacterium phage FP_Epona]	AUV56469.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WAK43897.1	WAK43897.1 baseplate assembly protein V [Sulfurimonas phage SNW-1]	WAK43897.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QCW19925.1	QCW19925.1 baseplate assembly protein V [Vibrio phage Va_PF430-3_p42]	QCW19925.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75451.1	QHJ75451.1 hypothetical protein [Wolbachia phage WO]	QHJ75451.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75575.1	QHJ75575.1 hypothetical protein [Wolbachia phage WO]	QHJ75575.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WJZ70002.1	WJZ70002.1 baseplate assembly protein V [Vibrio phage PVP-XSN]	WJZ70002.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75452.1	QHJ75452.1 hypothetical protein [Wolbachia phage WO]	QHJ75452.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHJ75576.1	QHJ75576.1 hypothetical protein [Wolbachia phage WO]	QHJ75576.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	BAP94468.1	BAP94468.1 baseplate assembly protein [Aurantimonas phage AmM-1]	BAP94468.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UIU47142.1	UIU47142.1 baseplate assembly protein [Escherichia phage SKA49]	UIU47142.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEM43046.1	QEM43046.1 hypothetical protein AC4HA13_0071 [Escherichia phage vB_EcoM_4HA13]	QEM43046.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WWE96946.1	WWE96946.1 hypothetical protein [Escherichia phage FXie-2024a]	WWE96946.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ASD53985.1	ASD53985.1 baseplate assembly protein [Escherichia phage ST32]	ASD53985.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	UIU26878.1	UIU26878.1 baseplate assembly protein [Escherichia phage vB_EcoM_SA91KD]	UIU26878.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QHR68777.1	QHR68777.1 baseplate assembly protein [Escherichia phage flopper]	QHR68777.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ABR68778.1	ABR68778.1 putative baseplate assembly protein [Escherichia phage phiEcoM-GJ1]	ABR68778.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WPF71400.1	WPF71400.1 baseplate assembly protein [Escherichia phage vB_EcoM_JL1]	WPF71400.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WAX24589.1	WAX24589.1 baseplate assembly protein [Escherichia phage vB_EcoM_DE15]	WAX24589.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	ALN97532.1	ALN97532.1 baseplate assembly protein V [Aeromonas phage phiARM81ld]	ALN97532.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEG07874.1	QEG07874.1 baseplate assembly protein [Escherichia phage Mangalitsa]	QEG07874.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QCW19666.1	QCW19666.1 baseplate protein [Vibrio phage Va_90-11-286_p16]	QCW19666.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QDJ96644.1	QDJ96644.1 putative baseplate assembly protein [Escherichia phage vB_EcoP_Bp7]	QDJ96644.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QEM42527.1	QEM42527.1 putative baseplate assembly protein [Escherichia phage vB_EcoM_Bp10]	QEM42527.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	WWQ71685.1	WWQ71685.1 baseplate assembly protein V [Pseudomonas phage Bise]	WWQ71685.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	CBX44533.1	CBX44533.1 phage baseplate assembly protein V [Erwinia phage phiEt88]	CBX44533.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	QXM18746.1	QXM18746.1 baseplate assembly protein V [Vibrio phage ST2-1pr]	QXM18746.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AWN08650.1	AWN08650.1 putative baseplate assembly protein [Erwinia phage Faunus]	AWN08650.1	0
+ba35b834-0506-44d9-93d3-8f7a592681e4	AZV00459.1	AZV00459.1 baseplate assembly protein V [Paracoccus phage vB_PyeM_Pyei1]	AZV00459.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNY41678.1	UNY41678.1 baseplate assembly protein [Burkholderia phage Musica]	UNY41678.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNY41737.1	UNY41737.1 baseplate assembly protein [Burkholderia phage Milagro]	UNY41737.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNY41850.1	UNY41850.1 baseplate assembly protein [Burkholderia phage Momento]	UNY41850.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNY41794.1	UNY41794.1 baseplate assembly protein [Burkholderia phage Menos]	UNY41794.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADP02318.1	ADP02318.1 gp25 [Burkholderia phage KL3]	ADP02318.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABO60746.1	ABO60746.1 gp34, phage baseplate assembly protein [Burkholderia phage phiE202]	ABO60746.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QWY84965.1	QWY84965.1 baseplate assembly protein [Burkholderia phage PK23]	QWY84965.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WWY66161.1	WWY66161.1 baseplate assembly protein [Burkholderia phage vB_HM387]	WWY66161.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABO60797.1	ABO60797.1 gp37, bacteriophage baseplate assembly protein J [Burkholderia phage phiE12-2]	ABO60797.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAZ72628.1	AAZ72628.1 bacteriophage baseplate assembly protein J [Burkholderia phage phiE52237]	AAZ72628.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QPI18558.1	QPI18558.1 baseplate assembly J-like protein [Burkholderia phage phiE094]	QPI18558.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AFV51413.1	AFV51413.1 J baseplate assembly protein [Burkholderia phage phiX216]	AFV51413.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UPI15577.1	UPI15577.1 baseplate assembly protein [Burkholderia phage PhiBP82.3]	UPI15577.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UKM53783.1	UKM53783.1 baseplate assembly protein [Burkholderia phage PhiBP82.2]	UKM53783.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AKA61144.1	AKA61144.1 putative baseplate assembly protein [Burkholderia phage AP3]	AKA61144.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	USM11625.1	USM11625.1 baseplate wedge protein [Burkholderia phage Carl1]	USM11625.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADP02272.1	ADP02272.1 gp25 [Burkholderia phage KS5]	ADP02272.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QPB09413.1	QPB09413.1 baseplate protein [Burkholderia phage Mana]	QPB09413.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AIP84307.1	AIP84307.1 baseplate J-like family protein [Burkholderia phage BEK]	AIP84307.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BCB23198.1	BCB23198.1 baseplate assembly protein (J) [Burkholderia phage FLC5]	BCB23198.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADP02365.1	ADP02365.1 gp20 [Burkholderia phage KS14]	ADP02365.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BDD79932.1	BDD79932.1 hypothetical protein [Burkholderia phage FLC10]	BDD79932.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AGK86792.1	AGK86792.1 phage baseplate assembly protein J [Burkholderia phage ST79]	AGK86792.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AVP40015.1	AVP40015.1 baseplate assembly protein [Ralstonia phage RsoM1USA]	AVP40015.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AZF87859.1	AZF87859.1 baseplate assembly protein [Pseudomonas phage Dobby]	AZF87859.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNA05877.1	UNA05877.1 baseplate assembly protein [Yersinia phage vB_YenM_06.16-2]	UNA05877.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UKL54259.1	UKL54259.1 baseplate assembly protein [Yersinia phage vB_YenM_31.17]	UKL54259.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNA05978.1	UNA05978.1 baseplate assembly protein [Yersinia phage vB_YenM_201.16]	UNA05978.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAP28124.1	BAP28124.1 hypothetical protein [Ralstonia phage RSY1]	BAP28124.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNA05926.1	UNA05926.1 baseplate assembly protein [Yersinia phage vB_YenM_56.17]	UNA05926.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WPJ21699.1	WPJ21699.1 baseplate J-like protein [Bacillus phage vB_BpuM-ZY1]	WPJ21699.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADX32416.1	ADX32416.1 baseplate assembly protein [Erwinia phage ENT90]	ADX32416.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNI73719.1	UNI73719.1 baseplate assembly protein [Klebsiella phage KP12]	UNI73719.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ARB15698.1	ARB15698.1 baseplate assembly protein [Klebsiella phage 4LV2017]	ARB15698.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ASD51169.1	ASD51169.1 baseplate assembly protein [Erwinia phage EtG]	ASD51169.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URE76607.1	URE76607.1 baseplate assembly protein [Escherichia phage vB_EcoM-613R3]	URE76607.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBQ71561.1	QBQ71561.1 baseplate assembly protein J [Klebsiella phage ST147-VIM1phi7.1]	QBQ71561.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAF52398.1	BAF52398.1 baseplate J-like protein [Ralstonia phage RSA1]	BAF52398.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAH1234701.1	CAH1234701.1 baseplate J protein [Escherichia phage Cartapus]	CAH1234701.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC10461.1	URC10461.1 baseplate assembly protein [Escherichia phage vB_EcoM-813R9]	URC10461.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AQT27296.1	AQT27296.1 baseplate assembly protein J [Salmonella phage SEN8]	AQT27296.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WPJ53100.1	WPJ53100.1 hypothetical protein RCIP0057_00027 [Klebsiella phage RCIP0057]	WPJ53100.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AGF88429.1	AGF88429.1 baseplate assembly protein [Salmonella phage FSLSP004]	AGF88429.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADQ92405.1	ADQ92405.1 baseplate assembly protein J [Salmonella phage RE2010]	ADQ92405.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WYC18455.1	WYC18455.1 baseplate assembly protein [Yersinia phage vB_YpM_MHG38]	WYC18455.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WYC18386.1	WYC18386.1 baseplate assembly protein [Yersinia phage vB_YpM_MDG94-186]	WYC18386.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WXX18226.1	WXX18226.1 baseplate assembly protein [Yersinia phage GCS667]	WXX18226.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WYC18413.1	WYC18413.1 baseplate assembly protein [Yersinia phage vB_YpM_MDG45]	WYC18413.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WFG40961.1	WFG40961.1 baseplate protein [Salmonella phage MET_P1_103_31]	WFG40961.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QYC52675.1	QYC52675.1 baseplate assembly protein [Salmonella phage BIS20]	QYC52675.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UTC25936.1	UTC25936.1 baseplate assembly protein [Salmonella phage vB_Sal_PHB48]	UTC25936.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAP04453.1	AAP04453.1 gpJ [Yersinia phage L-413C]	AAP04453.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAN08379.1	AAN08379.1 gp17 [Salmonella phage PSP3]	AAN08379.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC09837.1	URC09837.1 baseplate assembly protein [Escherichia phage vB_EcoM-720R8]	URC09837.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAC34162.1	AAC34162.1 baseplate [Escherichia phage 186]	AAC34162.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	API82952.1	API82952.1 Baseplate J-like protein [Salmonella phage STYP1]	API82952.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AKH49389.1	AKH49389.1 baseplate assembly protein J [Escherichia phage pro483]	AKH49389.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AGG36533.1	AGG36533.1 baseplate assembly protein J [Escherichia phage P2]	AGG36533.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QDP43512.1	QDP43512.1 baseplate assembly protein J [Bacteriophage R18C]	QDP43512.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AKH49329.1	AKH49329.1 baseplate assembly protein J [Escherichia phage pro147]	AKH49329.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD38022.1	VUD38022.1 Baseplate assembly protein J [Peduovirus P24B2]	VUD38022.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAN28235.1	AAN28235.1 gpJ [Escherichia phage Wphi]	AAN28235.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QIW90049.1	QIW90049.1 baseplate assembly protein [Yersinia phage P37]	QIW90049.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ56006.1	WOZ56006.1 hypothetical protein B115_00018 [Yersinia phage vB_YpM_115]	WOZ56006.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ56052.1	WOZ56052.1 hypothetical protein B117_00018 [Yersinia phage vB_YpM_117]	WOZ56052.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAG9593787.1	CAG9593787.1 hypothetical protein P2SIAC10_00026 [Peduovirus P2]	CAG9593787.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	APC62527.1	APC62527.1 baseplate assembly protein [Salmonella phage SEN1]	APC62527.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ULG01121.1	ULG01121.1 baseplate assembly protein [Escherichia phage 10W]	ULG01121.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ULG00880.1	ULG00880.1 baseplate assembly protein [Escherichia phage 11W]	ULG00880.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD39523.1	VUD39523.1 Baseplate assembly protein J [Peduovirus P24C9]	VUD39523.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD37978.1	VUD37978.1 Baseplate assembly protein J [Peduovirus P22H1]	VUD37978.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ULG00996.1	ULG00996.1 baseplate assembly protein [Escherichia phage 9W]	ULG00996.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAG9593870.1	CAG9593870.1 hypothetical protein P2SIDE7_00024 [Peduovirus P2]	CAG9593870.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD37935.1	VUD37935.1 Baseplate assembly protein J [Peduovirus P22H4]	VUD37935.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UPI11515.1	UPI11515.1 hypothetical protein BFNKNBEH_00025 [Yersinia phage VB-YPM-18]	UPI11515.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ56097.1	WOZ56097.1 hypothetical protein B476A_00017 [Yersinia phage vB_YpM_476A]	WOZ56097.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ULG00694.1	ULG00694.1 baseplate assembly protein [Escherichia phage D8]	ULG00694.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD38892.1	VUD38892.1 Baseplate assembly protein J [Peduovirus P24E6b]	VUD38892.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QKE55505.1	QKE55505.1 hypothetical protein vBYpM22_00020 [Yersinia phage vB_YpM_22]	QKE55505.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QXF95283.1	QXF95283.1 baseplate assembly protein [Yersinia phage HQ103]	QXF95283.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ56137.1	WOZ56137.1 hypothetical protein B476B_00017 [Yersinia phage vB_YpM_476B]	WOZ56137.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ULG01154.1	ULG01154.1 baseplate assembly protein [Escherichia phage 12W]	ULG01154.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AGX84568.1	AGX84568.1 baseplate assembly [Enterobacteria phage fiAA91-ss]	AGX84568.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URP83677.1	URP83677.1 baseplate assembly protein [Escherichia phage S164]	URP83677.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QKE55641.1	QKE55641.1 hypothetical protein vBYpM50_00020 [Yersinia phage vB_YpM_50]	QKE55641.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AFJ75489.1	AFJ75489.1 baseplate assembly protein [Stenotrophomonas phage Smp131]	AFJ75489.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC09629.1	URC09629.1 baseplate assembly protein [Escherichia phage vB_EcoM-569R9]	URC09629.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QEI25356.1	QEI25356.1 baseplate assembly protein [Salmonella phage SI22]	QEI25356.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QEI25401.1	QEI25401.1 baseplate assembly protein [Salmonella phage SW9]	QEI25401.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC10106.1	URC10106.1 baseplate assembly protein [Escherichia phage vB_EcoM-640R3]	URC10106.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAG9593822.1	CAG9593822.1 hypothetical protein P2DC1_00018 [Peduovirus P2]	CAG9593822.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ALF02305.1	ALF02305.1 baseplate assembly protein J [Salmonella phage SEN4]	ALF02305.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ALF02354.1	ALF02354.1 baseplate assembly protein J [Salmonella phage SEN5]	ALF02354.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QDJ98454.1	QDJ98454.1 hypothetical protein LLFFHNDI_00027 [Escherichia phage vB_EcoM-12474II]	QDJ98454.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QDJ98586.1	QDJ98586.1 hypothetical protein OMJLAAIH_00027 [Escherichia phage vB_EcoM-12474V]	QDJ98586.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QDJ98542.1	QDJ98542.1 hypothetical protein PBINGOGM_00027 [Escherichia phage vB_EcoM-12474IV]	QDJ98542.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QDJ98501.1	QDJ98501.1 hypothetical protein BBAMJIOM_00030 [Escherichia phage vB_EcoM-12474III]	QDJ98501.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAD03284.1	AAD03284.1 gpJ [Bacteriophage P2]	AAD03284.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UPI11466.1	UPI11466.1 hypothetical protein COILCCMC_00018 [Yersinia phage VB-YPM-4]	UPI11466.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QKE55598.1	QKE55598.1 hypothetical protein vBYpM46_00018 [Yersinia phage vB_YpM_46]	QKE55598.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAH0786510.1	CAH0786510.1 hypothetical protein P2AC1_00025 [Escherichia phage P2_AC1]	CAH0786510.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABD90621.1	ABD90621.1 baseplate assembly protein J [Mannheimia phage phiMhaA1-BAA410]	ABD90621.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABD90572.1	ABD90572.1 baseplate assembly protein J [Mannheimia phage PHL101]	ABD90572.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AJA73124.1	AJA73124.1 baseplate assembly protein J [Mannheimia phage vB_MhM_2256AP1]	AJA73124.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AFL46467.1	AFL46467.1 baseplate assembly protein J [Mannheimia phage vB_MhM_1152AP]	AFL46467.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD39034.1	VUD39034.1 Baseplate assembly protein J [Peduovirus P24A7b]	VUD39034.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AJA72892.1	AJA72892.1 baseplate assembly protein J [Mannheimia phage vB_MhM_535AP1]	AJA72892.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAA36245.1	BAA36245.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36245.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNA05756.1	UNA05756.1 baseplate assembly protein [Yersinia phage vB_YenM_42.18]	UNA05756.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WID42130.1	WID42130.1 baseplate J family protein [Pseudomonas phage ZRG1]	WID42130.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP08030.1	QBP08030.1 baseplate assembly protein J [Klebsiella phage ST437-OXA245phi4.1]	QBP08030.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27758.1	QBP27758.1 baseplate assembly protein J [Klebsiella phage ST512-KPC3phi13.6]	QBP27758.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27911.1	QBP27911.1 baseplate assembly protein J [Klebsiella phage ST258-KPC3phi16.1]	QBP27911.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WWQ72102.1	WWQ72102.1 baseplate assembly protein [Pseudomonas phage Sirocco]	WWQ72102.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBI84126.1	QBI84126.1 baseplate assembly protein J [Pseudomonas phage vB_Pae_BR319a]	QBI84126.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27433.1	QBP27433.1 baseplate assembly protein J [Klebsiella phage ST512-KPC3phi13.2]	QBP27433.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP07809.1	QBP07809.1 baseplate assembly protein J [Klebsiella phage ST11-VIM1phi8.4]	QBP07809.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27867.1	QBP27867.1 baseplate assembly protein J [Klebsiella phage ST11-OXA48phi15.3]	QBP27867.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP08099.1	QBP08099.1 baseplate assembly protein J [Klebsiella phage ST11-OXA245phi3.1]	QBP08099.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27672.1	QBP27672.1 baseplate assembly protein J [Klebsiella phage ST340-VIM1phi10.2]	QBP27672.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27964.1	QBP27964.1 baseplate assembly protein J [Klebsiella phage ST258-KPC3phi16.2]	QBP27964.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP27609.1	QBP27609.1 baseplate assembly protein J [Klebsiella phage ST13-OXA48phi12.1]	QBP27609.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AJA72943.1	AJA72943.1 baseplate assembly protein J [Mannheimia phage vB_MhM_587AP1]	AJA72943.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AJA73071.1	AJA73071.1 baseplate assembly protein J [Mannheimia phage vB_MhM_1127AP1]	AJA73071.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBQ72009.1	QBQ72009.1 baseplate assembly protein J [Klebsiella phage ST15-OXA48phi14.1]	QBQ72009.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QMP19176.1	QMP19176.1 baseplate J protein [Pseudomonas phage Persinger]	QMP19176.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UGC97270.1	UGC97270.1 baseplate assembly protein [Aeromonas phage vB_AsaM_LPM4]	UGC97270.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QOE32745.1	QOE32745.1 baseplate wedge protein [Achromobacter phage Mano]	QOE32745.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP07903.1	QBP07903.1 baseplate assembly protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07903.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AIM50565.1	AIM50565.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50565.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ARM70449.1	ARM70449.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70449.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ARB15651.1	ARB15651.1 baseplate assembly protein J [Klebsiella phage 3LV2017]	ARB15651.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ57129.1	WOZ57129.1 baseplate J family protein [Citrobacter phage Shae_phiSM]	WOZ57129.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ANN86121.1	ANN86121.1 putative baseplate J-like protein [Enterobacter phage Arya]	ANN86121.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUD40178.1	VUD40178.1 Baseplate assembly protein J [Xuanwuvirus P884B11]	VUD40178.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADE87924.1	ADE87924.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87924.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AIZ95145.1	AIZ95145.1 baseplate assembly protein J [Escherichia phage P88]	AIZ95145.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAO20613.1	BAO20613.1 putative baseplate J-like protein [Pseudomonas phage PPpW-3]	BAO20613.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WNY35852.1	WNY35852.1 baseplate protein [Vibrio phage Vb_VaM_Valp1]	WNY35852.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WNL50851.1	WNL50851.1 baseplate protein J [Xanthomonas phage Murka]	WNL50851.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QJB21916.1	QJB21916.1 baseplate assembly protein [Xanthomonas phage FoX3]	QJB21916.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QWY14228.1	QWY14228.1 baseplate assembly protein [Xanthomonas phage M29]	QWY14228.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QJB21994.1	QJB21994.1 baseplate assembly protein [Xanthomonas phage FoX5]	QJB21994.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QJB21754.1	QJB21754.1 baseplate assembly protein [Xanthomonas phage FoX1]	QJB21754.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QYW06305.1	QYW06305.1 baseplate assembly protein J [Shewanella phage vB_SspM_M16-3]	QYW06305.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QJB21835.1	QJB21835.1 baseplate assembly protein [Xanthomonas phage FoX2]	QJB21835.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	USZ80542.1	USZ80542.1 baseplate assembly protein [Serratia phage MQ-4]	USZ80542.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QIG65662.1	QIG65662.1 baseplate assembly protein [Salmonella phage PT1]	QIG65662.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AXF38223.1	AXF38223.1 putative baseplate J-like protein [Ralstonia phage phiRSP]	AXF38223.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AFV81353.1	AFV81353.1 baseplate assembly protein [Vibrio phage vB_VpaM_MAR]	AFV81353.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	CAX64995.1	CAX64995.1 gp14 protein [Vibrio phage VP585]	CAX64995.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAN12332.1	AAN12332.1 ORF32 [Vibrio phage VHML]	AAN12332.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AYD79803.1	AYD79803.1 hypothetical protein OGLPLLMI_00037 [Enterobacter phage phiT5282H]	AYD79803.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QPB08625.1	QPB08625.1 baseplate protein [Burkholderia phage Mica]	QPB08625.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QKN87910.1	QKN87910.1 baseplate protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87910.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBP07952.1	QBP07952.1 baseplate assembly protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07952.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QXN68742.1	QXN68742.1 baseplate assembly protein J [Hafnia phage yong2]	QXN68742.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UOL51122.1	UOL51122.1 hypothetical protein [Citrobacter phage Chris1]	UOL51122.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AZV00462.1	AZV00462.1 baseplate assembly protein J [Paracoccus phage vB_PyeM_Pyei1]	AZV00462.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WDE69794.1	WDE69794.1 baseplate J [Vibrio phage VPHZ6]	WDE69794.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC09742.1	URC09742.1 baseplate assembly protein J [Escherichia phage vB_EcoM-720R5]	URC09742.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC09438.1	URC09438.1 baseplate assembly protein J [Escherichia phage vB_EcoM-569R10]	URC09438.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC10614.1	URC10614.1 baseplate assembly protein J [Escherichia phage vB_EcoM-705R4]	URC10614.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC10680.1	URC10680.1 baseplate assembly protein J [Escherichia phage vB_EcoM-783R5]	URC10680.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WWY66196.1	WWY66196.1 putative baseplate assembly protein [Burkholderia phage vB_HM795]	WWY66196.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AWH15049.1	AWH15049.1 baseplate assembly protein I [Aeromonas phage 85AhydR10PP]	AWH15049.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AWH15323.1	AWH15323.1 baseplate assembly protein J [Aeromonas phage 14AhydR10PP]	AWH15323.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	APU01166.1	APU01166.1 baseplate assembly protein J [Aeromonas phage 32]	APU01166.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	APU00414.1	APU00414.1 baseplate assembly protein J [Aeromonas phage 3]	APU00414.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AWH14525.1	AWH14525.1 baseplate assembly protein [Aeromonas phage 13AhydR10PP]	AWH14525.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ANZ52207.1	ANZ52207.1 putative baseplate assembly protein [Aeromonas phage Ahp2]	ANZ52207.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	APU00750.1	APU00750.1 baseplate assembly protein J [Aeromonas phage Asp37]	APU00750.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ARQ95338.1	ARQ95338.1 baseplate assembly protein J [Bradyrhizobium phage BDU-MI-1]	ARQ95338.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QIZ02627.1	QIZ02627.1 putative baseplate assembly protein [Aeromonas phage AhyVDH1]	QIZ02627.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QEA09562.1	QEA09562.1 putative baseplate assembly protein [Wolbachia phage WO]	QEA09562.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHJ75384.1	QHJ75384.1 baseplate assembly protein J [Wolbachia phage WO]	QHJ75384.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	APU00835.1	APU00835.1 baseplate assembly protein [Aeromonas phage 59.1]	APU00835.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABY90379.1	ABY90379.1 putative baseplate assembly protein J [Halomonas phage phiHAP-1]	ABY90379.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHJ75448.1	QHJ75448.1 baseplate assembly protein J [Wolbachia phage WO]	QHJ75448.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHJ75572.1	QHJ75572.1 baseplate assembly protein J [Wolbachia phage WO]	QHJ75572.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WEV89344.1	WEV89344.1 hypothetical protein H10PHJ05_43 [Aeromonas phage HJ05]	WEV89344.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAD16796.1	BAD16796.1 similar to GPJ of phage P2 [Wolbachia phage WOcauB1]	BAD16796.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHJ75403.1	QHJ75403.1 baseplate assembly protein J [Wolbachia phage WO]	QHJ75403.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QXF95183.1	QXF95183.1 baseplate assembly protein J [Wolbachia phage WO]	QXF95183.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHJ75559.1	QHJ75559.1 baseplate assembly protein J [Wolbachia phage WO]	QHJ75559.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAA89651.1	BAA89651.1 gp26 [Wolbachia phage WO]	BAA89651.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AFU62890.1	AFU62890.1 phage baseplate assembly protein gpJ [Acidithiobacillus phage AcaML1]	AFU62890.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADW80192.1	ADW80192.1 baseplate J [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80192.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ADW80133.1	ADW80133.1 baseplate J [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80133.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AOA49537.1	AOA49537.1 baseplate J-like family protein [Wolbachia phage WO]	AOA49537.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAS38500.1	AAS38500.1 putative baseplate assembly protein [Vibrio phage VP882]	AAS38500.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AOT25323.1	AOT25323.1 baseplate protein [Ochrobactrum phage POA1180]	AOT25323.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UYL85516.1	UYL85516.1 baseplate J family protein [Acidovorax phage Alfacinha1]	UYL85516.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UYL85415.1	UYL85415.1 baseplate J family protein [Acidovorax phage Alfacinha3]	UYL85415.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QXM18743.1	QXM18743.1 baseplate J protein [Vibrio phage ST2-1pr]	QXM18743.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ALN97534.1	ALN97534.1 baseplate assembly J-like protein [Aeromonas phage phiARM81ld]	ALN97534.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AHN84838.1	AHN84838.1 baseplate [Vibrio phage phi 2]	AHN84838.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AIA10321.1	AIA10321.1 baseplate J-like protein [Vibrio phage X29]	AIA10321.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QBJ01024.1	QBJ01024.1 baseplate protein [Vibrio phage Rostov 7]	QBJ01024.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UZV40219.1	UZV40219.1 baseplate J family protein [Acidovorax phage Acica]	UZV40219.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AYP68511.1	AYP68511.1 baseplate assembly protein [Exiguobacterium phage vB_EalM-137]	AYP68511.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AAS47889.1	AAS47889.1 gp50 [Burkholderia phage BcepMu]	AAS47889.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AUV56786.1	AUV56786.1 baseplate J protein [Faecalibacterium phage FP_Toutatis]	AUV56786.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	ABO60694.1	ABO60694.1 gp24, conserved hypothetical protein [Burkholderia phage phiE255]	ABO60694.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNI73663.1	UNI73663.1 baseplate assembly protein J [Klebsiella phage KP12]	UNI73663.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AWY03262.1	AWY03262.1 baseplate protein [Pasteurella phage AFS-2018a]	AWY03262.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UTV61033.1	UTV61033.1 baseplate assembly protein [Fusobacterium phage JD-Fnp2]	UTV61033.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UTV61175.1	UTV61175.1 baseplate assembly protein [Fusobacterium phage JD-Fnp5]	UTV61175.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UTV61093.1	UTV61093.1 baseplate assembly protein [Fusobacterium phage JD-Fnp3]	UTV61093.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AUV56472.1	AUV56472.1 baseplate P2 J-like protein [Faecalibacterium phage FP_Epona]	AUV56472.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WJZ70005.1	WJZ70005.1 baseplate protein [Vibrio phage PVP-XSN]	WJZ70005.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QCW19927.1	QCW19927.1 baseplate J protein [Vibrio phage Va_PF430-3_p42]	QCW19927.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QCW19668.1	QCW19668.1 baseplate J protein [Vibrio phage Va_90-11-286_p16]	QCW19668.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WWQ71687.1	WWQ71687.1 baseplate assembly J family protein [Pseudomonas phage Bise]	WWQ71687.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AKC57550.1	AKC57550.1 baseplate J-like protein [Fusobacterium phage Funu1]	AKC57550.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URE76663.1	URE76663.1 baseplate assembly protein J [Escherichia phage vB_EcoM-473R2]	URE76663.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	URC09215.1	URC09215.1 baseplate assembly protein J [Escherichia phage vB_EcoM-613R2]	URC09215.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ55806.1	WOZ55806.1 hypothetical protein P39_00022 [Yersinia phage vB_YpM_39]	WOZ55806.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ55876.1	WOZ55876.1 hypothetical protein P41_00022 [Yersinia phage vB_YpM_41]	WOZ55876.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WOZ55943.1	WOZ55943.1 hypothetical protein P44_00022 [Yersinia phage vB_YpM_44]	WOZ55943.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QVQ56205.1	QVQ56205.1 baseplate J protein [Paenibacillus phage Pd_22F]	QVQ56205.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	QHZ54124.1	QHZ54124.1 baseplate assembly protein [Paenibacillus phage phiERICV]	QHZ54124.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	UNY40529.1	UNY40529.1 baseplate J-like protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40529.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	VUE37410.1	VUE37410.1 Baseplate J family protein [Roseburia phage Shimadzu]	VUE37410.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WNA15516.1	WNA15516.1 baseplate protein J [Acinetobacter phage HFM1]	WNA15516.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WAK79552.1	WAK79552.1 baseplate protein [Clostridium phage Saumur]	WAK79552.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WAK43895.1	WAK43895.1 baseplate protein J [Sulfurimonas phage SNW-1]	WAK43895.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WAK43895.1	WAK43895.1 baseplate protein J [Sulfurimonas phage SNW-1]	WAK43895.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AJK27747.1	AJK27747.1 baseplate protein [Bacteriophage Lily]	AJK27747.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WKW83145.1	WKW83145.1 baseplate assembly protein [Campylobacter phage CAM-P21]	WKW83145.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WKW83145.1	WKW83145.1 baseplate assembly protein [Campylobacter phage CAM-P21]	WKW83145.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	BAP94472.1	BAP94472.1 baseplate assembly protein [Aurantimonas phage AmM-1]	BAP94472.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AUR88216.1	AUR88216.1 hypothetical protein NVP1111A_22 [Vibrio phage 1.111.A._10N.286.45.E6]	AUR88216.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	AUR88278.1	AUR88278.1 hypothetical protein NVP1111B_22 [Vibrio phage 1.111.B._10N.286.45.E6]	AUR88278.1	0
+608ab459-7d95-4ea2-bc25-8f0e79efe27e	WRQ07999.1	WRQ07999.1 hypothetical protein [Phage nd4]	WRQ07999.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNY41736.1	UNY41736.1 baseplate wedge subunit [Burkholderia phage Milagro]	UNY41736.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNY41677.1	UNY41677.1 baseplate wedge subunit [Burkholderia phage Musica]	UNY41677.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADP02319.1	ADP02319.1 gp26 [Burkholderia phage KL3]	ADP02319.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNY41793.1	UNY41793.1 baseplate wedge subunit [Burkholderia phage Menos]	UNY41793.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNY41849.1	UNY41849.1 baseplate wedge subunit [Burkholderia phage Momento]	UNY41849.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QWY84964.1	QWY84964.1 baseplate assembly protein [Burkholderia phage PK23]	QWY84964.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAZ72629.1	AAZ72629.1 phage baseplate assembly protein [Burkholderia phage phiE52237]	AAZ72629.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UPI15576.1	UPI15576.1 baseplate assembly protein [Burkholderia phage PhiBP82.3]	UPI15576.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QPI18557.1	QPI18557.1 baseplate assembly W-like protein [Burkholderia phage phiE094]	QPI18557.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UKM53782.1	UKM53782.1 baseplate assembly protein [Burkholderia phage PhiBP82.2]	UKM53782.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AIP84302.1	AIP84302.1 lysozyme family protein [Burkholderia phage BEK]	AIP84302.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AFV51412.1	AFV51412.1 W baseplate wedge protein [Burkholderia phage phiX216]	AFV51412.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ABO60729.1	ABO60729.1 gp35, phage baseplate assembly protein [Burkholderia phage phiE202]	ABO60729.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ABO60767.1	ABO60767.1 gp38, phage baseplate assembly protein [Burkholderia phage phiE12-2]	ABO60767.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WWY66160.1	WWY66160.1 baseplate wedge subunit [Burkholderia phage vB_HM387]	WWY66160.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BDD79931.1	BDD79931.1 hypothetical protein [Burkholderia phage FLC10]	BDD79931.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADP02366.1	ADP02366.1 gp21 [Burkholderia phage KS14]	ADP02366.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BCB23199.1	BCB23199.1 baseplate assembly protein (W) [Burkholderia phage FLC5]	BCB23199.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBI84125.1	QBI84125.1 baseplate assembly protein [Pseudomonas phage vB_Pae_BR319a]	QBI84125.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAA36244.1	BAA36244.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36244.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AZF87858.1	AZF87858.1 baseplate assembly protein [Pseudomonas phage Dobby]	AZF87858.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WWQ72101.1	WWQ72101.1 baseplate wedge protein [Pseudomonas phage Sirocco]	WWQ72101.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AGK86791.1	AGK86791.1 phage baseplate assembly protein W [Burkholderia phage ST79]	AGK86791.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AVP40013.1	AVP40013.1 baseplate assembly protein [Ralstonia phage RsoM1USA]	AVP40013.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAP28123.1	BAP28123.1 hypothetical protein [Ralstonia phage RSY1]	BAP28123.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AFV81352.1	AFV81352.1 baseplate assembly protein [Vibrio phage vB_VpaM_MAR]	AFV81352.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QXN68741.1	QXN68741.1 baseplate wedge protein [Hafnia phage yong2]	QXN68741.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAX64994.1	CAX64994.1 gp13 protein [Vibrio phage VP585]	CAX64994.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAN12331.1	AAN12331.1 ORF31 [Vibrio phage VHML]	AAN12331.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAF52397.1	BAF52397.1 gpW/gp25 family protein [Ralstonia phage RSA1]	BAF52397.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WNL50850.1	WNL50850.1 baseplate protein W [Xanthomonas phage Murka]	WNL50850.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNA05925.1	UNA05925.1 baseplate assembly protein [Yersinia phage vB_YenM_56.17]	UNA05925.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBQ71560.1	QBQ71560.1 baseplate assembly protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71560.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	USZ80541.1	USZ80541.1 baseplate assembly protein [Serratia phage MQ-4]	USZ80541.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AXF38222.1	AXF38222.1 putative tail protein [Ralstonia phage phiRSP]	AXF38222.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNA05755.1	UNA05755.1 baseplate assembly protein [Yersinia phage vB_YenM_42.18]	UNA05755.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UKL54258.1	UKL54258.1 baseplate assembly protein [Yersinia phage vB_YenM_31.17]	UKL54258.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AFJ75494.1	AFJ75494.1 baseplate assembly protein [Stenotrophomonas phage Smp131]	AFJ75494.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNA05876.1	UNA05876.1 baseplate assembly protein [Yersinia phage vB_YenM_06.16-2]	UNA05876.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QJB21993.1	QJB21993.1 baseplate assembly protein [Xanthomonas phage FoX5]	QJB21993.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QJB21915.1	QJB21915.1 baseplate assembly protein [Xanthomonas phage FoX3]	QJB21915.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QJB21834.1	QJB21834.1 baseplate assembly protein [Xanthomonas phage FoX2]	QJB21834.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QJB21753.1	QJB21753.1 baseplate assembly protein [Xanthomonas phage FoX1]	QJB21753.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QWY14254.1	QWY14254.1 baseplate assembly protein [Xanthomonas phage M29]	QWY14254.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UGC97271.1	UGC97271.1 baseplate assembly protein [Aeromonas phage vB_AsaM_LPM4]	UGC97271.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WPJ21698.1	WPJ21698.1 baseplate assembly protein [Bacillus phage vB_BpuM-ZY1]	WPJ21698.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QPB09412.1	QPB09412.1 baseplate protein [Burkholderia phage Mana]	QPB09412.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNA05977.1	UNA05977.1 baseplate assembly protein [Yersinia phage vB_YenM_201.16]	UNA05977.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QOE32744.1	QOE32744.1 baseplate protein [Achromobacter phage Mano]	QOE32744.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ANN86120.1	ANN86120.1 putative baseplate assembly protein W [Enterobacter phage Arya]	ANN86120.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAO20612.1	BAO20612.1 putative baseplate assembly protein with lysozyme [Pseudomonas phage PPpW-3]	BAO20612.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QHJ75558.1	QHJ75558.1 baseplate assembly protein [Wolbachia phage WO]	QHJ75558.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADX32447.1	ADX32447.1 baseplate assembly protein [Erwinia phage ENT90]	ADX32447.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WNY35853.1	WNY35853.1 baseplate protein [Vibrio phage Vb_VaM_Valp1]	WNY35853.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ULG00693.1	ULG00693.1 baseplate assembly protein [Escherichia phage D8]	ULG00693.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD39033.1	VUD39033.1 Phage baseplate assembly protein [Peduovirus P24A7b]	VUD39033.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD38889.1	VUD38889.1 Phage baseplate assembly protein [Peduovirus P24E6b]	VUD38889.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ULG01153.1	ULG01153.1 baseplate assembly protein [Escherichia phage 12W]	ULG01153.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADE87925.1	ADE87925.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87925.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC10105.1	URC10105.1 baseplate assembly protein [Escherichia phage vB_EcoM-640R3]	URC10105.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AIM50564.1	AIM50564.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50564.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ARM70450.1	ARM70450.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70450.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC09838.1	URC09838.1 baseplate assembly protein [Escherichia phage vB_EcoM-720R8]	URC09838.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UPI11465.1	UPI11465.1 hypothetical protein COILCCMC_00017 [Yersinia phage VB-YPM-4]	UPI11465.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AKH49388.1	AKH49388.1 baseplate assembly protein W [Escherichia phage pro483]	AKH49388.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QKE55597.1	QKE55597.1 hypothetical protein vBYpM46_00017 [Yersinia phage vB_YpM_46]	QKE55597.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAG9593821.1	CAG9593821.1 hypothetical protein P2DC1_00017 [Peduovirus P2]	CAG9593821.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QXF95282.1	QXF95282.1 baseplate assembly protein [Yersinia phage HQ103]	QXF95282.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AGX84578.1	AGX84578.1 putative baseplate protein [Enterobacteria phage fiAA91-ss]	AGX84578.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QPB08624.1	QPB08624.1 baseplate wedge protein [Burkholderia phage Mica]	QPB08624.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WOZ56005.1	WOZ56005.1 hypothetical protein B115_00017 [Yersinia phage vB_YpM_115]	WOZ56005.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WOZ56051.1	WOZ56051.1 hypothetical protein B117_00017 [Yersinia phage vB_YpM_117]	WOZ56051.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIW90050.1	QIW90050.1 baseplate assembly protein [Yersinia phage P37]	QIW90050.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAG9593871.1	CAG9593871.1 hypothetical protein P2SIDE7_00025 [Peduovirus P2]	CAG9593871.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD37977.1	VUD37977.1 Phage baseplate assembly protein [Peduovirus P22H1]	VUD37977.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QDJ98455.1	QDJ98455.1 hypothetical protein LLFFHNDI_00028 [Escherichia phage vB_EcoM-12474II]	QDJ98455.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ULG00995.1	ULG00995.1 baseplate assembly protein [Escherichia phage 9W]	ULG00995.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD37934.1	VUD37934.1 Phage baseplate assembly protein W [Peduovirus P22H4]	VUD37934.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QDJ98587.1	QDJ98587.1 hypothetical protein OMJLAAIH_00028 [Escherichia phage vB_EcoM-12474V]	QDJ98587.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QDJ98543.1	QDJ98543.1 hypothetical protein PBINGOGM_00028 [Escherichia phage vB_EcoM-12474IV]	QDJ98543.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QDJ98502.1	QDJ98502.1 hypothetical protein BBAMJIOM_00031 [Escherichia phage vB_EcoM-12474III]	QDJ98502.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QHJ75402.1	QHJ75402.1 baseplate assembly protein [Wolbachia phage WO]	QHJ75402.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	API82951.1	API82951.1 Gene 25-like lysozyme [Salmonella phage STYP1]	API82951.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAH0786511.1	CAH0786511.1 hypothetical protein P2AC1_00026 [Escherichia phage P2_AC1]	CAH0786511.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QKN87909.1	QKN87909.1 tail tube intiator [Acinetobacter phage vB_AbaP_Alexa]	QKN87909.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UOL51121.1	UOL51121.1 baseplate assembly protein [Citrobacter phage Chris1]	UOL51121.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AKA61143.1	AKA61143.1 putative baseplate assembly protein [Burkholderia phage AP3]	AKA61143.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QDP43511.1	QDP43511.1 baseplate assembly protein [Bacteriophage R18C]	QDP43511.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AKH49330.1	AKH49330.1 baseplate assembly protein W [Escherichia phage pro147]	AKH49330.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAG9593788.1	CAG9593788.1 hypothetical protein P2SIAC10_00027 [Peduovirus P2]	CAG9593788.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAP04452.1	AAP04452.1 gpW [Yersinia phage L-413C]	AAP04452.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAD03283.1	AAD03283.1 gpW [Bacteriophage P2]	AAD03283.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD38021.1	VUD38021.1 Phage baseplate assembly protein W [Peduovirus P24B2]	VUD38021.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QKE55640.1	QKE55640.1 hypothetical protein vBYpM50_00019 [Yersinia phage vB_YpM_50]	QKE55640.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QMP19175.1	QMP19175.1 baseplate with lysin [Pseudomonas phage Persinger]	QMP19175.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WFG40962.1	WFG40962.1 baseplate wedge subunit [Salmonella phage MET_P1_103_31]	WFG40962.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UZV40218.1	UZV40218.1 baseplate assembly chaperone [Acidovorax phage Acica]	UZV40218.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QEA09563.1	QEA09563.1 baseplate assembly protein [Wolbachia phage WO]	QEA09563.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADW80193.1	ADW80193.1 baseplate W [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80193.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADW80134.1	ADW80134.1 baseplate W [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80134.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC09628.1	URC09628.1 baseplate assembly protein [Escherichia phage vB_EcoM-569R9]	URC09628.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAN28234.1	AAN28234.1 gpW [Escherichia phage Wphi]	AAN28234.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAD16795.1	BAD16795.1 similar to GPW of phage P2 [Wolbachia phage WOcauB1]	BAD16795.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ARB15697.1	ARB15697.1 baseplate protein [Klebsiella phage 4LV2017]	ARB15697.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC10462.1	URC10462.1 baseplate assembly protein [Escherichia phage vB_EcoM-813R9]	URC10462.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	CAH1234699.1	CAH1234699.1 baseplate wedge subunit W [Escherichia phage Cartapus]	CAH1234699.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADP02273.1	ADP02273.1 gp26 [Burkholderia phage KS5]	ADP02273.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QXF95182.1	QXF95182.1 baseplate assembly protein [Wolbachia phage WO]	QXF95182.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QEI25355.1	QEI25355.1 baseplate assembly protein [Salmonella phage SI22]	QEI25355.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QEI25400.1	QEI25400.1 baseplate assembly protein [Salmonella phage SW9]	QEI25400.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UPI11514.1	UPI11514.1 hypothetical protein BFNKNBEH_00024 [Yersinia phage VB-YPM-18]	UPI11514.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WOZ56096.1	WOZ56096.1 hypothetical protein B476A_00016 [Yersinia phage vB_YpM_476A]	WOZ56096.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QKE55504.1	QKE55504.1 hypothetical protein vBYpM22_00019 [Yersinia phage vB_YpM_22]	QKE55504.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WOZ56136.1	WOZ56136.1 hypothetical protein B476B_00016 [Yersinia phage vB_YpM_476B]	WOZ56136.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URP83676.1	URP83676.1 baseplate assembly protein [Escherichia phage S164]	URP83676.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AGG36532.1	AGG36532.1 phage baseplate assembly protein W [Escherichia phage P2]	AGG36532.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ULG01122.1	ULG01122.1 baseplate assembly protein [Escherichia phage 10W]	ULG01122.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ULG00879.1	ULG00879.1 baseplate assembly protein [Escherichia phage 11W]	ULG00879.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD39520.1	VUD39520.1 Phage baseplate assembly protein W [Peduovirus P24C9]	VUD39520.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	USM11624.1	USM11624.1 baseplate wedge protein [Burkholderia phage Carl1]	USM11624.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AFU62889.1	AFU62889.1 phage baseplate assembly protein gpW [Acidithiobacillus phage AcaML1]	AFU62889.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URE76608.1	URE76608.1 baseplate assembly protein [Escherichia phage vB_EcoM-613R3]	URE76608.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ASD51170.1	ASD51170.1 baseplate assembly protein [Erwinia phage EtG]	ASD51170.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WPJ53101.1	WPJ53101.1 hypothetical protein RCIP0057_00028 [Klebsiella phage RCIP0057]	WPJ53101.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAC34161.1	AAC34161.1 M protein [Escherichia phage 186]	AAC34161.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QHJ75383.1	QHJ75383.1 baseplate assembly protein [Wolbachia phage WO]	QHJ75383.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNI73720.1	UNI73720.1 baseplate assembly protein [Klebsiella phage KP12]	UNI73720.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ALF02304.1	ALF02304.1 baseplate assembly protein [Salmonella phage SEN4]	ALF02304.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ALF02353.1	ALF02353.1 baseplate assembly protein [Salmonella phage SEN5]	ALF02353.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WYC18454.1	WYC18454.1 baseplate assembly protein [Yersinia phage vB_YpM_MHG38]	WYC18454.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WYC18385.1	WYC18385.1 baseplate assembly protein [Yersinia phage vB_YpM_MDG94-186]	WYC18385.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WXX18227.1	WXX18227.1 baseplate assembly protein [Yersinia phage GCS667]	WXX18227.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WYC18412.1	WYC18412.1 baseplate assembly protein [Yersinia phage vB_YpM_MDG45]	WYC18412.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AOA49557.1	AOA49557.1 baseplate assembly protein W [Wolbachia phage WO]	AOA49557.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP08031.1	QBP08031.1 baseplate assembly protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08031.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27759.1	QBP27759.1 baseplate assembly protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27759.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27912.1	QBP27912.1 baseplate assembly protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27912.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ALF02254.1	ALF02254.1 baseplate assembly protein W [Salmonella phage SEN1]	ALF02254.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QYW06306.1	QYW06306.1 baseplate assembly protein W [Shewanella phage vB_SspM_M16-3]	QYW06306.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	BAA89650.1	BAA89650.1 gp25 [Wolbachia phage WO]	BAA89650.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QYC52674.1	QYC52674.1 type VI secretion system lysozyme-like protein [Salmonella phage BIS20]	QYC52674.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QHJ75449.1	QHJ75449.1 baseplate assembly protein [Wolbachia phage WO]	QHJ75449.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QHJ75573.1	QHJ75573.1 baseplate assembly protein [Wolbachia phage WO]	QHJ75573.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP07951.1	QBP07951.1 baseplate assembly protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07951.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WID42129.1	WID42129.1 baseplate assembly protein W [Pseudomonas phage ZRG1]	WID42129.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AIZ95144.1	AIZ95144.1 lysozyme family baseplate assembly protein [Escherichia phage P88]	AIZ95144.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AGF88428.1	AGF88428.1 baseplate wedge subunit [Salmonella phage FSLSP004]	AGF88428.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAN08378.1	AAN08378.1 gp16 [Salmonella phage PSP3]	AAN08378.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ADQ92404.1	ADQ92404.1 baseplate wedge subunit [Salmonella phage RE2010]	ADQ92404.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQT27295.1	AQT27295.1 baseplate assembly protein W [Salmonella phage SEN8]	AQT27295.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	VUD40177.1	VUD40177.1 Phage baseplate assembly protein [Xuanwuvirus P884B11]	VUD40177.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27610.1	QBP27610.1 baseplate assembly protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27610.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC09743.1	URC09743.1 hypothetical protein [Escherichia phage vB_EcoM-720R5]	URC09743.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC09439.1	URC09439.1 hypothetical protein [Escherichia phage vB_EcoM-569R10]	URC09439.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC10681.1	URC10681.1 hypothetical protein [Escherichia phage vB_EcoM-783R5]	URC10681.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WOZ57130.1	WOZ57130.1 baseplate assembly protein [Citrobacter phage Shae_phiSM]	WOZ57130.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27432.1	QBP27432.1 baseplate assembly protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27432.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP07810.1	QBP07810.1 baseplate assembly protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07810.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27868.1	QBP27868.1 baseplate assembly protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27868.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP08098.1	QBP08098.1 baseplate assembly protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08098.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27671.1	QBP27671.1 baseplate assembly protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27671.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP27965.1	QBP27965.1 baseplate assembly protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27965.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBQ72008.1	QBQ72008.1 baseplate assembly protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72008.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QBP07904.1	QBP07904.1 baseplate assembly protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07904.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ARB15650.1	ARB15650.1 baseplate assembly protein [Klebsiella phage 3LV2017]	ARB15650.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UTC25937.1	UTC25937.1 hypothetical protein [Salmonella phage vB_Sal_PHB48]	UTC25937.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	URC10615.1	URC10615.1 hypothetical protein [Escherichia phage vB_EcoM-705R4]	URC10615.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AZV00461.1	AZV00461.1 baseplate assembly protein W [Paracoccus phage vB_PyeM_Pyei1]	AZV00461.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AYD79802.1	AYD79802.1 hypothetical protein OGLPLLMI_00036 [Enterobacter phage phiT5282H]	AYD79802.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AJA72942.1	AJA72942.1 baseplate assembly protein W [Mannheimia phage vB_MhM_587AP1]	AJA72942.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AJA73070.1	AJA73070.1 baseplate assembly protein W [Mannheimia phage vB_MhM_1127AP1]	AJA73070.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ABD90620.1	ABD90620.1 baseplate assembly protein W [Mannheimia phage phiMhaA1-BAA410]	ABD90620.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ABD90571.1	ABD90571.1 baseplate assembly protein W [Mannheimia phage PHL101]	ABD90571.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AJA73123.1	AJA73123.1 baseplate assembly protein W [Mannheimia phage vB_MhM_2256AP1]	AJA73123.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AJA72891.1	AJA72891.1 baseplate assembly protein W [Mannheimia phage vB_MhM_535AP1]	AJA72891.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AFL46466.1	AFL46466.1 baseplate assembly protein W [Mannheimia phage vB_MhM_1152AP]	AFL46466.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WWY66195.1	WWY66195.1 putative baseplate assembly protein [Burkholderia phage vB_HM795]	WWY66195.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WWQ71686.1	WWQ71686.1 tail baseplate protein [Pseudomonas phage Bise]	WWQ71686.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG65661.1	QIG65661.1 baseplate assembly protein [Salmonella phage PT1]	QIG65661.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WEV89343.1	WEV89343.1 hypothetical protein H10PHJ05_42 [Aeromonas phage HJ05]	WEV89343.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ALN97533.1	ALN97533.1 baseplate assembly protein W [Aeromonas phage phiARM81ld]	ALN97533.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG71812.1	QIG71812.1 baseplate assembly protein W [Rhizobium phage RHph_TM40]	QIG71812.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG71448.1	QIG71448.1 baseplate assembly protein W [Rhizobium phage RHph_TM30]	QIG71448.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG72535.1	QIG72535.1 baseplate assembly protein W [Rhizobium phage RHph_TM3_3_6]	QIG72535.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG77922.1	QIG77922.1 baseplate assembly protein W [Rhizobium phage RHph_TM61]	QIG77922.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG72898.1	QIG72898.1 baseplate assembly protein W [Rhizobium phage RHph_Y65]	QIG72898.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIG72172.1	QIG72172.1 baseplate assembly protein W [Rhizobium phage RHph_TM2_3B]	QIG72172.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WKW83144.1	WKW83144.1 baseplate assembly protein [Campylobacter phage CAM-P21]	WKW83144.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AAS47888.1	AAS47888.1 gp49 [Burkholderia phage BcepMu]	AAS47888.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ABO60671.1	ABO60671.1 gp23 [Burkholderia phage phiE255]	ABO60671.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WDE69793.1	WDE69793.1 lysozyme [Vibrio phage VPHZ6]	WDE69793.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AOT25322.1	AOT25322.1 baseplate assembly protein [Ochrobactrum phage POA1180]	AOT25322.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	ARQ95339.1	ARQ95339.1 hypothetical protein [Bradyrhizobium phage BDU-MI-1]	ARQ95339.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	WBU87738.1	WBU87738.1 hypothetical protein [Escherichia phage EP_H11]	WBU87738.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	UNI73664.1	UNI73664.1 putative baseplate protein [Klebsiella phage KP12]	UNI73664.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	QIZ02626.1	QIZ02626.1 baseplate assembly protein V [Aeromonas phage AhyVDH1]	QIZ02626.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32067.1	AQN32067.1 type IV secretion protein [Phage DP-2017a]	AQN32067.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32083.1	AQN32083.1 type IV secretion protein [Phage DP-2017a]	AQN32083.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32147.1	AQN32147.1 type IV secretion protein [Phage DP-2017a]	AQN32147.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32115.1	AQN32115.1 type IV secretion protein [Phage DP-2017a]	AQN32115.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32099.1	AQN32099.1 type IV secretion protein [Phage DP-2017a]	AQN32099.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AQN32131.1	AQN32131.1 type IV secretion protein [Phage DP-2017a]	AQN32131.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	APU00834.1	APU00834.1 baseplate assembly protein [Aeromonas phage 59.1]	APU00834.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AJK27746.1	AJK27746.1 baseplate wedge protein [Bacteriophage Lily]	AJK27746.1	0
+25220146-69da-49cd-beb2-d3cada26b4c1	AUV56864.1	AUV56864.1 baseplate wedge protein [Faecalibacterium phage FP_Taranis]	AUV56864.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNY41679.1	UNY41679.1 tail protein [Burkholderia phage Musica]	UNY41679.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNY41738.1	UNY41738.1 tail protein [Burkholderia phage Milagro]	UNY41738.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADP02317.1	ADP02317.1 gp24 [Burkholderia phage KL3]	ADP02317.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNY41795.1	UNY41795.1 tail protein [Burkholderia phage Menos]	UNY41795.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNY41851.1	UNY41851.1 tail protein [Burkholderia phage Momento]	UNY41851.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QWY84966.1	QWY84966.1 tail formation protein [Burkholderia phage PK23]	QWY84966.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ABO60705.1	ABO60705.1 gp33, phage tail protein I [Burkholderia phage phiE202]	ABO60705.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAZ72627.1	AAZ72627.1 phage tail protein I [Burkholderia phage phiE52237]	AAZ72627.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ABO60760.1	ABO60760.1 gp36, phage tail protein I [Burkholderia phage phiE12-2]	ABO60760.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UPI15578.1	UPI15578.1 tail formation protein [Burkholderia phage PhiBP82.3]	UPI15578.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UKM53784.1	UKM53784.1 tail formation protein [Burkholderia phage PhiBP82.2]	UKM53784.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AIP84298.1	AIP84298.1 phage tail protein I [Burkholderia phage BEK]	AIP84298.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AFV51414.1	AFV51414.1 phage tail protein I [Burkholderia phage phiX216]	AFV51414.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WWY66162.1	WWY66162.1 tail protein [Burkholderia phage vB_HM387]	WWY66162.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QPI18559.1	QPI18559.1 tail formation protein [Burkholderia phage phiE094]	QPI18559.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADP02271.1	ADP02271.1 gp24 [Burkholderia phage KS5]	ADP02271.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	USM11626.1	USM11626.1 baseblate asssembly protein [Burkholderia phage Carl1]	USM11626.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QPB09414.1	QPB09414.1 baseplate protein [Burkholderia phage Mana]	QPB09414.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AKA61145.1	AKA61145.1 putative tail protein [Burkholderia phage AP3]	AKA61145.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADP02364.1	ADP02364.1 gp19 [Burkholderia phage KS14]	ADP02364.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BCB23197.1	BCB23197.1 baseplate assembly protein (I) [Burkholderia phage FLC5]	BCB23197.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BDD79933.1	BDD79933.1 hypothetical protein [Burkholderia phage FLC10]	BDD79933.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AGK86793.1	AGK86793.1 phage tail protein I [Burkholderia phage ST79]	AGK86793.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AFJ75490.1	AFJ75490.1 baseplate assembly protein [Stenotrophomonas phage Smp131]	AFJ75490.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WPJ21700.1	WPJ21700.1 tail protein [Bacillus phage vB_BpuM-ZY1]	WPJ21700.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADE87923.1	ADE87923.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87923.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	USZ80543.1	USZ80543.1 tail protein [Serratia phage MQ-4]	USZ80543.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AXF38224.1	AXF38224.1 putative tail protein II [Ralstonia phage phiRSP]	AXF38224.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WID42131.1	WID42131.1 tail protein I [Pseudomonas phage ZRG1]	WID42131.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WDE69795.1	WDE69795.1 putative tail fiber protein [Vibrio phage VPHZ6]	WDE69795.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AIM50566.1	AIM50566.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50566.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ARM70448.1	ARM70448.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70448.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QPB08626.1	QPB08626.1 baseplate protein [Burkholderia phage Mica]	QPB08626.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AFV81354.1	AFV81354.1 tail protein [Vibrio phage vB_VpaM_MAR]	AFV81354.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAX64996.1	CAX64996.1 gp15 protein [Vibrio phage VP585]	CAX64996.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QKN87911.1	QKN87911.1 baseplate protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87911.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BAA36246.1	BAA36246.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36246.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBI84127.1	QBI84127.1 tail fibers protein [Pseudomonas phage vB_Pae_BR319a]	QBI84127.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QMP19177.1	QMP19177.1 tailspike protein [Pseudomonas phage Persinger]	QMP19177.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WWQ72103.1	WWQ72103.1 tail formation protein [Pseudomonas phage Sirocco]	WWQ72103.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AZF87860.1	AZF87860.1 tail protein I [Pseudomonas phage Dobby]	AZF87860.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QYW06304.1	QYW06304.1 tail protein [Shewanella phage vB_SspM_M16-3]	QYW06304.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QIG65663.1	QIG65663.1 tail fibers protein [Salmonella phage PT1]	QIG65663.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAN12333.1	AAN12333.1 ORF33 [Vibrio phage VHML]	AAN12333.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QJB21995.1	QJB21995.1 tail formation protein [Xanthomonas phage FoX5]	QJB21995.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QJB21917.1	QJB21917.1 tail formation protein [Xanthomonas phage FoX3]	QJB21917.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QJB21836.1	QJB21836.1 tail formation protein [Xanthomonas phage FoX2]	QJB21836.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QJB21755.1	QJB21755.1 tail formation protein [Xanthomonas phage FoX1]	QJB21755.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QWY14238.1	QWY14238.1 tail formation protein [Xanthomonas phage M29]	QWY14238.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAH1234703.1	CAH1234703.1 phage tail protein I [Escherichia phage Cartapus]	CAH1234703.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ANN86122.1	ANN86122.1 putative tail protein [Enterobacter phage Arya]	ANN86122.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNI73718.1	UNI73718.1 putative tail protein [Klebsiella phage KP12]	UNI73718.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC10460.1	URC10460.1 tail formation protein [Escherichia phage vB_EcoM-813R9]	URC10460.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QOE32746.1	QOE32746.1 baseplate wedge protein [Achromobacter phage Mano]	QOE32746.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ARB15699.1	ARB15699.1 baseplate assembly protein [Klebsiella phage 4LV2017]	ARB15699.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP07953.1	QBP07953.1 tail protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07953.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ABD90622.1	ABD90622.1 tail formation protein I [Mannheimia phage phiMhaA1-BAA410]	ABD90622.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ABD90573.1	ABD90573.1 tail formation protein I [Mannheimia phage PHL101]	ABD90573.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AJA73125.1	AJA73125.1 tail formation protein I [Mannheimia phage vB_MhM_2256AP1]	AJA73125.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AJA72893.1	AJA72893.1 tail formation protein I [Mannheimia phage vB_MhM_535AP1]	AJA72893.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AFL46468.1	AFL46468.1 tail formation protein I [Mannheimia phage vB_MhM_1152AP]	AFL46468.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WNL50852.1	WNL50852.1 baseplate protein I [Xanthomonas phage Murka]	WNL50852.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AQT27297.1	AQT27297.1 tail protein [Salmonella phage SEN8]	AQT27297.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADQ92406.1	ADQ92406.1 tail protein I [Salmonella phage RE2010]	ADQ92406.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ55877.1	WOZ55877.1 hypothetical protein P41_00023 [Yersinia phage vB_YpM_41]	WOZ55877.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ55807.1	WOZ55807.1 hypothetical protein P39_00023 [Yersinia phage vB_YpM_39]	WOZ55807.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ55944.1	WOZ55944.1 hypothetical protein P44_00023 [Yersinia phage vB_YpM_44]	WOZ55944.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AVP40016.1	AVP40016.1 tail protein [Ralstonia phage RsoM1USA]	AVP40016.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD40179.1	VUD40179.1 Phage tail fibers [Xuanwuvirus P884B11]	VUD40179.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AKH49390.1	AKH49390.1 tail fibers protein [Escherichia phage pro483]	AKH49390.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URP83678.1	URP83678.1 tail protein I [Escherichia phage S164]	URP83678.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URE76664.1	URE76664.1 tail protein I [Escherichia phage vB_EcoM-473R2]	URE76664.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC09214.1	URC09214.1 hypothetical protein [Escherichia phage vB_EcoM-613R2]	URC09214.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ANZ52208.1	ANZ52208.1 putative tail fiber protein [Aeromonas phage Ahp2]	ANZ52208.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BAP28125.1	BAP28125.1 hypothetical protein [Ralstonia phage RSY1]	BAP28125.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AGG36534.1	AGG36534.1 phage tail fibers protein [Escherichia phage P2]	AGG36534.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WFG40960.1	WFG40960.1 tail protein [Salmonella phage MET_P1_103_31]	WFG40960.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC09741.1	URC09741.1 tail formation protein [Escherichia phage vB_EcoM-720R5]	URC09741.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC09437.1	URC09437.1 tail formation protein [Escherichia phage vB_EcoM-569R10]	URC09437.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC10613.1	URC10613.1 tail formation protein [Escherichia phage vB_EcoM-705R4]	URC10613.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC10679.1	URC10679.1 tail formation protein [Escherichia phage vB_EcoM-783R5]	URC10679.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BAF52399.1	BAF52399.1 phage tail protein gpI [Ralstonia phage RSA1]	BAF52399.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC10107.1	URC10107.1 tail formation protein [Escherichia phage vB_EcoM-640R3]	URC10107.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BAO20614.1	BAO20614.1 putative tail protein I [Pseudomonas phage PPpW-3]	BAO20614.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27608.1	QBP27608.1 tail protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27608.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APU00836.1	APU00836.1 tail protein I [Aeromonas phage 59.1]	APU00836.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APU00751.1	APU00751.1 tail protein I [Aeromonas phage Asp37]	APU00751.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AYD79804.1	AYD79804.1 hypothetical protein OGLPLLMI_00038 [Enterobacter phage phiT5282H]	AYD79804.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AJA72944.1	AJA72944.1 tail formation protein I [Mannheimia phage vB_MhM_587AP1]	AJA72944.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AJA73072.1	AJA73072.1 tail formation protein I [Mannheimia phage vB_MhM_1127AP1]	AJA73072.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBQ72010.1	QBQ72010.1 tail protein I [Klebsiella phage ST15-OXA48phi14.1]	QBQ72010.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APU00415.1	APU00415.1 tail protein I [Aeromonas phage 3]	APU00415.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QIZ02628.1	QIZ02628.1 putative tail fiber protein [Aeromonas phage AhyVDH1]	QIZ02628.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD37979.1	VUD37979.1 Tail protein I [Peduovirus P22H1]	VUD37979.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QEI25357.1	QEI25357.1 tail protein [Salmonella phage SI22]	QEI25357.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QEI25402.1	QEI25402.1 tail fibers protein [Salmonella phage SW9]	QEI25402.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAP04454.1	AAP04454.1 gpI [Yersinia phage L-413C]	AAP04454.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAG9593869.1	CAG9593869.1 hypothetical protein P2SIDE7_00023 [Peduovirus P2]	CAG9593869.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC09630.1	URC09630.1 tail formation protein [Escherichia phage vB_EcoM-569R9]	URC09630.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27434.1	QBP27434.1 tail protein I [Klebsiella phage ST512-KPC3phi13.2]	QBP27434.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP07808.1	QBP07808.1 tail protein I [Klebsiella phage ST11-VIM1phi8.4]	QBP07808.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27866.1	QBP27866.1 tail protein I [Klebsiella phage ST11-OXA48phi15.3]	QBP27866.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP08100.1	QBP08100.1 tail protein I [Klebsiella phage ST11-OXA245phi3.1]	QBP08100.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27673.1	QBP27673.1 tail protein I [Klebsiella phage ST340-VIM1phi10.2]	QBP27673.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27963.1	QBP27963.1 tail protein I [Klebsiella phage ST258-KPC3phi16.2]	QBP27963.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QXN68743.1	QXN68743.1 tail protein [Hafnia phage yong2]	QXN68743.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ULG00695.1	ULG00695.1 tail formation protein [Escherichia phage D8]	ULG00695.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD38895.1	VUD38895.1 Tail protein I [Peduovirus P24E6b]	VUD38895.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ULG01155.1	ULG01155.1 tail formation protein [Escherichia phage 12W]	ULG01155.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ56007.1	WOZ56007.1 hypothetical protein B115_00019 [Yersinia phage vB_YpM_115]	WOZ56007.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ56053.1	WOZ56053.1 hypothetical protein B117_00019 [Yersinia phage vB_YpM_117]	WOZ56053.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	API82953.1	API82953.1 Phage tail protein (Tail_P2_I) [Salmonella phage STYP1]	API82953.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ULG00997.1	ULG00997.1 tail formation protein [Escherichia phage 9W]	ULG00997.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD37936.1	VUD37936.1 Tail protein I [Peduovirus P22H4]	VUD37936.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QDJ98453.1	QDJ98453.1 hypothetical protein LLFFHNDI_00026 [Escherichia phage vB_EcoM-12474II]	QDJ98453.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QDJ98585.1	QDJ98585.1 hypothetical protein OMJLAAIH_00026 [Escherichia phage vB_EcoM-12474V]	QDJ98585.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QDJ98541.1	QDJ98541.1 hypothetical protein PBINGOGM_00026 [Escherichia phage vB_EcoM-12474IV]	QDJ98541.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QDJ98500.1	QDJ98500.1 hypothetical protein BBAMJIOM_00029 [Escherichia phage vB_EcoM-12474III]	QDJ98500.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AIZ95146.1	AIZ95146.1 tail protein [Escherichia phage P88]	AIZ95146.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UPI11467.1	UPI11467.1 hypothetical protein COILCCMC_00019 [Yersinia phage VB-YPM-4]	UPI11467.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QKE55599.1	QKE55599.1 hypothetical protein vBYpM46_00019 [Yersinia phage vB_YpM_46]	QKE55599.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ57128.1	WOZ57128.1 tail protein I [Citrobacter phage Shae_phiSM]	WOZ57128.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAG9593786.1	CAG9593786.1 hypothetical protein P2SIAC10_00025 [Peduovirus P2]	CAG9593786.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAD03285.1	AAD03285.1 gpI [Bacteriophage P2]	AAD03285.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAG9593823.1	CAG9593823.1 hypothetical protein P2DC1_00019 [Peduovirus P2]	CAG9593823.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AGX84579.1	AGX84579.1 baseplate assembly [Enterobacteria phage fiAA91-ss]	AGX84579.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ULG01120.1	ULG01120.1 tail formation protein [Escherichia phage 10W]	ULG01120.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QIW90048.1	QIW90048.1 tail protein I [Yersinia phage P37]	QIW90048.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ULG00881.1	ULG00881.1 tail formation protein [Escherichia phage 11W]	ULG00881.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD39526.1	VUD39526.1 Phage tail fibers [Peduovirus P24C9]	VUD39526.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AWH15324.1	AWH15324.1 tail protein I [Aeromonas phage 14AhydR10PP]	AWH15324.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AWH14526.1	AWH14526.1 tail protein I [Aeromonas phage 13AhydR10PP]	AWH14526.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AKH49328.1	AKH49328.1 tail protein I [Escherichia phage pro147]	AKH49328.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	CAH0786509.1	CAH0786509.1 hypothetical protein P2AC1_00024 [Escherichia phage P2_AC1]	CAH0786509.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UOL51123.1	UOL51123.1 tail formation protein [Citrobacter phage Chris1]	UOL51123.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QXF95284.1	QXF95284.1 tail formation protein [Yersinia phage HQ103]	QXF95284.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QDP43513.1	QDP43513.1 tail protein I [Bacteriophage R18C]	QDP43513.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAN28236.1	AAN28236.1 gpI [Escherichia phage Wphi]	AAN28236.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAN08380.1	AAN08380.1 gp18 [Salmonella phage PSP3]	AAN08380.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URC09836.1	URC09836.1 tail formation protein [Escherichia phage vB_EcoM-720R8]	URC09836.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UPI11516.1	UPI11516.1 hypothetical protein BFNKNBEH_00026 [Yersinia phage VB-YPM-18]	UPI11516.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ56098.1	WOZ56098.1 hypothetical protein B476A_00018 [Yersinia phage vB_YpM_476A]	WOZ56098.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QKE55506.1	QKE55506.1 hypothetical protein vBYpM22_00021 [Yersinia phage vB_YpM_22]	QKE55506.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WOZ56138.1	WOZ56138.1 hypothetical protein B476B_00018 [Yersinia phage vB_YpM_476B]	WOZ56138.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD39035.1	VUD39035.1 Tail protein I [Peduovirus P24A7b]	VUD39035.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QKE55642.1	QKE55642.1 hypothetical protein vBYpM50_00021 [Yersinia phage vB_YpM_50]	QKE55642.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UKL54260.1	UKL54260.1 tail formation protein [Yersinia phage vB_YenM_31.17]	UKL54260.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	URE76606.1	URE76606.1 tail formation protein [Escherichia phage vB_EcoM-613R3]	URE76606.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WPJ53099.1	WPJ53099.1 hypothetical protein RCIP0057_00026 [Klebsiella phage RCIP0057]	WPJ53099.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBQ71562.1	QBQ71562.1 tail protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71562.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUD38023.1	VUD38023.1 Phage tail fibers [Peduovirus P24B2]	VUD38023.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP07902.1	QBP07902.1 tail protein I [Klebsiella phage ST101-KPC2phi6.2]	QBP07902.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ALF02255.1	ALF02255.1 tail fibers protein [Salmonella phage SEN1]	ALF02255.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ASD51168.1	ASD51168.1 tail fibers protein [Erwinia phage EtG]	ASD51168.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AWH15048.1	AWH15048.1 tail protein I [Aeromonas phage 85AhydR10PP]	AWH15048.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNA05927.1	UNA05927.1 tail formation protein [Yersinia phage vB_YenM_56.17]	UNA05927.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNA05979.1	UNA05979.1 tail formation protein [Yersinia phage vB_YenM_201.16]	UNA05979.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UTC25935.1	UTC25935.1 tail protein [Salmonella phage vB_Sal_PHB48]	UTC25935.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNA05878.1	UNA05878.1 tail formation protein [Yersinia phage vB_YenM_06.16-2]	UNA05878.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QYC52676.1	QYC52676.1 tail protein [Salmonella phage BIS20]	QYC52676.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WYC18387.1	WYC18387.1 tail fiber protein [Yersinia phage vB_YpM_MDG94-186]	WYC18387.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AUR88217.1	AUR88217.1 tail protein [Vibrio phage 1.111.A._10N.286.45.E6]	AUR88217.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AUR88279.1	AUR88279.1 tail protein [Vibrio phage 1.111.B._10N.286.45.E6]	AUR88279.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WYC18456.1	WYC18456.1 tail formation protein [Yersinia phage vB_YpM_MHG38]	WYC18456.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WXX18225.1	WXX18225.1 tail fiber protein [Yersinia phage GCS667]	WXX18225.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WYC18414.1	WYC18414.1 tail formation protein [Yersinia phage vB_YpM_MDG45]	WYC18414.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AGF88430.1	AGF88430.1 phage tail protein [Salmonella phage FSLSP004]	AGF88430.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WNY35851.1	WNY35851.1 tail protein [Vibrio phage Vb_VaM_Valp1]	WNY35851.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAC34163.1	AAC34163.1 tail protein [Escherichia phage 186]	AAC34163.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APU01167.1	APU01167.1 tail protein I [Aeromonas phage 32]	APU01167.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ARB15652.1	ARB15652.1 tail fibers protein [Klebsiella phage 3LV2017]	ARB15652.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ADX32421.1	ADX32421.1 bacteriophage protein [Erwinia phage ENT90]	ADX32421.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNA05757.1	UNA05757.1 tail formation protein [Yersinia phage vB_YenM_42.18]	UNA05757.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UGC97269.1	UGC97269.1 tail protein I [Aeromonas phage vB_AsaM_LPM4]	UGC97269.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP08029.1	QBP08029.1 tail protein I [Klebsiella phage ST437-OXA245phi4.1]	QBP08029.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27757.1	QBP27757.1 hypothetical protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27757.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	QBP27910.1	QBP27910.1 tail protein I [Klebsiella phage ST258-KPC3phi16.1]	QBP27910.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WWY66197.1	WWY66197.1 putative tail protein I [Burkholderia phage vB_HM795]	WWY66197.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APC62522.1	APC62522.1 baseplate assembly protein I [Salmonella phage SEN4]	APC62522.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	APC62518.1	APC62518.1 baseplate assembly protein I [Salmonella phage SEN5]	APC62518.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AAS38499.2	AAS38499.2 phage tail protein I [Vibrio phage VP882]	AAS38499.2	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AZV00463.1	AZV00463.1 tail protein [Paracoccus phage vB_PyeM_Pyei1]	AZV00463.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	BAP94473.1	BAP94473.1 tail protein [Aurantimonas phage AmM-1]	BAP94473.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	ARQ95337.1	ARQ95337.1 tail fibers protein [Bradyrhizobium phage BDU-MI-1]	ARQ95337.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	WAK79551.1	WAK79551.1 baseplate protein [Clostridium phage Saumur]	WAK79551.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AFU62891.1	AFU62891.1 phage baseplate assembly protein gpI [Acidithiobacillus phage AcaML1]	AFU62891.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	UNY40536.1	UNY40536.1 baseplate I-like protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40536.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	VUE37412.1	VUE37412.1 tail protein P2_I family [Roseburia phage Shimadzu]	VUE37412.1	0
+a8a39fd6-f9ae-45bf-8925-b27ccf3e32a0	AUV56787.1	AUV56787.1 tail protein [Faecalibacterium phage FP_Toutatis]	AUV56787.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UNY41739.1	UNY41739.1 tail fiber protein [Burkholderia phage Milagro]	UNY41739.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UNY41680.1	UNY41680.1 long tail fiber protein [Burkholderia phage Musica]	UNY41680.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADP02316.1	ADP02316.1 gp23 [Burkholderia phage KL3]	ADP02316.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UNY41796.1	UNY41796.1 tail fiber protein [Burkholderia phage Menos]	UNY41796.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UNY41852.1	UNY41852.1 tail fiber protein [Burkholderia phage Momento]	UNY41852.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABO60734.1	ABO60734.1 gp32, bacteriophage protein [Burkholderia phage phiE202]	ABO60734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABO60734.1	ABO60734.1 gp32, bacteriophage protein [Burkholderia phage phiE202]	ABO60734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPI15579.1	UPI15579.1 tail fiber protein [Burkholderia phage PhiBP82.3]	UPI15579.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPI15579.1	UPI15579.1 tail fiber protein [Burkholderia phage PhiBP82.3]	UPI15579.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UKM53785.1	UKM53785.1 tail fiber protein [Burkholderia phage PhiBP82.2]	UKM53785.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UKM53785.1	UKM53785.1 tail fiber protein [Burkholderia phage PhiBP82.2]	UKM53785.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFV51415.1	AFV51415.1 putative phage tail fiber protein [Burkholderia phage phiX216]	AFV51415.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFV51415.1	AFV51415.1 putative phage tail fiber protein [Burkholderia phage phiX216]	AFV51415.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAZ72626.1	AAZ72626.1 bacteriophage protein [Burkholderia phage phiE52237]	AAZ72626.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAZ72626.1	AAZ72626.1 bacteriophage protein [Burkholderia phage phiE52237]	AAZ72626.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWY66163.1	WWY66163.1 long tail fiber protein [Burkholderia phage vB_HM387]	WWY66163.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWY66163.1	WWY66163.1 long tail fiber protein [Burkholderia phage vB_HM387]	WWY66163.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPI18560.1	QPI18560.1 tail fiber protein [Burkholderia phage phiE094]	QPI18560.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPI18560.1	QPI18560.1 tail fiber protein [Burkholderia phage phiE094]	QPI18560.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWY84967.1	QWY84967.1 tail fiber protein [Burkholderia phage PK23]	QWY84967.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWY84967.1	QWY84967.1 tail fiber protein [Burkholderia phage PK23]	QWY84967.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABO60779.1	ABO60779.1 gp35, bacteriophage protein [Burkholderia phage phiE12-2]	ABO60779.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABO60779.1	ABO60779.1 gp35, bacteriophage protein [Burkholderia phage phiE12-2]	ABO60779.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKA61146.1	AKA61146.1 putative tail fiber protein [Burkholderia phage AP3]	AKA61146.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKA61146.1	AKA61146.1 putative tail fiber protein [Burkholderia phage AP3]	AKA61146.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKA61146.1	AKA61146.1 putative tail fiber protein [Burkholderia phage AP3]	AKA61146.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AGK86794.1	AGK86794.1 phage tail fiber protein [Burkholderia phage ST79]	AGK86794.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AGK86794.1	AGK86794.1 phage tail fiber protein [Burkholderia phage ST79]	AGK86794.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AGK86794.1	AGK86794.1 phage tail fiber protein [Burkholderia phage ST79]	AGK86794.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	USM11627.1	USM11627.1 tail fiber protein [Burkholderia phage Carl1]	USM11627.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	USM11627.1	USM11627.1 tail fiber protein [Burkholderia phage Carl1]	USM11627.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADP02270.1	ADP02270.1 gp23 [Burkholderia phage KS5]	ADP02270.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADP02270.1	ADP02270.1 gp23 [Burkholderia phage KS5]	ADP02270.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	APU00298.1	APU00298.1 tail fiber proximal subunit [Ralstonia phage RS-PII-1]	APU00298.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BCB23196.1	BCB23196.1 tail fiber protein [Burkholderia phage FLC5]	BCB23196.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BCB23196.1	BCB23196.1 tail fiber protein [Burkholderia phage FLC5]	BCB23196.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BDD79934.1	BDD79934.1 hypothetical protein [Burkholderia phage FLC10]	BDD79934.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BDD79934.1	BDD79934.1 hypothetical protein [Burkholderia phage FLC10]	BDD79934.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADP02363.1	ADP02363.1 gp18 [Burkholderia phage KS14]	ADP02363.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADP02363.1	ADP02363.1 gp18 [Burkholderia phage KS14]	ADP02363.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BAP15843.1	BAP15843.1 putative phage-related tail fiber protein [Ralstonia phage RSJ2]	BAP15843.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPB09415.1	QPB09415.1 tail fiber protein [Burkholderia phage Mana]	QPB09415.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFJ75491.1	AFJ75491.1 putative phage tail fiber protein [Stenotrophomonas phage Smp131]	AFJ75491.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URE76665.1	URE76665.1 side tail fiber protein, partial [Escherichia phage vB_EcoM-473R2]	URE76665.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WOZ55945.1	WOZ55945.1 hypothetical protein P44_00024 [Yersinia phage vB_YpM_44]	WOZ55945.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WOZ55878.1	WOZ55878.1 hypothetical protein P41_00024 [Yersinia phage vB_YpM_41]	WOZ55878.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URC09213.1	URC09213.1 side tail fiber protein [Escherichia phage vB_EcoM-613R2]	URC09213.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WOZ55808.1	WOZ55808.1 hypothetical protein P39_00024 [Yersinia phage vB_YpM_39]	WOZ55808.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ21701.1	WPJ21701.1 tail collar domain protein [Bacillus phage vB_BpuM-ZY1]	WPJ21701.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WID42133.1	WID42133.1 tail protein [Pseudomonas phage ZRG1]	WID42133.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	USZ80546.1	USZ80546.1 tail protein [Serratia phage MQ-4]	USZ80546.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNR53876.1	QNR53876.1 putative tail fiber protein [Pseudomonas phage phiK7A1]	QNR53876.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AGH57633.1	AGH57633.1 hypothetical protein CPKG_00002 [Cyanophage KBS-S-2A]	AGH57633.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG66677.1	QIG66677.1 tail collar domain-containing protein [Rhizobium phage RHph_TM16]	QIG66677.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEC52963.1	AEC52963.1 phage tail collar domain-containing protein [Synechococcus phage S-CRM01]	AEC52963.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ASV44784.1	ASV44784.1 tail fibers protein [Agrobacterium phage Atu_ph08]	ASV44784.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AGR47756.1	AGR47756.1 putative tail fiber protein [Sinorhizobium phage phiM12]	AGR47756.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKF12995.1	AKF12995.1 putative tail fiber protein [Sinorhizobium phage phiM19]	AKF12995.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKF12635.1	AKF12635.1 putative tail fiber protein [Sinorhizobium phage phiM7]	AKF12635.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ACH72966.1	ACH72966.1 gp47 [Burkholderia phage KS10]	ACH72966.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVH13925.1	WVH13925.1 hypothetical protein CASP1_00002 [Alcaligenes phage CASP1]	WVH13925.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WKV24022.1	WKV24022.1 tail fiber protein [Pseudomonas phage PaBSM-2607-JFK]	WKV24022.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ALY08275.1	ALY08275.1 tail fiber protein [Pseudomonas phage phi3]	ALY08275.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXP07711.1	AXP07711.1 putative tail-fiber protein [Sinorhizobium phage phiM6]	AXP07711.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKZ65595.1	AKZ65595.1 putative tail fiber protein [Sinorhizobium phage phiN3]	AKZ65595.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJT60790.1	AJT60790.1 putative tail fiber protein [Ralstonia phage phiITL-1]	AJT60790.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ACH86147.1	ACH86147.1 tail collar protein [Pseudomonas phage DVM-2008]	ACH86147.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG76098.1	QIG76098.1 tail collar domain-containing protein [Rhizobium phage RHph_I4]	QIG76098.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BAG41644.1	BAG41644.1 phage tail collar domain protein [Ralstonia phage phiRSL1]	BAG41644.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADE87921.1	ADE87921.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87921.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVQ00430.1	WVQ00430.1 tail collar domain containing protein [Synechococcus phage ME01]	WVQ00430.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVQ00676.1	WVQ00676.1 tail collar domain containing protein [Synechococcus phage MC09]	WVQ00676.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVQ00133.1	WVQ00133.1 tail collar domain containing protein [Synechococcus phage MA10]	WVQ00133.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVQ00187.1	WVQ00187.1 tail collar domain containing protein [Synechococcus phage MA01]	WVQ00187.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKN87913.1	QKN87913.1 putative tail fiber protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87913.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ALH46228.1	ALH46228.1 putative tail collar protein [Pseudomonas phage POR1]	ALH46228.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN96920.1	QIN96920.1 tail collar domain containing protein [Synechococcus phage S-H34]	QIN96920.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN96879.1	QIN96879.1 tail collar protein [Synechococcus phage S-N03]	QIN96879.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYP28166.1	AYP28166.1 tail collar domain-containing protein [Lentibacter phage vB_LenP_ICBM1]	AYP28166.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARM70446.1	ARM70446.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70446.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIM50568.1	AIM50568.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50568.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYP28010.1	AYP28010.1 hypothetical protein [Lentibacter phage vB_LenP_ICBM3]	AYP28010.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QSM01477.1	QSM01477.1 tail protein [Marinomonas phage MfV]	QSM01477.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWT49814.1	WWT49814.1 long-tail fiber proximal subunit [Escherichia phage 236Ecol005PP]	WWT49814.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWT49814.1	WWT49814.1 long-tail fiber proximal subunit [Escherichia phage 236Ecol005PP]	WWT49814.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEZ50874.1	AEZ50874.1 tail fiber protein [Burkholderia phage DC1]	AEZ50874.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBP06145.1	QBP06145.1 tail fiber protein [Synechococcus phage S-B68]	QBP06145.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UJH95997.1	UJH95997.1 hypothetical protein [Pantoea phage Nafs113]	UJH95997.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXQ70431.1	AXQ70431.1 tail fiber protein [Synechococcus phage S-T4]	AXQ70431.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BAF52401.1	BAF52401.1 phage tail collar protein [Ralstonia phage RSA1]	BAF52401.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJZ70007.1	WJZ70007.1 tail fiber protein [Vibrio phage PVP-XSN]	WJZ70007.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QDK00654.1	QDK00654.1 hypothetical protein JOHFDMOO_00131 [Escherichia phage vB_EcoS-26175V]	QDK00654.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QDK00122.1	QDK00122.1 hypothetical protein EGCEDKNN_00042 [Escherichia phage vB_EcoS-26175II]	QDK00122.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QDK00357.1	QDK00357.1 hypothetical protein INCEGHDL_00150 [Escherichia phage vB_EcoS-26175III]	QDK00357.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QDK00417.1	QDK00417.1 hypothetical protein BNKMLPFJ_00021 [Escherichia phage vB_EcoS-26175IV]	QDK00417.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ASJ79180.1	ASJ79180.1 tail fiber protein [Curvibacter phage P26059A]	ASJ79180.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BBJ33907.1	BBJ33907.1 tail fiber protein [Escherichia phage SP15]	BBJ33907.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJN62478.1	WJN62478.1 tail fiber protein [Escherichia phage phiG7]	WJN62478.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BEU75852.1	BEU75852.1 hypothetical protein KSS14E_0930 [Escherichia coli phage KS_S14]	BEU75852.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEP53225.1	QEP53225.1 tail fiber protein [Acinetobacter phage BS46]	QEP53225.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHJ10721.1	AHJ10721.1 tail collar domain-containing protein [Rhizobium phage vB_RglS_P106B]	AHJ10721.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QMV32928.1	QMV32928.1 hypothetical protein 2CaD_00038 [Ralstonia phage Dina]	QMV32928.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QTP86358.1	QTP86358.1 tail fiber protein [Synechococcus phage S-SRP02]	QTP86358.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU26740.1	UIU26740.1 tail fiber protein [Escherichia phage vB_EcoS_SA126VB]	UIU26740.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHN84586.1	AHN84586.1 side tail fiber [Enterobacteria phage 9g]	AHN84586.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BAF52400.1	BAF52400.1 tail fiber protein gpH [Ralstonia phage RSA1]	BAF52400.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VUF55652.1	VUF55652.1 hypothetical protein [Escherichia phage T5_ev219]	VUF55652.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJZ69808.1	WJZ69808.1 hypothetical protein YZUL1_158 [Citrobacter phage YZU-L1]	WJZ69808.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VCU43556.1	VCU43556.1 tail fiber protein [Escherichia phage vB_Eco_mar004NP2]	VCU43556.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNT48387.1	WNT48387.1 tail fiber protein [Salmonella phage SPLA5b]	WNT48387.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU46991.1	UIU46991.1 long tail fiber proximal subunit [Escherichia phage EP01]	UIU46991.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU46991.1	UIU46991.1 long tail fiber proximal subunit [Escherichia phage EP01]	UIU46991.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYJ76510.1	AYJ76510.1 collar/phage tail collar domain protein, partial [Acinetobacter phage AJO2]	AYJ76510.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXF38225.1	AXF38225.1 putative tail-collar fiber protein [Ralstonia phage phiRSP]	AXF38225.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BEU75662.1	BEU75662.1 hypothetical protein NGA1_0450 [Escherichia coli phage NG_A1]	BEU75662.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CCI88551.1	CCI88551.1 phage tail fiber protein [Yersinia phage phiR2-01]	CCI88551.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNL62880.1	WNL62880.1 tail fiber [Escherichia phage Es2]	WNL62880.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHN83563.1	AHN83563.1 tail fiber protein [Escherichia phage vB_EcoS_FFH_1]	AHN83563.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWD13088.1	WWD13088.1 tail fiber protein [Escherichia phage Baret]	WWD13088.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QMP19179.1	QMP19179.1 tail fiber [Pseudomonas phage Persinger]	QMP19179.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UCR75718.1	UCR75718.1 tail fiber protein [Burkholderia phage phiBt-TXDOH]	UCR75718.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QCW23758.1	QCW23758.1 tail fiber protein [Pantoea phage vB_PagS_AAS21]	QCW23758.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41761.1	AJA41761.1 L-shaped tail fiber assembly [Escherichia phage DT571/2]	AJA41761.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41761.1	AJA41761.1 L-shaped tail fiber assembly [Escherichia phage DT571/2]	AJA41761.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AZF88931.1	AZF88931.1 putative tail protein [Escherichia phage BRET]	AZF88931.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG61243.1	QIG61243.1 tail fibers protein [Salmonella phage L6jm]	QIG61243.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URF91710.1	URF91710.1 tail fiber [Escherichia phage EC122]	URF91710.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIS74187.1	UIS74187.1 tail fiber [Escherichia phage EC100]	UIS74187.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URN71056.1	URN71056.1 tail fiber [Escherichia phage EC142]	URN71056.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URN70890.1	URN70890.1 tail fiber [Escherichia phage EC105]	URN70890.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URN70735.1	URN70735.1 tail fiber [Escherichia phage EC104]	URN70735.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVL05981.1	WVL05981.1 putative peptidase S74 domain-containing protein [Salmonella phage vB_SalS-SIA3lw]	WVL05981.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMU95271.1	WMU95271.1 hypothetical protein [Salmonella phage PH204]	WMU95271.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BAP28126.1	BAP28126.1 hypothetical protein [Ralstonia phage RSY1]	BAP28126.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKO61495.1	AKO61495.1 tail fiber protein [Escherichia phage phiAPCEc03]	AKO61495.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UYE89889.1	UYE89889.1 hypothetical protein PhiBtE2641_48 [Burkholderia phage PhiBt-E264.1]	UYE89889.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV84327.1	QXV84327.1 tail fiber protein [Escherichia phage SelmaRatti]	QXV84327.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AET24747.1	AET24747.1 tail fiber protein [Escherichia phage vB_EcoS_AKFV33]	AET24747.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN92083.1	QIN92083.1 tail fiber protein [Phage NBEco002]	QIN92083.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY11826.1	URY11826.1 long tail fiber [Shigella phage ESh17]	URY11826.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY11826.1	URY11826.1 long tail fiber [Shigella phage ESh17]	URY11826.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41760.1	AJA41760.1 L-shaped tail fiber assembly [Escherichia phage DT571/2]	AJA41760.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABO60848.1	ABO60848.1 gp17 [Burkholderia phage phi644-2]	ABO60848.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BEU75917.1	BEU75917.1 hypothetical protein AZ23E_0030 [Escherichia coli phage AZ23]	BEU75917.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BEU76062.1	BEU76062.1 hypothetical protein AZ21E_0030 [Escherichia coli phage AZ21]	BEU76062.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYC97255.1	QYC97255.1 tail fiber protein [Escherichia phage IME178]	QYC97255.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAR23167.1	AAR23167.1 gp16 [Burkholderia phage phi1026b]	AAR23167.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UNI72101.1	UNI72101.1 tail fiber protein [Burkholderia phage PhiBP82.1]	UNI72101.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPW39085.1	UPW39085.1 tail fiber protein [Escherichia phage vB_EcoS_ESCO40]	UPW39085.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WEU69026.1	WEU69026.1 hypothetical protein vBEcoPHC25922_15 [Escherichia phage vB_EcoP_HC-25922]	WEU69026.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41627.1	AJA41627.1 L-shaped tail fiber assembly [Escherichia phage DT57C]	AJA41627.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEA09950.1	QEA09950.1 tail fiber protein [Salmonella phage VSe12]	QEA09950.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYC96892.1	QYC96892.1 tail fiber protein [Escherichia phage IME267]	QYC96892.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UCR91933.1	UCR91933.1 putative tail fiber protein [Escherichia phage vB_EcoP_IMEP8]	UCR91933.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAL40290.1	AAL40290.1 gp17 [Burkholderia phage phiE125]	AAL40290.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNO23867.1	WNO23867.1 tail fiber protein [Burkholderia phage phiBtTUL1a]	WNO23867.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QAX92350.1	QAX92350.1 putative tail fiber protein [Pantoea phage vB_PagM_LIET2]	QAX92350.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYC51511.1	QYC51511.1 putative L-shaped tail fiber protein [Erwinia phage KEY]	QYC51511.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWD10814.1	WWD10814.1 tail fiber protein [Escherchia phage Stokescottia]	WWD10814.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UCR80918.1	UCR80918.1 tail fiber protein [Escherichia phage Lindwurm]	UCR80918.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO55999.1	UGO55999.1 putative tail fiber protein [Escherichia phage JLBYU40]	UGO55999.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT74068.1	AIT74068.1 long tail fiber distal subunit [Enterobacteria phage RB9]	AIT74068.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT73254.1	AIT73254.1 long tail fiber distal subunit [Enterobacteria phage RB5]	AIT73254.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT73796.1	AIT73796.1 long tail fiber distal subunit [Enterobacteria phage RB7]	AIT73796.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT73525.1	AIT73525.1 long tail fiber distal subunit [Enterobacteria phage RB6]	AIT73525.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT74341.1	AIT74341.1 long tail fiber distal subunit [Enterobacteria phage RB10]	AIT74341.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT72983.1	AIT72983.1 long tail fiber distal subunit [Escherichia phage RB3]	AIT72983.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV80205.1	QXV80205.1 tail fiber protein [Escherichia phage IrisVonRoten]	QXV80205.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AMM43564.1	AMM43564.1 fused tail fiber protein [Escherichia phage DT571/2]	AMM43564.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AMM43564.1	AMM43564.1 fused tail fiber protein [Escherichia phage DT571/2]	AMM43564.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BCM29313.1	BCM29313.1 long tail fiber [Enterobacter phage vB_EkoM5VN]	BCM29313.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUM57595.1	AUM57595.1 putative fiber protein [Escherichia phage LAMP]	AUM57595.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ATW62653.1	ATW62653.1 tail fiber protein [Salmonella phage SP3]	ATW62653.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ATW62653.1	ATW62653.1 tail fiber protein [Salmonella phage SP3]	ATW62653.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAC61976.1	AAC61976.1 large subunit distal tail fiber [Enterobacteria phage T6]	AAC61976.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ78032.1	QBQ78032.1 hypothetical protein G9062_00261 [Escherichia phage vB_EcoM_G9062]	QBQ78032.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPB08629.1	QPB08629.1 tail fiber protein [Burkholderia phage Mica]	QPB08629.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAW07548.1	UAW07548.1 long tail fiber proximal component [Escherichia phage ELT1]	UAW07548.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAW07548.1	UAW07548.1 long tail fiber proximal component [Escherichia phage ELT1]	UAW07548.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ALF01959.1	ALF01959.1 L-shaped tail fiber protein [Citrobacter phage Margaery]	ALF01959.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO65943.1	QBO65943.1 hypothetical protein G4500_00267 [Escherichia phage vB_EcoM_G4500]	QBO65943.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO64571.1	QBO64571.1 hypothetical protein G29_00264 [Escherichia phage vB_EcoM_G29]	QBO64571.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ78530.1	QBQ78530.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_KAW1E185]	QBQ78530.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ78530.1	QBQ78530.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_KAW1E185]	QBQ78530.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UDY80622.1	UDY80622.1 hypothetical protein [Shigella phage CT01]	UDY80622.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNA14628.1	WNA14628.1 long tail fiber protein distal subunit [Escherichia phage MIZ3]	WNA14628.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMT11527.1	WMT11527.1 long tail fiber protein distal subunit [Escherichia phage MIZ6]	WMT11527.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN95689.1	QIN95689.1 hypothetical protein MN03_00021 [Escherichia phage MN03]	QIN95689.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW00295.1	QYW00295.1 hypothetical protein [Escherichia phage vB_EcoM_FJ1]	QYW00295.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW00295.1	QYW00295.1 hypothetical protein [Escherichia phage vB_EcoM_FJ1]	QYW00295.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNA14360.1	WNA14360.1 long tail fiber protein distal subunit [Escherichia phage MIZ2]	WNA14360.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPW39838.1	UPW39838.1 long tail fiber, distal subunit [Escherichia phage vB_EcoM_ESCO58]	UPW39838.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BEH83405.1	BEH83405.1 hypothetical protein [Escherichia phage phiEc_1]	BEH83405.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYP69720.1	AYP69720.1 long tail fiber, distal subunit [Escherichia phage vB_EcoM_DalCa]	AYP69720.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO65115.1	QBO65115.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G50]	QBO65115.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO65115.1	QBO65115.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G50]	QBO65115.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QFG06848.1	QFG06848.1 tail fiber protein [Escherichia phage vB_Eco4M-7]	QFG06848.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WZK99016.1	WZK99016.1 hypothetical protein O157vBn_00011 [Escherichia phage vB_Eco4M-7n]	WZK99016.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY16244.1	URY16244.1 tail fiber [Shigella phage ESh36]	URY16244.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QDK04379.1	QDK04379.1 tail fibers protein [Escherichia phage VEc20]	QDK04379.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1578801.1	CAJ1578801.1 Phage long tail fiber [Escherichia phage vB_Eco_Solly]	CAJ1578801.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1578801.1	CAJ1578801.1 Phage long tail fiber [Escherichia phage vB_Eco_Solly]	CAJ1578801.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WGG14615.1	WGG14615.1 tail fiber [Salmonella phage phC17]	WGG14615.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEA73198.1	AEA73198.1 putative long tail fiber proximal subunit [Shigella phage Shfl2]	AEA73198.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEA73198.1	AEA73198.1 putative long tail fiber proximal subunit [Shigella phage Shfl2]	AEA73198.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WGG14460.1	WGG14460.1 tail fiber [Salmonella phage phC11]	WGG14460.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WGG14303.1	WGG14303.1 tail fiber [Salmonella phage phA11]	WGG14303.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ51317.1	ANZ51317.1 long tail fiber proximal subunit [Enterobacteria phage ATK48]	ANZ51317.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ51317.1	ANZ51317.1 long tail fiber proximal subunit [Enterobacteria phage ATK48]	ANZ51317.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ50975.1	ANZ50975.1 putative long tail fiber proximal subunit [Enterobacteria phage ATK47]	ANZ50975.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ50975.1	ANZ50975.1 putative long tail fiber proximal subunit [Enterobacteria phage ATK47]	ANZ50975.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXN58284.1	AXN58284.1 large distal tail fiber subunit [Enterobacteria phage T6]	AXN58284.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BBF63668.1	BBF63668.1 long tail fiber distal subunit [Enterobacteria phage T6]	BBF63668.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AOG16681.1	AOG16681.1 large distal tail fiber subunit [Cronobacter phage vB_CsaM_leN]	AOG16681.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AOG16395.1	AOG16395.1 L-shaped tail fiber protein [Cronobacter phage vB_CsaM_leB]	AOG16395.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAA7537759.1	CAA7537759.1 large distal tail fiber subunit [Shigella phage vB_SsoM_113]	CAA7537759.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63106.1	AUV63106.1 long tail fiber subunit, proximal [Shigella phage Sf24]	AUV63106.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63106.1	AUV63106.1 long tail fiber subunit, proximal [Shigella phage Sf24]	AUV63106.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63378.1	AUV63378.1 proximal long tail fiber subunit [Shigella phage Sf25]	AUV63378.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63378.1	AUV63378.1 proximal long tail fiber subunit [Shigella phage Sf25]	AUV63378.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AVZ45661.1	AVZ45661.1 putative tail fiber protein [Escherichia phage vB_EcoM-Ro157lw]	AVZ45661.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35758.1	WPK35758.1 long tail fiber [Escherichia phage AV117]	WPK35758.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35758.1	WPK35758.1 long tail fiber [Escherichia phage AV117]	WPK35758.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AVP40017.1	AVP40017.1 tail protein [Ralstonia phage RsoM1USA]	AVP40017.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI80049.1	QZI80049.1 long tail fiber [Escherichia phage vB_EcoM-172859UKE1]	QZI80049.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI80049.1	QZI80049.1 long tail fiber [Escherichia phage vB_EcoM-172859UKE1]	QZI80049.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41628.1	AJA41628.1 L-shaped tail fiber assembly [Escherichia phage DT57C]	AJA41628.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJA41628.1	AJA41628.1 L-shaped tail fiber assembly [Escherichia phage DT57C]	AJA41628.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAW58942.1	UAW58942.1 putative tail structure protein [Roseobacter phage CRP-207]	UAW58942.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARW57951.1	ARW57951.1 long tail fiber distal subunit [Serratia phage CBH8]	ARW57951.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYN80696.1	QYN80696.1 hypothetical protein [Kosakonia phage Kc304]	QYN80696.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARW57676.1	ARW57676.1 long tail fiber distal subunit [Serratia phage CHI14]	ARW57676.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AMB48779.1	AMB48779.1 tail fiber protein AB [Enterobacteria phage DT530]	AMB48779.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AMB48779.1	AMB48779.1 tail fiber protein AB [Enterobacteria phage DT530]	AMB48779.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFH20214.1	AFH20214.1 long tail fiber distal subunit [Escherichia phage vB_EcoM_ACG-C40]	AFH20214.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY13398.1	URY13398.1 hypothetical protein [Shigella phage ESh25]	URY13398.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG09839.1	QEG09839.1 tail fiber [Escherichia phage Mansfield]	QEG09839.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV83445.1	QXV83445.1 long tail fiber proximal subunit [Escherichia phage PaulHMueller]	QXV83445.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV83445.1	QXV83445.1 long tail fiber proximal subunit [Escherichia phage PaulHMueller]	QXV83445.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ51420.1	ANZ51420.1 long tail fiber proximal subunit [Enterobacteria phage GiZh]	ANZ51420.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ51420.1	ANZ51420.1 long tail fiber proximal subunit [Enterobacteria phage GiZh]	ANZ51420.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFO10457.1	AFO10457.1 phage tail fiber protein [Escherichia phage ECML-117]	AFO10457.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFD55658.1	WFD55658.1 hypothetical protein phi5_178 [Enterobacter phage phi5]	WFD55658.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY12208.1	URY12208.1 long tail fiber [Shigella phage ESh18]	URY12208.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY12208.1	URY12208.1 long tail fiber [Shigella phage ESh18]	URY12208.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCZ66303.1	WCZ66303.1 tail fiber protein [Yersinia phage MHG19]	WCZ66303.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UYE94920.1	UYE94920.1 tail fiber [Escherichia phage vB_EcoM-pEB20]	UYE94920.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UYE94920.1	UYE94920.1 tail fiber [Escherichia phage vB_EcoM-pEB20]	UYE94920.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANN86874.1	ANN86874.1 tail fibers protein [Shigella phage SHFML-26]	ANN86874.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1327496.1	CAL1327496.1 Long tail fiber [Escherichia phage vB_Eco_EL]	CAL1327496.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1327496.1	CAL1327496.1 Long tail fiber [Escherichia phage vB_Eco_EL]	CAL1327496.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOC55525.1	QOC55525.1 tail fibers protein [Escherichia phage JEP8]	QOC55525.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CEO90855.1	CEO90855.1 Putative large distal tail fiber subunit protein [Enterobacteria phage GEC-3S]	CEO90855.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URO83400.1	URO83400.1 hypothetical protein [Escherichia phage EC150]	URO83400.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWD12790.1	WWD12790.1 long tail fiber protein distal subunit [Escherichia phage GoldenSnicker]	WWD12790.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77300.1	QBQ77300.1 hypothetical protein WFH_00013 [Escherichia phage vB_EcoM_WFH]	QBQ77300.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIE02371.1	QIE02371.1 tail fiber protein [Escherichia phage fp01]	QIE02371.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCS66660.1	WCS66660.1 long tail fiber proximal subunit [Escherichia phage KIT06]	WCS66660.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCS66660.1	WCS66660.1 long tail fiber proximal subunit [Escherichia phage KIT06]	WCS66660.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QUL76918.1	QUL76918.1 large distal tail fiber subunit [Escherichia phage UPEC03]	QUL76918.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QGS83855.1	QGS83855.1 long tail fiber protein [Escherichia phage Ec_Makalu_002]	QGS83855.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG05558.1	QEG05558.1 long tail fiber distal subunit [Shigella phage JK32]	QEG05558.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QCQ57224.1	QCQ57224.1 tail fibers protein [Escherichia phage EcNP1]	QCQ57224.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV73269.1	QXV73269.1 tail fibers protein [Escherichia phage vB_EcoM_Nami]	QXV73269.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WAE77580.1	WAE77580.1 long tail fiber protein [Escherichia phage ph0021]	WAE77580.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIT74882.1	AIT74882.1 long tail fiber distal subunit [Enterobacteria phage RB33]	AIT74882.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABI95067.1	ABI95067.1 large distal tail fiber subunit [Escherichia phage RB32]	ABI95067.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80017.1	WBF80017.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F26]	WBF80017.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80017.1	WBF80017.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F26]	WBF80017.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77405.1	QBQ77405.1 hypothetical protein WFC_00013 [Escherichia phage vB_EcoM_WFC]	QBQ77405.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG77866.1	WFG77866.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM01]	WFG77866.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG77866.1	WFG77866.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM01]	WFG77866.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG78404.1	WFG78404.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM03]	WFG78404.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG78404.1	WFG78404.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM03]	WFG78404.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG78135.1	WFG78135.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM02]	WFG78135.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG78135.1	WFG78135.1 tail fiber protein proximal subunit [Escherichia phage vB_VIPECOOM02]	WFG78135.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF82110.1	QLF82110.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_Lutter]	QLF82110.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF82110.1	QLF82110.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_Lutter]	QLF82110.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WGG26093.1	WGG26093.1 long tail fiber [Escherichia phage GADS24]	WGG26093.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WGG26093.1	WGG26093.1 long tail fiber [Escherichia phage GADS24]	WGG26093.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV59615.1	AUV59615.1 long tail fiber proximal subunit [Citrobacter phage vB_CroM_CrRp10]	AUV59615.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV59615.1	AUV59615.1 long tail fiber proximal subunit [Citrobacter phage vB_CroM_CrRp10]	AUV59615.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU27916.1	UIU27916.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SA21RB]	UIU27916.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU27916.1	UIU27916.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SA21RB]	UIU27916.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN69511.1	QXN69511.1 putative tail fiber proximal subunit [Hafnia phage vB_HpaM_IsaacDaniel]	QXN69511.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN69511.1	QXN69511.1 putative tail fiber proximal subunit [Hafnia phage vB_HpaM_IsaacDaniel]	QXN69511.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWD91693.1	AWD91693.1 long tail fiber proximal subunit [Enterobacteria phage vB_EcoM_IME340]	AWD91693.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWD91693.1	AWD91693.1 long tail fiber proximal subunit [Enterobacteria phage vB_EcoM_IME340]	AWD91693.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYJ73130.1	AYJ73130.1 long tail fiber [Citrobacter phage Maroon]	AYJ73130.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBY52766.1	WBY52766.1 tail fiber protein proximal subunit [Escherichia phage REP1]	WBY52766.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBY52766.1	WBY52766.1 tail fiber protein proximal subunit [Escherichia phage REP1]	WBY52766.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF80755.1	QLF80755.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SP1]	QLF80755.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF80755.1	QLF80755.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SP1]	QLF80755.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWM11961.1	AWM11961.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_NBG2]	AWM11961.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWM11961.1	AWM11961.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_NBG2]	AWM11961.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY86432.1	WLY86432.1 long-tail fiber proximal subunit [Escherichia phage 310Ecol104PP]	WLY86432.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY86432.1	WLY86432.1 long-tail fiber proximal subunit [Escherichia phage 310Ecol104PP]	WLY86432.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIQ68304.1	QIQ68304.1 long tail fiber proximal subunit [Citrobacter phage PhiZZ6]	QIQ68304.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIQ68304.1	QIQ68304.1 long tail fiber proximal subunit [Citrobacter phage PhiZZ6]	QIQ68304.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WQN07507.1	WQN07507.1 long tail fiber proximal subunit [Escherichia phage vB-Eco-KMB23]	WQN07507.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WQN07507.1	WQN07507.1 long tail fiber proximal subunit [Escherichia phage vB-Eco-KMB23]	WQN07507.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANH50381.2	ANH50381.2 long tail fiber, proximal subunit [Escherichia phage UFV-AREG1]	ANH50381.2	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANH50381.2	ANH50381.2 long tail fiber, proximal subunit [Escherichia phage UFV-AREG1]	ANH50381.2	0
+36c541f8-7003-40cd-a8b8-680449c12606	WIK99977.1	WIK99977.1 tail fiber protein [Escherichia phage GADU22]	WIK99977.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMM91666.1	WMM91666.1 tail fiber [Escherichia phage KK4]	WMM91666.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU28189.1	UIU28189.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SA20RB]	UIU28189.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIU28189.1	UIU28189.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SA20RB]	UIU28189.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHI60790.1	AHI60790.1 putative tail fiber protein [Escherichia phage KBNP1711]	AHI60790.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO46913.1	UGO46913.1 putative long tail fiber proximal [Shigella phage vB_SboM_Phaginator]	UGO46913.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO46913.1	UGO46913.1 putative long tail fiber proximal [Shigella phage vB_SboM_Phaginator]	UGO46913.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WKV22910.1	WKV22910.1 tail fiber protein, distal subunit [Escherichia phage BW-1]	WKV22910.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHB43270.1	QHB43270.1 long tail fiber subunit, proximal [Shigella phage KRT47]	QHB43270.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHB43270.1	QHB43270.1 long tail fiber subunit, proximal [Shigella phage KRT47]	QHB43270.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WZE64466.1	WZE64466.1 long tail fiber proximal subunit [Escherichia phage Ge15]	WZE64466.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WZE64466.1	WZE64466.1 long tail fiber proximal subunit [Escherichia phage Ge15]	WZE64466.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ULA51710.2	ULA51710.2 long tail fiber proximal subunit [Escherichia phage vB_EcoM-RPN226]	ULA51710.2	0
+36c541f8-7003-40cd-a8b8-680449c12606	ULA51710.2	ULA51710.2 long tail fiber proximal subunit [Escherichia phage vB_EcoM-RPN226]	ULA51710.2	0
+36c541f8-7003-40cd-a8b8-680449c12606	WIL79058.1	WIL79058.1 long tail fiber protein [Escherichia phage vB_EcoM_11B_SA_NWU]	WIL79058.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WIL79058.1	WIL79058.1 long tail fiber protein [Escherichia phage vB_EcoM_11B_SA_NWU]	WIL79058.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75357.1	QXV75357.1 long tail fiber proximal subunit [Escherichia phage AdolfPortmann]	QXV75357.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75357.1	QXV75357.1 long tail fiber proximal subunit [Escherichia phage AdolfPortmann]	QXV75357.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY14586.1	URY14586.1 tail fiber [Shigella phage ESh30]	URY14586.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ50831.1	ANZ50831.1 long tail fiber proximal subunit [Enterobacteria phage Aplg8]	ANZ50831.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANZ50831.1	ANZ50831.1 long tail fiber proximal subunit [Enterobacteria phage Aplg8]	ANZ50831.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNV49385.1	WNV49385.1 tail fiber [Escherichia phage L14]	WNV49385.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WRQ07164.1	WRQ07164.1 long-tail fiber proximal subunit [Escherichia phage BP32]	WRQ07164.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WRQ07164.1	WRQ07164.1 long-tail fiber proximal subunit [Escherichia phage BP32]	WRQ07164.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAD7712071.1	CAD7712071.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_NR1]	CAD7712071.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAD7712071.1	CAD7712071.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_NR1]	CAD7712071.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVH02243.1	WVH02243.1 long tail fiber [Escherichia phage ECP2301]	WVH02243.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVH02243.1	WVH02243.1 long tail fiber [Escherichia phage ECP2301]	WVH02243.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UVD36930.1	UVD36930.1 hypothetical protein A2_gp244 [Shigella phage A2]	UVD36930.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UVD36930.1	UVD36930.1 hypothetical protein A2_gp244 [Shigella phage A2]	UVD36930.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO56565.1	UGO56565.1 putative long tail fiber proximal subunit [Escherichia phage JLBYU22]	UGO56565.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO56565.1	UGO56565.1 putative long tail fiber proximal subunit [Escherichia phage JLBYU22]	UGO56565.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFL46948.1	AFL46948.1 putative phage tail fiber protein [Salmonella phage SSU5]	AFL46948.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY13523.1	URY13523.1 long tail fiber [Shigella phage ESh26]	URY13523.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY13523.1	URY13523.1 long tail fiber [Shigella phage ESh26]	URY13523.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328665.1	CAL1328665.1 Long tail fiber [Escherichia phage vB_Eco_Some]	CAL1328665.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328665.1	CAL1328665.1 Long tail fiber [Escherichia phage vB_Eco_Some]	CAL1328665.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAH1486986.1	CAH1486986.1 tail fiber protein proximal subunit [Escherichia phage UGJNEcP1]	CAH1486986.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAH1616317.1	CAH1616317.1 tail fiber protein proximal subunit [Escherichia phage UGJNEcP2]	CAH1616317.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAV89211.1	UAV89211.1 putative tail fiber protein [Escherichia phage U115]	UAV89211.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWV60327.1	QWV60327.1 long-tail fiber proximal subunit [Escherichia phage S143_2]	QWV60327.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWV60327.1	QWV60327.1 long-tail fiber proximal subunit [Escherichia phage S143_2]	QWV60327.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAD2273057.1	CAD2273057.1 long tail fiber, distal subunit [Shigella phage vB_SsoM_JK08]	CAD2273057.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYN56624.1	AYN56624.1 long-tail fiber proximal subunit [Escherichia phage p000y]	AYN56624.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYN56624.1	AYN56624.1 long-tail fiber proximal subunit [Escherichia phage p000y]	AYN56624.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCZ57627.1	WCZ57627.1 chaperone of endosialidase [Salmonella phage Kenya-K36]	WCZ57627.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCZ57627.1	WCZ57627.1 chaperone of endosialidase [Salmonella phage Kenya-K36]	WCZ57627.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ADD10651.1	ADD10651.1 gp37 [Enterobacteria phage IP008]	ADD10651.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI78826.1	QZI78826.1 tail fiber [Escherichia phage vB_EcoM-101112UKE3-1]	QZI78826.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIS74322.1	UIS74322.1 tail fiber [Escherichia phage EC101]	UIS74322.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNJ49544.1	QNJ49544.1 tail fiber protein [Yersinia phage PYps11T]	QNJ49544.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ71158.1	WPJ71158.1 tail fiber [Escherichia phage vB-Eco-KMB26]	WPJ71158.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYJ74494.1	AYJ74494.1 large tail fiber subunit [Yersinia phage PYPS2T]	AYJ74494.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOI70755.1	QOI70755.1 tail fiber protein [Yersinia phage PYps10T]	QOI70755.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOI70219.1	QOI70219.1 tail fiber protein [Yersinia phage PYPS2T]	QOI70219.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CCI89142.1	CCI89142.1 phage long tail fiber proximal subunit [Yersinia phage phiD1]	CCI89142.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CCI89142.1	CCI89142.1 phage long tail fiber proximal subunit [Yersinia phage phiD1]	CCI89142.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOI70485.1	QOI70485.1 tail fiber protein [Yersinia phage PYps5T]	QOI70485.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNJ50339.1	QNJ50339.1 tail fiber protein [Yersinia phage PYps35T]	QNJ50339.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV61109.1	AUV61109.1 long tail fiber, distal subunit [Escherichia phage vB_EcoM-fFiEco06]	AUV61109.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UEN68645.1	UEN68645.1 tail fibers protein [Escherichia phage MLP2]	UEN68645.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANN86680.1	ANN86680.1 tail fibers protein [Shigella phage SHFML-11]	ANN86680.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYD85516.1	AYD85516.1 tail fiber protein [Escherichia phage FEC19]	AYD85516.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO62407.1	QBO62407.1 hypothetical protein G2248_00252 [Escherichia phage vB_EcoM_G2248]	QBO62407.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO54998.1	UGO54998.1 putative long tail fiber proximal subunit [Escherichia phage JLBYU31]	UGO54998.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO54998.1	UGO54998.1 putative long tail fiber proximal subunit [Escherichia phage JLBYU31]	UGO54998.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF82360.1	WBF82360.1 long tail fiber protein distal subunit [Escherichia phage a15]	WBF82360.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UJJ22248.1	UJJ22248.1 long tail fiber distal subunit [Erwinia phage Virsaitis27]	UJJ22248.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWT37217.1	WWT37217.1 tail fiber [Escherichia phage UPWr_E4]	WWT37217.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOQ37625.1	QOQ37625.1 long tail fiber [Escherichia phage vB_EcoM_WL-3]	QOQ37625.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QOQ37625.1	QOQ37625.1 long tail fiber [Escherichia phage vB_EcoM_WL-3]	QOQ37625.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WNL51045.1	WNL51045.1 short tail fiber protein [Synechococcus phage S-CREM2]	WNL51045.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64206.1	QHR64206.1 long tail fiber proximal subunit [Escherichia phage teqskov]	QHR64206.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64206.1	QHR64206.1 long tail fiber proximal subunit [Escherichia phage teqskov]	QHR64206.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36571.1	WPK36571.1 long tail fiber [Escherichia phage AV120]	WPK36571.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36571.1	WPK36571.1 long tail fiber [Escherichia phage AV120]	WPK36571.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36295.1	WPK36295.1 long tail fiber [Escherichia phage AV119]	WPK36295.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36295.1	WPK36295.1 long tail fiber [Escherichia phage AV119]	WPK36295.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR66230.1	QHR66230.1 putative large distal tail fiber subunit protein [Escherichia phage kaaroe]	QHR66230.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN97913.1	QIN97913.1 long tail fiber proximal subunit [Serratia phage PhiZZ30]	QIN97913.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN97913.1	QIN97913.1 long tail fiber proximal subunit [Serratia phage PhiZZ30]	QIN97913.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJJ57298.1	WJJ57298.1 tail fiber [Escherichia phage 4E8]	WJJ57298.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWY04359.1	AWY04359.1 tail fiber protein [Escherichia phage LL5]	AWY04359.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPI17927.1	QPI17927.1 hypothetical protein POP12_135 [Pectobacterium phage POP12]	QPI17927.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ATS92458.1	ATS92458.1 tail fiber protein [Escherichia phage PGT2]	ATS92458.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE45738.1	AKE45738.1 hypothetical protein ECTP6_00871 [Escherichia coli O157 typing phage 6]	AKE45738.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE45738.1	AKE45738.1 hypothetical protein ECTP6_00871 [Escherichia coli O157 typing phage 6]	AKE45738.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE45308.1	AKE45308.1 hypothetical protein ECTP3_00430 [Escherichia coli O157 typing phage 3]	AKE45308.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE45308.1	AKE45308.1 hypothetical protein ECTP3_00430 [Escherichia coli O157 typing phage 3]	AKE45308.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE47004.1	AKE47004.1 hypothetical protein ECTP13_02228 [Escherichia coli O157 typing phage 13]	AKE47004.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKE47004.1	AKE47004.1 hypothetical protein ECTP13_02228 [Escherichia coli O157 typing phage 13]	AKE47004.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBY53096.1	WBY53096.1 tail fiber protein proximal subunit [Escherichia phage REP4]	WBY53096.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBY53096.1	WBY53096.1 tail fiber protein proximal subunit [Escherichia phage REP4]	WBY53096.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO65388.1	QBO65388.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G53]	QBO65388.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO65388.1	QBO65388.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G53]	QBO65388.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UYE90811.1	UYE90811.1 endo-N-acetylneuraminidase [Escherichia phage vB_EcoM_SP13]	UYE90811.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WAQ79347.1	WAQ79347.1 tail protein [Escherichia phage F13]	WAQ79347.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AVZ45096.1	AVZ45096.1 putative tail fiber protein [Escherichia phage EP335]	AVZ45096.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89594.1	VEV89594.1 Phage tail fibers [Yersinia phage fPS-65]	VEV89594.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAH6634719.1	CAH6634719.1 long tail fiber distal subunit [Escherichia phage vB_Eco_TB34]	CAH6634719.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEM42585.1	QEM42585.1 putative tail protein [Shigella phage SGF2]	QEM42585.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVT33377.1	WVT33377.1 hypothetical protein PS49_273 [Aeromonas phage PS49]	WVT33377.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN69781.1	QXN69781.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_Kelasse]	QXN69781.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN69781.1	QXN69781.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_Kelasse]	QXN69781.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARW58228.1	ARW58228.1 long tail fiber distal subunit [Serratia phage X20]	ARW58228.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWM11694.1	AWM11694.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_NBG1]	AWM11694.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWM11694.1	AWM11694.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_NBG1]	AWM11694.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAQ15494.1	AAQ15494.1 large distal tail fiber subunit [Escherichia phage RB49]	AAQ15494.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36028.1	WPK36028.1 long tail fiber [Escherichia phage AV118]	WPK36028.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK36028.1	WPK36028.1 long tail fiber [Escherichia phage AV118]	WPK36028.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ULA52771.1	ULA52771.1 long tail fiber [Enterobacter phage vB-EclM_KMB20]	ULA52771.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANA50274.1	ANA50274.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM-UFV13]	ANA50274.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANA50274.1	ANA50274.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM-UFV13]	ANA50274.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35242.1	WPK35242.1 long tail fiber [Escherichia phage AV115]	WPK35242.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35242.1	WPK35242.1 long tail fiber [Escherichia phage AV115]	WPK35242.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35501.1	WPK35501.1 long tail fiber [Escherichia phage AV116]	WPK35501.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK35501.1	WPK35501.1 long tail fiber [Escherichia phage AV116]	WPK35501.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328201.1	CAL1328201.1 Hypothetical protein TRBSAP_119 [Escherichia phage vB_Eco_SAP]	CAL1328201.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI94098.1	QZI94098.1 hypothetical protein HFGIMCCB_00249 [Enterobacteria phage Whisky]	QZI94098.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AJW61396.1	AJW61396.1 tail fibers protein [Escherichia phage 172-1]	AJW61396.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG06090.1	QEG06090.1 proximal tail fiber subunit [Shigella phage JK38]	QEG06090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG06090.1	QEG06090.1 proximal tail fiber subunit [Shigella phage JK38]	QEG06090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFU62576.1	AFU62576.1 tail fiber [Escherichia phage NJ01]	AFU62576.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEK12499.1	AEK12499.1 phage long tail fiber proximal subunit [Escherichia phage ime09]	AEK12499.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEK12499.1	AEK12499.1 phage long tail fiber proximal subunit [Escherichia phage ime09]	AEK12499.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF82645.1	WBF82645.1 tail fiber protein proximal subunit [Escherichia phage a20]	WBF82645.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF82645.1	WBF82645.1 tail fiber protein proximal subunit [Escherichia phage a20]	WBF82645.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WAX14052.1	WAX14052.1 long-tail fiber protein [Escherichia phage ECO07P5]	WAX14052.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WAX13778.1	WAX13778.1 long-tail fiber protein [Escherichia phage ECO07P4]	WAX13778.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34983.1	WPK34983.1 long tail fiber [Escherichia phage AV114]	WPK34983.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34983.1	WPK34983.1 long tail fiber [Escherichia phage AV114]	WPK34983.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK33666.1	WPK33666.1 long tail fiber [Escherichia phage AV109]	WPK33666.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK33666.1	WPK33666.1 long tail fiber [Escherichia phage AV109]	WPK33666.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG57056.1	QIG57056.1 tail fiber [Yersinia phage vB_YepM_ZN18]	QIG57056.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV84819.1	QXV84819.1 long tail fiber proximal subunit [Escherichia phage TadeuszReichstein]	QXV84819.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV84819.1	QXV84819.1 long tail fiber proximal subunit [Escherichia phage TadeuszReichstein]	QXV84819.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI79408.1	QZI79408.1 long tail fiber [Escherichia phage vB_EcoM-101117BS1]	QZI79408.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI79408.1	QZI79408.1 long tail fiber [Escherichia phage vB_EcoM-101117BS1]	QZI79408.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY85734.1	WLY85734.1 long-tail fiber proximal subunit [Escherichia phage 303Ecol101PP]	WLY85734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY85734.1	WLY85734.1 long-tail fiber proximal subunit [Escherichia phage 303Ecol101PP]	WLY85734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN97645.1	QIN97645.1 long tail fiber proximal subunit [Citrobacter phage PhiZZ23]	QIN97645.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN97645.1	QIN97645.1 long tail fiber proximal subunit [Citrobacter phage PhiZZ23]	QIN97645.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFR52046.1	AFR52046.1 putative phage tail protein [Escherichia phage ECBP2]	AFR52046.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1327985.1	CAL1327985.1 Long tail fiber [Escherichia phage vB_Eco_EH2]	CAL1327985.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1327985.1	CAL1327985.1 Long tail fiber [Escherichia phage vB_Eco_EH2]	CAL1327985.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ79578.1	QBQ79578.1 hypothetical protein OE5505_00263 [Escherichia phage vB_EcoM_OE5505]	QBQ79578.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV78522.1	QXV78522.1 long tail fiber proximal subunit [Escherichia phage FelixPlatter]	QXV78522.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV78522.1	QXV78522.1 long tail fiber proximal subunit [Escherichia phage FelixPlatter]	QXV78522.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ70890.1	WPJ70890.1 long tail fiber proximal subunit [Escherichia phage vB-Eco-KMB22]	WPJ70890.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ70890.1	WPJ70890.1 long tail fiber proximal subunit [Escherichia phage vB-Eco-KMB22]	WPJ70890.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89093.1	VEV89093.1 Phage tail fibers [Yersinia phage fPS-90]	VEV89093.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIS25200.1	UIS25200.1 putative tail fiber protein [Shigella phage CWP003]	UIS25200.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV85090.1	QXV85090.1 lateral tail fiber protein [Escherichia phage TrudiGerster]	QXV85090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV85090.1	QXV85090.1 lateral tail fiber protein [Escherichia phage TrudiGerster]	QXV85090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR66938.1	QHR66938.1 long tail fiber proximal subunit [Escherichia phage mogra]	QHR66938.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV80373.1	QXV80373.1 lateral tail fiber protein [Escherichia phage IrmaTschudi]	QXV80373.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34194.1	WPK34194.1 long tail fiber [Escherichia phage AV111]	WPK34194.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34194.1	WPK34194.1 long tail fiber [Escherichia phage AV111]	WPK34194.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN68333.1	QXN68333.1 long tail fiber, proximal subunit [Escherichia phage JK1]	QXN68333.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXN68333.1	QXN68333.1 long tail fiber, proximal subunit [Escherichia phage JK1]	QXN68333.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80285.1	WBF80285.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F27]	WBF80285.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80285.1	WBF80285.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F27]	WBF80285.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR68342.1	QHR68342.1 long tail fiber proximal subunit [Escherichia phage moha]	QHR68342.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR68342.1	QHR68342.1 long tail fiber proximal subunit [Escherichia phage moha]	QHR68342.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ74269.1	QBQ74269.1 tail fibers protein [Escherichia phage vB_EcoM_PHB13]	QBQ74269.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ79857.1	QBQ79857.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_R5505]	QBQ79857.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ79857.1	QBQ79857.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_R5505]	QBQ79857.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKJ72882.1	AKJ72882.1 hypothetical protein HY03_0240 [Escherichia phage HY03]	AKJ72882.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKJ72882.1	AKJ72882.1 hypothetical protein HY03_0240 [Escherichia phage HY03]	AKJ72882.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UGO56828.1	UGO56828.1 putative tail fiber protein [Escherichia phage JLBYU37]	UGO56828.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF81841.1	QLF81841.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_Ozark]	QLF81841.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF81841.1	QLF81841.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_Ozark]	QLF81841.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANY29934.1	ANY29934.1 tail fibers protein [Escherichia phage Sloth]	ANY29934.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANY29649.1	ANY29649.1 tail fibers protein [Escherichia phage Envy]	ANY29649.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO60983.1	QBO60983.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G2133]	QBO60983.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO60983.1	QBO60983.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G2133]	QBO60983.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64090.1	QHR64090.1 long tail fiber proximal subunit [Escherichia phage teqsoen]	QHR64090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64090.1	QHR64090.1 long tail fiber proximal subunit [Escherichia phage teqsoen]	QHR64090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77263.1	QBQ77263.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFK]	QBQ77263.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77263.1	QBQ77263.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFK]	QBQ77263.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWV60590.1	QWV60590.1 large tail fiber protein [Escherichia phage W143]	QWV60590.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWV60590.1	QWV60590.1 large tail fiber protein [Escherichia phage W143]	QWV60590.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIM50825.1	AIM50825.1 proximal long tail fiber [Shigella phage Shf125875]	AIM50825.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIM50825.1	AIM50825.1 proximal long tail fiber [Shigella phage Shf125875]	AIM50825.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF81562.1	QLF81562.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_F1]	QLF81562.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QLF81562.1	QLF81562.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_F1]	QLF81562.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW00610.1	QYW00610.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_FN]	QYW00610.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW00610.1	QYW00610.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_FN]	QYW00610.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY11358.1	URY11358.1 long tail fiber [Shigella phage ESh15]	URY11358.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY11358.1	URY11358.1 long tail fiber [Shigella phage ESh15]	URY11358.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QVW29390.1	QVW29390.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SQ17]	QVW29390.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QVW29390.1	QVW29390.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_SQ17]	QVW29390.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY13904.1	URY13904.1 long tail fiber [Shigella phage ESh27]	URY13904.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY13904.1	URY13904.1 long tail fiber [Shigella phage ESh27]	URY13904.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAP76150.1	AAP76150.1 gp34 long tail fiber, proximal subunit [Escherichia phage RB69]	AAP76150.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AAP76150.1	AAP76150.1 gp34 long tail fiber, proximal subunit [Escherichia phage RB69]	AAP76150.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63791.1	AUV63791.1 long tail fiber subunit, proximal [Shigella phage Sf21]	AUV63791.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63791.1	AUV63791.1 long tail fiber subunit, proximal [Shigella phage Sf21]	AUV63791.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY16241.1	URY16241.1 long tail fiber [Shigella phage ESh36]	URY16241.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY16241.1	URY16241.1 long tail fiber [Shigella phage ESh36]	URY16241.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWY13300.1	QWY13300.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM-ZQ3]	QWY13300.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWY13300.1	QWY13300.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM-ZQ3]	QWY13300.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QVW28396.1	QVW28396.1 long tail fiber proximal subunit [Escherichia phage C6]	QVW28396.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY14003.1	URY14003.1 long tail fiber [Shigella phage ESh28]	URY14003.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY14003.1	URY14003.1 long tail fiber [Shigella phage ESh28]	URY14003.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UUB18364.1	UUB18364.1 long tail fiber [Escherichia phage ST2]	UUB18364.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UUB18364.1	UUB18364.1 long tail fiber [Escherichia phage ST2]	UUB18364.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYR04159.1	AYR04159.1 long tail fiber proximal subunit [Escherichia phage OLB35]	AYR04159.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYR04159.1	AYR04159.1 long tail fiber proximal subunit [Escherichia phage OLB35]	AYR04159.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIX11797.1	AIX11797.1 putative tail fiber protein [Escherichia phage YD-2008.s]	AIX11797.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPW39413.1	UPW39413.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_ESCO47]	UPW39413.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UPW39413.1	UPW39413.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_ESCO47]	UPW39413.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QSL99341.1	QSL99341.1 long-tail fiber proximal subunit [Escherichia phage PTK]	QSL99341.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QSL99341.1	QSL99341.1 long-tail fiber proximal subunit [Escherichia phage PTK]	QSL99341.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY86216.1	WLY86216.1 long-tail fiber proximal subunit [Escherichia phage 308Ecol101PP]	WLY86216.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WLY86216.1	WLY86216.1 long-tail fiber proximal subunit [Escherichia phage 308Ecol101PP]	WLY86216.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHV82940.1	AHV82940.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_PhAPEC2]	AHV82940.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHV82940.1	AHV82940.1 long tail fiber proximal subunit [Escherichia phage vB_EcoM_PhAPEC2]	AHV82940.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBJ01026.1	QBJ01026.1 uncharacterized protein Rostov7_00137 [Vibrio phage Rostov 7]	QBJ01026.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV76920.1	QXV76920.1 long tail fiber proximal subunit [Escherichia phage ChristianSchoenbein]	QXV76920.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV76920.1	QXV76920.1 long tail fiber proximal subunit [Escherichia phage ChristianSchoenbein]	QXV76920.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77002.1	QBQ77002.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFL6982]	QBQ77002.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77002.1	QBQ77002.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFL6982]	QBQ77002.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG05826.1	QEG05826.1 long tail fiber proximal subunit [Shigella phage JK36]	QEG05826.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG05826.1	QEG05826.1 long tail fiber proximal subunit [Shigella phage JK36]	QEG05826.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WQN07228.1	WQN07228.1 long tail fiber [Escherichia phage vB-Eco-KMB38]	WQN07228.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WQN07228.1	WQN07228.1 long tail fiber [Escherichia phage vB-Eco-KMB38]	WQN07228.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75082.1	QXV75082.1 long tail fiber proximal subunit [Escherichia phage AlbertHofmann]	QXV75082.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75082.1	QXV75082.1 long tail fiber proximal subunit [Escherichia phage AlbertHofmann]	QXV75082.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89858.1	VEV89858.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-2]	VEV89858.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89858.1	VEV89858.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-2]	VEV89858.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UXD79597.1	UXD79597.1 hypothetical protein OJNDCHOG_01665 [Klebsiella phage 150049]	UXD79597.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AFO10772.1	AFO10772.1 tail fiber protein [Escherichia phage ECML-134]	AFO10772.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URQ05440.1	URQ05440.1 tail fiber protein [Escherichia phage vB_EcoM_SCS4]	URQ05440.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKM75972.1	QKM75972.1 non-contractile tail fiber protein [Escherichia phage P1723]	QKM75972.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WDR22381.1	WDR22381.1 long tail fiber [Salmonella phage vB_SenS_UTK0010]	WDR22381.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64532.1	QHR64532.1 long tail fiber proximal subunit [Escherichia phage teqdroes]	QHR64532.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR64532.1	QHR64532.1 long tail fiber proximal subunit [Escherichia phage teqdroes]	QHR64532.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG06640.1	QEG06640.1 long tail fiber proximal subunit [Shigella phage JK45]	QEG06640.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QEG06640.1	QEG06640.1 long tail fiber proximal subunit [Shigella phage JK45]	QEG06640.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKO61356.1	AKO61356.1 putative long tail fiber proximal subunit [Escherichia phage APCEc01]	AKO61356.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKO61356.1	AKO61356.1 putative long tail fiber proximal subunit [Escherichia phage APCEc01]	AKO61356.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WAX14149.1	WAX14149.1 hypothetical protein ECO71P1_00086 [Escherichia phage ECO71P1]	WAX14149.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIA10319.1	AIA10319.1 tail fiber protein [Vibrio phage X29]	AIA10319.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328813.1	CAL1328813.1 Long tail fiber [Escherichia phage vB_Eco_Geo]	CAL1328813.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328813.1	CAL1328813.1 Long tail fiber [Escherichia phage vB_Eco_Geo]	CAL1328813.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328734.1	CAL1328734.1 Long tail fiber [Escherichia phage vB_Eco_CP]	CAL1328734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAL1328734.1	CAL1328734.1 Long tail fiber [Escherichia phage vB_Eco_CP]	CAL1328734.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34456.1	WPK34456.1 long tail fiber [Escherichia phage AV112]	WPK34456.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34456.1	WPK34456.1 long tail fiber [Escherichia phage AV112]	WPK34456.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	BCG45033.1	BCG45033.1 tail fiber protein [Escherichia phage EK010]	BCG45033.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ASJ80337.1	ASJ80337.1 long tail fiber distal subunit [Escherichia phage ECD7]	ASJ80337.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHZ59623.1	QHZ59623.1 tail fiber protein [Escherichia phage bob]	QHZ59623.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AHN84840.1	AHN84840.1 hypothetical protein Phi2_0031 [Vibrio phage phi 2]	AHN84840.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UYE89917.1	UYE89917.1 tail fiber [Escherichia phage E20-1]	UYE89917.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMM35395.1	WMM35395.1 hypothetical protein JLDGIFAJ_00142 [Salmonella phage EH7]	WMM35395.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AEZ65107.1	AEZ65107.1 tail fiber protein [Escherichia phage phiKT]	AEZ65107.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK33924.1	WPK33924.1 long tail fiber proximal subunit [Escherichia phage AV110]	WPK33924.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK33924.1	WPK33924.1 long tail fiber proximal subunit [Escherichia phage AV110]	WPK33924.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANH51051.1	ANH51051.1 tail fibers protein [Salmonella phage 118970_sal2]	ANH51051.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ANM45640.1	ANM45640.1 tail fibers protein [Salmonella phage 100268_sal2]	ANM45640.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARM70798.1	ARM70798.1 long tail fiber, proximal subunit [Escherichia phage phiC120]	ARM70798.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ARM70798.1	ARM70798.1 long tail fiber, proximal subunit [Escherichia phage phiC120]	ARM70798.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMM34931.1	WMM34931.1 hypothetical protein MKLDHNNG_00140 [Salmonella phage EH1]	WMM34931.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WRO06086.1	WRO06086.1 tail fiber protein [Salmonella phage STK8t]	WRO06086.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVX92836.1	WVX92836.1 tail fiber protein proximal subunit [Escherichia phage vB_EcoM_HZ_ZJUN4]	WVX92836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WVX92836.1	WVX92836.1 tail fiber protein proximal subunit [Escherichia phage vB_EcoM_HZ_ZJUN4]	WVX92836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ78805.1	QBQ78805.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_KAW3E185]	QBQ78805.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ78805.1	QBQ78805.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_KAW3E185]	QBQ78805.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR72836.1	QHR72836.1 long tail fiber proximal subunit [Escherichia phage mobillu]	QHR72836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR72836.1	QHR72836.1 long tail fiber proximal subunit [Escherichia phage mobillu]	QHR72836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77757.1	QBQ77757.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFbE185]	QBQ77757.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBQ77757.1	QBQ77757.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_WFbE185]	QBQ77757.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1523441.1	CAJ1523441.1 Phage long tail fiber [Escherichia phage vB_Eco_NicPhage]	CAJ1523441.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1523441.1	CAJ1523441.1 Phage long tail fiber [Escherichia phage vB_Eco_NicPhage]	CAJ1523441.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34716.1	WPK34716.1 long tail fiber [Escherichia phage AV113]	WPK34716.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK34716.1	WPK34716.1 long tail fiber [Escherichia phage AV113]	WPK34716.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIZ02316.1	AIZ02316.1 long tail fiber protein proximal subunit [Escherichia phage vB_EcoM_VR20]	AIZ02316.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBP05598.1	QBP05598.1 long tail fiber proximal subunit [Escherichia phage PHB12]	QBP05598.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBP05598.1	QBP05598.1 long tail fiber proximal subunit [Escherichia phage PHB12]	QBP05598.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYN56439.1	AYN56439.1 long-tail fiber proximal subunit [Escherichia phage p000v]	AYN56439.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYN56439.1	AYN56439.1 long-tail fiber proximal subunit [Escherichia phage p000v]	AYN56439.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWD91439.1	AWD91439.1 long tail fiber proximal subunit [Enterobacteria phage vB_EcoM_IME339]	AWD91439.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AWD91439.1	AWD91439.1 long tail fiber proximal subunit [Enterobacteria phage vB_EcoM_IME339]	AWD91439.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXY85082.1	AXY85082.1 L-shaped tail fiber protein [Salmonella phage Sw2]	AXY85082.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UZV41564.1	UZV41564.1 tail protein [Escherichia phage Ec_MI-02]	UZV41564.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UZV41564.1	UZV41564.1 tail protein [Escherichia phage Ec_MI-02]	UZV41564.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK28662.1	WPK28662.1 long tail fiber [Escherichia phage vB_EcoM_EP32a]	WPK28662.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK28662.1	WPK28662.1 long tail fiber [Escherichia phage vB_EcoM_EP32a]	WPK28662.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG57468.1	QIG57468.1 long tail fiber proximal subunit [Escherichia phage F2]	QIG57468.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIG57468.1	QIG57468.1 long tail fiber proximal subunit [Escherichia phage F2]	QIG57468.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYD79451.1	AYD79451.1 hypothetical protein FFEPELFE_00211 [Shigella phage phi25-307]	AYD79451.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AYD79451.1	AYD79451.1 hypothetical protein FFEPELFE_00211 [Shigella phage phi25-307]	AYD79451.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WCX68663.1	WCX68663.1 tail fiber protein [Salmonella phage GSW6]	WCX68663.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR76706.1	QHR76706.1 long tail fiber proximal subunit [Escherichia phage moskry]	QHR76706.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR76706.1	QHR76706.1 long tail fiber proximal subunit [Escherichia phage moskry]	QHR76706.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWT42811.1	WWT42811.1 long-tail fiber proximal subunit [Escherichia phage 215Ecol030PP]	WWT42811.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWT42811.1	WWT42811.1 long-tail fiber proximal subunit [Escherichia phage 215Ecol030PP]	WWT42811.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN92811.1	QIN92811.1 hypothetical protein [Phage NBSal003]	QIN92811.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV56613.1	AUV56613.1 putative tail fiber protein [Faecalibacterium phage FP_Lugh]	AUV56613.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXC41642.1	AXC41642.1 tail fibers protein [Salmonella phage S131]	AXC41642.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QCQ65468.1	QCQ65468.1 L-shaped tail fiber protein [Salmonella phage Seabear]	QCQ65468.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR63706.1	QHR63706.1 long tail fiber proximal subunit [Escherichia phage teqhal]	QHR63706.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHR63706.1	QHR63706.1 long tail fiber proximal subunit [Escherichia phage teqhal]	QHR63706.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QIN99285.1	QIN99285.1 L-shaped tail fiber protein [Salmonella phage oldekolle]	QIN99285.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHJ73470.1	QHJ73470.1 long tail fiber distal subunit [Escherichia phage Ec_Makalu_001]	QHJ73470.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIW04091.1	AIW04091.1 L-shaped tail fiber protein [Salmonella phage Stitch]	AIW04091.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUM57596.1	AUM57596.1 putative fiber protein [Escherichia phage LAMP]	AUM57596.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WMM35089.1	WMM35089.1 hypothetical protein KPBMHCEF_00158 [Salmonella phage EH3]	WMM35089.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNR52187.1	QNR52187.1 tail fiber protein [Escherichia coli phage vB_EcoS_Ace]	QNR52187.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UHS64823.1	UHS64823.1 tail fiber [Escherichia phage vB_EcoD_Opt212]	UHS64823.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QWY14139.1	QWY14139.1 hypothetical protein SU7_12 [Escherichia phage vB_EcoP_SU7]	QWY14139.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHJ73198.1	QHJ73198.1 long tail fiber distal subunit [Escherichia phage Ec_Makalu_003]	QHJ73198.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80553.1	WBF80553.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F31]	WBF80553.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBF80553.1	WBF80553.1 long tail fiber, proximal subunit [Escherichia phage vB_Eco_F31]	WBF80553.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAW07038.1	UAW07038.1 long tail fiber protein [Escherichia phage vB_EcoM-pEK20]	UAW07038.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UAW07038.1	UAW07038.1 long tail fiber protein [Escherichia phage vB_EcoM-pEK20]	UAW07038.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWS22967.1	WWS22967.1 tail fiber protein proximal subunit [Escherichia phage LH01]	WWS22967.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WWS22967.1	WWS22967.1 tail fiber protein proximal subunit [Escherichia phage LH01]	WWS22967.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UOL50632.1	UOL50632.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_SCS57]	UOL50632.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UOL50632.1	UOL50632.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_SCS57]	UOL50632.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJJ57170.1	WJJ57170.1 long tail fiber [Escherichia phage LH2]	WJJ57170.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WJJ57170.1	WJJ57170.1 long tail fiber [Escherichia phage LH2]	WJJ57170.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY15506.1	URY15506.1 long tail fiber [Shigella phage ESh33]	URY15506.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	URY15506.1	URY15506.1 long tail fiber [Shigella phage ESh33]	URY15506.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO62942.1	QBO62942.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G2469]	QBO62942.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QBO62942.1	QBO62942.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM_G2469]	QBO62942.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV78792.1	QXV78792.1 long tail fiber proximal subunit [Escherichia phage FriedrichMiescher]	QXV78792.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV78792.1	QXV78792.1 long tail fiber proximal subunit [Escherichia phage FriedrichMiescher]	QXV78792.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV79069.1	QXV79069.1 long tail fiber proximal subunit [Escherichia phage FriedrichZschokke]	QXV79069.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV79069.1	QXV79069.1 long tail fiber proximal subunit [Escherichia phage FriedrichZschokke]	QXV79069.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV63938.1	AUV63938.1 long tail fiber protein, distal subunit [Shigella phage Sf20]	AUV63938.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW08373.1	QYW08373.1 long tail fiber [Enterobacteria phage phiC600P9]	QYW08373.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QYW08373.1	QYW08373.1 long tail fiber [Enterobacteria phage phiC600P9]	QYW08373.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNI20326.1	QNI20326.1 long tail fiber [Enterobacteria phage phiC600P9]	QNI20326.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QNI20326.1	QNI20326.1 long tail fiber [Enterobacteria phage phiC600P9]	QNI20326.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK37118.1	WPK37118.1 long tail fiber [Escherichia phage AV122]	WPK37118.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK37118.1	WPK37118.1 long tail fiber [Escherichia phage AV122]	WPK37118.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK17788.1	WPK17788.1 hypothetical protein [Escherichia phage BYEP01]	WPK17788.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPK17788.1	WPK17788.1 hypothetical protein [Escherichia phage BYEP01]	WPK17788.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	USM81266.1	USM81266.1 tail fiber [Escherichia phage vB_EcoP-101114BS3]	USM81266.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI79148.1	QZI79148.1 tail fiber [Escherichia phage vB_EcoP-101114UKE3]	QZI79148.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXC41492.1	AXC41492.1 tail fiber protein [Salmonella phage S130]	AXC41492.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QTJ63443.1	QTJ63443.1 L-shaped tail fiber [Salmonella phage STWB21]	QTJ63443.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIO58177.1	UIO58177.1 long-tail fiber proximal subunit [Escherichia phage vB_EcoM-S1P5QW]	UIO58177.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UIO58177.1	UIO58177.1 long-tail fiber proximal subunit [Escherichia phage vB_EcoM-S1P5QW]	UIO58177.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1092732.1	CAJ1092732.1 Phage long tail fiber [Escherichia phage vB_Eco_QOTSP]	CAJ1092732.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	CAJ1092732.1	CAJ1092732.1 Phage long tail fiber [Escherichia phage vB_Eco_QOTSP]	CAJ1092732.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ATI16836.1	ATI16836.1 long tail fiber subunit, proximal [Shigella phage Sf22]	ATI16836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ATI16836.1	ATI16836.1 long tail fiber subunit, proximal [Shigella phage Sf22]	ATI16836.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXF42554.1	AXF42554.1 long tail fiber proximal subunit [Enterobacteria phage RB18]	AXF42554.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXF42554.1	AXF42554.1 long tail fiber proximal subunit [Enterobacteria phage RB18]	AXF42554.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WZK98926.1	WZK98926.1 tail fiber protein [Escherichia phage Dru_SM1]	WZK98926.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIA79977.1	AIA79977.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_JS09]	AIA79977.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIA79977.1	AIA79977.1 putative long tail fiber proximal subunit [Escherichia phage vB_EcoM_JS09]	AIA79977.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WQN06567.1	WQN06567.1 tail fibers protein [Escherichia phage vB-Eco-KMB43]	WQN06567.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AKA61062.1	AKA61062.1 tail fiber protein [Enterobacteria phage JenK1]	AKA61062.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QHB48847.1	QHB48847.1 long tail fiber distal subunit [Escherichia phage E26]	QHB48847.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABR24760.1	ABR24760.1 gp37 long tail fiber distal subunit [Escherichia phage Phi1]	ABR24760.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UJP29742.1	UJP29742.1 putative long tail fiber protein [Salmonella phage UAB_60]	UJP29742.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75934.1	QXV75934.1 long tail fiber proximal subunit [Escherichia phage AndreasVesalius]	QXV75934.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV75934.1	QXV75934.1 long tail fiber proximal subunit [Escherichia phage AndreasVesalius]	QXV75934.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AUV61381.1	AUV61381.1 long tail fiber, distal subunit [Escherichia phage vB_EcoM-fHoEco02]	AUV61381.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKN87515.1	QKN87515.1 tail fiber protein [Yersinia phage vB_YenM_281]	QKN87515.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKN87515.1	QKN87515.1 tail fiber protein [Yersinia phage vB_YenM_281]	QKN87515.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	ABY52816.1	ABY52816.1 tail fiber [Escherichia phage phiEco32]	ABY52816.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QVW09054.1	QVW09054.1 large tail fiber protein [Salmonella phage Lv5cm]	QVW09054.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QVW09054.1	QVW09054.1 large tail fiber protein [Salmonella phage Lv5cm]	QVW09054.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ71688.1	WPJ71688.1 long tail fiber, proximal subunit [Escherichia phage vB-Eco-KMB40]	WPJ71688.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WPJ71688.1	WPJ71688.1 long tail fiber, proximal subunit [Escherichia phage vB-Eco-KMB40]	WPJ71688.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UEN68518.1	UEN68518.1 tail fibers protein [Escherichia phage MLP3]	UEN68518.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG41956.1	WFG41956.1 long tail fiber [Escherichia phage ADUt]	WFG41956.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WFG41956.1	WFG41956.1 long tail fiber [Escherichia phage ADUt]	WFG41956.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89591.1	VEV89591.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-65]	VEV89591.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89591.1	VEV89591.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-65]	VEV89591.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AIF71766.1	AIF71766.1 putative tail protein [Escherichia phage vB_EcoP_SU10]	AIF71766.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89090.1	VEV89090.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-90]	VEV89090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	VEV89090.1	VEV89090.1 Phage long tail fiber proximal subunit [Yersinia phage fPS-90]	VEV89090.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBM23482.1	WBM23482.1 long tail fiber proximal subunit [Escherichia phage PNJ-6]	WBM23482.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	WBM23482.1	WBM23482.1 long tail fiber proximal subunit [Escherichia phage PNJ-6]	WBM23482.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPI14988.1	QPI14988.1 long tail fiber [Salmonella phage GEC_vB_N3]	QPI14988.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QPI15607.1	QPI15607.1 long tail fiber [Salmonella phage GEC_vB_N7]	QPI15607.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AXC34569.1	AXC34569.1 tail fiber protein [Escherichia phage SRT7]	AXC34569.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AND75267.1	AND75267.1 tail fiber protein [Acinetobacter phage vB_AbaM_ME3]	AND75267.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	UCR74973.1	UCR74973.1 large distal tail fiber subunit [Escherichia phage vB_EcoM_C2-3]	UCR74973.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AVH86076.1	AVH86076.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM-G28]	AVH86076.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	AVH86076.1	AVH86076.1 putative long tail fiber, proximal subunit [Escherichia phage vB_EcoM-G28]	AVH86076.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKN87059.1	QKN87059.1 tail fiber protein [Yersinia phage vB_YenM_531]	QKN87059.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QKN87059.1	QKN87059.1 tail fiber protein [Yersinia phage vB_YenM_531]	QKN87059.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QCQ57221.1	QCQ57221.1 tail protein [Escherichia phage EcNP1]	QCQ57221.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QCQ57221.1	QCQ57221.1 tail protein [Escherichia phage EcNP1]	QCQ57221.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV73267.1	QXV73267.1 long tail fiber [Escherichia phage vB_EcoM_Nami]	QXV73267.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QXV73267.1	QXV73267.1 long tail fiber [Escherichia phage vB_EcoM_Nami]	QXV73267.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QGZ13716.1	QGZ13716.1 tail fibers protein [Escherichia phage vB_EcoP_EcoN5]	QGZ13716.1	0
+36c541f8-7003-40cd-a8b8-680449c12606	QZI80511.1	QZI80511.1 tail fiber [Escherichia phage vB_EcoP-CHD5UKE1]	QZI80511.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNY41740.1	UNY41740.1 tail fiber assembly protein [Burkholderia phage Milagro]	UNY41740.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNY41681.1	UNY41681.1 tail fiber assembly protein [Burkholderia phage Musica]	UNY41681.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ADP02315.1	ADP02315.1 gp22 [Burkholderia phage KL3]	ADP02315.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNY41853.1	UNY41853.1 tail fiber assembly protein [Burkholderia phage Momento]	UNY41853.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNY41797.1	UNY41797.1 tail fiber assembly protein [Burkholderia phage Menos]	UNY41797.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ABO60719.1	ABO60719.1 gp31, bacteriophage-acquired protein [Burkholderia phage phiE202]	ABO60719.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WWY66164.1	WWY66164.1 tail fiber assembly protein [Burkholderia phage vB_HM387]	WWY66164.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QWY84968.1	QWY84968.1 tail fiber assembly protein [Burkholderia phage PK23]	QWY84968.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AIP84297.1	AIP84297.1 caudovirales tail fiber assembly family protein [Burkholderia phage BEK]	AIP84297.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AAZ72625.1	AAZ72625.1 bacteriophage-acquired protein [Burkholderia phage phiE52237]	AAZ72625.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ABO60796.1	ABO60796.1 gp34, bacteriophage-acquired protein [Burkholderia phage phiE12-2]	ABO60796.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UPI15580.1	UPI15580.1 tail fiber assembly protein [Burkholderia phage PhiBP82.3]	UPI15580.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AFV51416.1	AFV51416.1 phage-acquired protein [Burkholderia phage phiX216]	AFV51416.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UKM53786.1	UKM53786.1 tail fiber assembly protein [Burkholderia phage PhiBP82.2]	UKM53786.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QPI18561.1	QPI18561.1 tail fiber assembly chaperone [Burkholderia phage phiE094]	QPI18561.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	USM11628.1	USM11628.1 tail fiber assembly protein [Burkholderia phage Carl1]	USM11628.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	USM11628.1	USM11628.1 tail fiber assembly protein [Burkholderia phage Carl1]	USM11628.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ADP02269.1	ADP02269.1 gp22 [Burkholderia phage KS5]	ADP02269.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ADP02269.1	ADP02269.1 gp22 [Burkholderia phage KS5]	ADP02269.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ADP02362.1	ADP02362.1 gp17 [Burkholderia phage KS14]	ADP02362.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BDD79935.1	BDD79935.1 hypothetical protein [Burkholderia phage FLC10]	BDD79935.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BDD79935.1	BDD79935.1 hypothetical protein [Burkholderia phage FLC10]	BDD79935.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BCB23195.1	BCB23195.1 tail fiber assembly protein [Burkholderia phage FLC5]	BCB23195.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BCB23195.1	BCB23195.1 tail fiber assembly protein [Burkholderia phage FLC5]	BCB23195.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	APU00297.1	APU00297.1 putative tail fiber assembly protein [Ralstonia phage RS-PII-1]	APU00297.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BAP15844.1	BAP15844.1 putative tail fiber assembly potein homolog [Ralstonia phage RSJ2]	BAP15844.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BAF52402.1	BAF52402.1 tail fiber assembly-like protein [Ralstonia phage RSA1]	BAF52402.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	BAP28127.1	BAP28127.1 hypothetical protein [Ralstonia phage RSY1]	BAP28127.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AVP40018.1	AVP40018.1 tail assembly protein [Ralstonia phage RsoM1USA]	AVP40018.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QMV32929.1	QMV32929.1 hypothetical protein 2CaD_00039 [Ralstonia phage Dina]	QMV32929.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UVD31937.1	UVD31937.1 tail fiber assembly protein [Klebsiella phage GZ7]	UVD31937.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WPJ51463.1	WPJ51463.1 tail fiber assembly protein [Klebsiella phage RCIP0034]	WPJ51463.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WPJ55913.1	WPJ55913.1 tail fiber assembly protein [Klebsiella phage RCIP0098]	WPJ55913.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UVK80398.1	UVK80398.1 tail fiber protein [Escherichia phage vB_EcoM_PD328]	UVK80398.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNI73660.1	UNI73660.1 tail fiber protein [Klebsiella phage KP12]	UNI73660.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AHN84587.1	AHN84587.1 tail fiber assembly protein [Enterobacteria phage 9g]	AHN84587.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QBQ80951.1	QBQ80951.1 putative tail fiber assembly protein [Escherichia phage vB_EcoS_HdK1]	QBQ80951.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AYD79767.1	AYD79767.1 tail fiber assembly protein [Enterobacter phage phiT5282H]	AYD79767.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WJZ70008.1	WJZ70008.1 tail fiber assembly-like protein [Vibrio phage PVP-XSN]	WJZ70008.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UOK17567.1	UOK17567.1 tail fiber assembly [Bordetella phage vB_BaM-IFTN9]	UOK17567.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AHN84841.1	AHN84841.1 hypothetical protein Phi2_0032 [Vibrio phage phi 2]	AHN84841.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AIA10318.1	AIA10318.1 tail fiber assembly-like protein [Vibrio phage X29]	AIA10318.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ACH86148.1	ACH86148.1 conserved hypothetical protein [Pseudomonas phage DVM-2008]	ACH86148.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AIX12244.1	AIX12244.1 dital long tail fiber assembly protein [Citrobacter phage Moon]	AIX12244.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ALA45719.1	ALA45719.1 tail fiber assembly protein [Escherichia phage Lambda]	ALA45719.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AFH20776.1	AFH20776.1 tail fiber assembly protein [Escherichia phage HK630]	AFH20776.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AFM76508.1	AFM76508.1 tail fiber assembly protein [Escherichia phage HK629]	AFM76508.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNA07124.1	UNA07124.1 tail fiber assembly protein [Escherichia phage Lambda imm21]	UNA07124.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNA07195.1	UNA07195.1 tail fiber assembly protein [Escherichia phage Lambda imm434]	UNA07195.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AAF31112.1	AAF31112.1 Gp29 [Escherichia phage HK97]	AAF31112.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AAA96558.1	AAA96558.1 orf-194 [Escherichia phage Lambda]	AAA96558.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ULG01048.1	ULG01048.1 tail fiber assembly protein [Escherichia phage 4W]	ULG01048.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ULG01205.1	ULG01205.1 tail fiber assembly protein [Escherichia phage E26-Berryhill]	ULG01205.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WRQ14351.1	WRQ14351.1 tail fiber assembly [Escherichia phage Lambda]	WRQ14351.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QPB10272.1	QPB10272.1 tail fiber assembly protein [Campylobacter phage CJLB-4]	QPB10272.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AFH20713.1	AFH20713.1 tail fiber assembly protein [Escherichia phage HK106]	AFH20713.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	VUF53596.1	VUF53596.1 Phage tail fiber assembly protein @ Phage tail fiber assembly protein, TfaP/TfaQ type [Escherichia phage ev099]	VUF53596.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UOX38130.1	UOX38130.1 tail fiber assembly protein [Salmonella phage SPF_0923]	UOX38130.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WJN66839.1	WJN66839.1 prophage tail fiber assembly protein [Edwardsiella phage EPP-1]	WJN66839.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	ASD51166.1	ASD51166.1 tail fiber assembly protein [Erwinia phage EtG]	ASD51166.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	AGG36536.1	AGG36536.1 putative tail fiber assembly protein [Escherichia phage P2]	AGG36536.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QEI25450.1	QEI25450.1 tail fiber assembly protein [Salmonella phage SI7]	QEI25450.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WOZ57166.1	WOZ57166.1 tail fiber assembly protein [Citrobacter phage phiNP]	WOZ57166.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QSM01476.1	QSM01476.1 tail fiber assembly-like protein [Marinomonas phage MfV]	QSM01476.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	UNI73716.1	UNI73716.1 tail fiber assembly protein [Klebsiella phage KP12]	UNI73716.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QEI25541.1	QEI25541.1 tail fiber assembly protein [Salmonella phage SW3]	QEI25541.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QEI25503.1	QEI25503.1 tail fiber assembly protein [Salmonella phage SW5]	QEI25503.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	VUF53360.1	VUF53360.1 Phage tail fiber assembly protein [Escherichia phage mEp460_ev081]	VUF53360.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	QPB11983.1	QPB11983.1 tail fiber assembly protein [Providencia phage PSTCR3]	QPB11983.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WFG40958.1	WFG40958.1 tail fiber assembly protein [Salmonella phage MET_P1_103_31]	WFG40958.1	0
+d378d1be-83e3-40fd-844a-2ecd6ea85fa1	WMM35450.1	WMM35450.1 prophage tail fiber assembly protein [Escherichia phage vB_EcoM-813R1]	WMM35450.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNY41682.1	UNY41682.1 tail sheath protein [Burkholderia phage Musica]	UNY41682.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNY41741.1	UNY41741.1 tail sheath protein [Burkholderia phage Milagro]	UNY41741.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADP02314.1	ADP02314.1 gp21 [Burkholderia phage KL3]	ADP02314.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNY41798.1	UNY41798.1 tail sheath protein [Burkholderia phage Menos]	UNY41798.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNY41854.1	UNY41854.1 tail sheath protein [Burkholderia phage Momento]	UNY41854.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WWY66165.1	WWY66165.1 major tail sheath protein [Burkholderia phage vB_HM387]	WWY66165.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QWY84969.1	QWY84969.1 tail sheath monomer [Burkholderia phage PK23]	QWY84969.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UPI15581.1	UPI15581.1 tail sheath monomer [Burkholderia phage PhiBP82.3]	UPI15581.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AFV51417.1	AFV51417.1 major tail sheath protein [Burkholderia phage phiX216]	AFV51417.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABO60733.1	ABO60733.1 gp30, phage tail sheath protein [Burkholderia phage phiE202]	ABO60733.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAZ72624.1	AAZ72624.1 phage tail sheath protein [Burkholderia phage phiE52237]	AAZ72624.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABO60754.1	ABO60754.1 gp33, phage tail sheath protein [Burkholderia phage phiE12-2]	ABO60754.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QPI18562.1	QPI18562.1 tail sheath monomer [Burkholderia phage phiE094]	QPI18562.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UKM53787.1	UKM53787.1 tail sheath monomer [Burkholderia phage PhiBP82.2]	UKM53787.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BCB23194.1	BCB23194.1 tail sheath protein (FI) [Burkholderia phage FLC5]	BCB23194.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADP02361.1	ADP02361.1 gp16 [Burkholderia phage KS14]	ADP02361.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AIP84270.1	AIP84270.1 phage tail sheath family protein [Burkholderia phage BEK]	AIP84270.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BDD79936.1	BDD79936.1 hypothetical protein [Burkholderia phage FLC10]	BDD79936.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAP28129.1	BAP28129.1 hypothetical protein [Ralstonia phage RSY1]	BAP28129.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAF52404.1	BAF52404.1 major tail seath protein gpFI [Ralstonia phage RSA1]	BAF52404.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AQT27304.1	AQT27304.1 major tail sheath protein [Salmonella phage SEN8]	AQT27304.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNA05760.1	UNA05760.1 tail sheath monomer [Yersinia phage vB_YenM_42.18]	UNA05760.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AGK86797.1	AGK86797.1 phage major tail sheath protein [Burkholderia phage ST79]	AGK86797.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADQ92414.1	ADQ92414.1 major tail sheath protein [Salmonella phage RE2010]	ADQ92414.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27604.1	QBP27604.1 tail sheath protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27604.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP08025.1	QBP08025.1 tail sheath protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08025.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27753.1	QBP27753.1 tail sheath monomer [Klebsiella phage ST512-KPC3phi13.6]	QBP27753.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27906.1	QBP27906.1 tail sheath monomer [Klebsiella phage ST258-KPC3phi16.1]	QBP27906.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27439.1	QBP27439.1 tail sheath protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27439.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBQ72014.1	QBQ72014.1 tail sheath monomer [Klebsiella phage ST15-OXA48phi14.1]	QBQ72014.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP07803.1	QBP07803.1 tail sheath protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07803.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27861.1	QBP27861.1 tail sheath monomer [Klebsiella phage ST11-OXA48phi15.3]	QBP27861.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP08105.1	QBP08105.1 tail sheath monomer [Klebsiella phage ST11-OXA245phi3.1]	QBP08105.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27678.1	QBP27678.1 tail sheath monomer [Klebsiella phage ST340-VIM1phi10.2]	QBP27678.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP27958.1	QBP27958.1 tail sheath monomer [Klebsiella phage ST258-KPC3phi16.2]	QBP27958.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AVP40020.1	AVP40020.1 tail sheath protein [Ralstonia phage RsoM1USA]	AVP40020.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNI73713.1	UNI73713.1 tail sheath monomer [Klebsiella phage KP12]	UNI73713.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QPB09420.1	QPB09420.1 tail sheath protein [Burkholderia phage Mana]	QPB09420.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAH1234714.1	CAH1234714.1 tail sheath protein [Escherichia phage Cartapus]	CAH1234714.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QYW06300.1	QYW06300.1 tail sheath protein FI [Shewanella phage vB_SspM_M16-3]	QYW06300.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBI84130.1	QBI84130.1 tail sheath monomer [Pseudomonas phage vB_Pae_BR319a]	QBI84130.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAA36249.1	BAA36249.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36249.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADP02266.1	ADP02266.1 gp19 [Burkholderia phage KS5]	ADP02266.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WWQ72106.1	WWQ72106.1 tail sheath protein [Pseudomonas phage Sirocco]	WWQ72106.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	USM11631.1	USM11631.1 tail sheath protein [Burkholderia phage Carl1]	USM11631.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AZF87863.1	AZF87863.1 tail sheath protein [Pseudomonas phage Dobby]	AZF87863.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARB15702.1	ARB15702.1 hypothetical protein [Klebsiella phage 4LV2017]	ARB15702.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AKA61151.1	AKA61151.1 putative tail sheath protein [Burkholderia phage AP3]	AKA61151.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADX32412.1	ADX32412.1 tail sheath protein [Erwinia phage ENT90]	ADX32412.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNA05881.1	UNA05881.1 tail sheath monomer [Yersinia phage vB_YenM_06.16-2]	UNA05881.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WPJ21705.1	WPJ21705.1 tail sheath protein [Bacillus phage vB_BpuM-ZY1]	WPJ21705.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNA05935.1	UNA05935.1 tail sheath monomer [Yersinia phage vB_YenM_56.17]	UNA05935.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UKL54263.1	UKL54263.1 tail sheath monomer [Yersinia phage vB_YenM_31.17]	UKL54263.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URE76601.1	URE76601.1 tail sheath monomer [Escherichia phage vB_EcoM-613R3]	URE76601.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNA05987.1	UNA05987.1 tail sheath monomer [Yersinia phage vB_YenM_201.16]	UNA05987.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QDJ98449.1	QDJ98449.1 tail sheath protein [Escherichia phage vB_EcoM-12474II]	QDJ98449.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QDJ98581.1	QDJ98581.1 tail sheath protein [Escherichia phage vB_EcoM-12474V]	QDJ98581.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QDJ98537.1	QDJ98537.1 tail sheath protein [Escherichia phage vB_EcoM-12474IV]	QDJ98537.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QDJ98496.1	QDJ98496.1 tail sheath protein [Escherichia phage vB_EcoM-12474III]	QDJ98496.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAG9593828.1	CAG9593828.1 Putative prophage major tail sheath protein [Peduovirus P2]	CAG9593828.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AGX84583.1	AGX84583.1 major tail sheath [Enterobacteria phage fiAA91-ss]	AGX84583.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	API82956.1	API82956.1 Phage tail sheath protein [Salmonella phage STYP1]	API82956.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAG9593865.1	CAG9593865.1 Putative prophage major tail sheath protein [Peduovirus P2]	CAG9593865.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAN28240.1	AAN28240.1 gpFI [Escherichia phage Wphi]	AAN28240.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UPI11472.1	UPI11472.1 putative major tail sheath protein [Yersinia phage VB-YPM-4]	UPI11472.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QKE55603.1	QKE55603.1 putative major tail sheath protein [Yersinia phage vB_YpM_46]	QKE55603.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAD03289.1	AAD03289.1 gpFI [Bacteriophage P2]	AAD03289.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC09635.1	URC09635.1 tail sheath monomer [Escherichia phage vB_EcoM-569R9]	URC09635.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WFG40955.1	WFG40955.1 tail sheath protein FI [Salmonella phage MET_P1_103_31]	WFG40955.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AKH49396.1	AKH49396.1 major tail sheath protein [Escherichia phage pro483]	AKH49396.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ULG01114.1	ULG01114.1 tail sheath monomer [Escherichia phage 10W]	ULG01114.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AGG36540.1	AGG36540.1 phage tail sheath protein FI [Escherichia phage P2]	AGG36540.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ULG00885.1	ULG00885.1 tail sheath monomer [Escherichia phage 11W]	ULG00885.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD39543.1	VUD39543.1 Phage major tail sheath protein [Peduovirus P24C9]	VUD39543.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AKH49323.1	AKH49323.1 tail sheath monomer [Escherichia phage pro147]	AKH49323.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ56013.1	WOZ56013.1 putative prophage major tail sheath protein [Yersinia phage vB_YpM_115]	WOZ56013.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ULG00700.1	ULG00700.1 tail sheath monomer [Escherichia phage D8]	ULG00700.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD38910.1	VUD38910.1 Major tail sheath protein [Peduovirus P24E6b]	VUD38910.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ56059.1	WOZ56059.1 putative prophage major tail sheath protein [Yersinia phage vB_YpM_117]	WOZ56059.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ULG01160.1	ULG01160.1 tail sheath monomer [Escherichia phage 12W]	ULG01160.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAH0786505.1	CAH0786505.1 Putative prophage major tail sheath protein [Escherichia phage P2_AC1]	CAH0786505.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URP83683.1	URP83683.1 tail sheath protein [Escherichia phage S164]	URP83683.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QXF95289.1	QXF95289.1 tail sheath monomer [Yersinia phage HQ103]	QXF95289.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD37984.1	VUD37984.1 Major tail sheath protein [Peduovirus P22H1]	VUD37984.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ULG01002.1	ULG01002.1 tail sheath monomer [Escherichia phage 9W]	ULG01002.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD37940.1	VUD37940.1 Phage major tail sheath protein [Peduovirus P22H4]	VUD37940.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AGF88433.1	AGF88433.1 major tail sheath protein [Salmonella phage FSLSP004]	AGF88433.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QEI25360.1	QEI25360.1 tail sheath protein [Salmonella phage SI22]	QEI25360.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QEI25405.1	QEI25405.1 tail sheath protein [Salmonella phage SW9]	QEI25405.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAG9593782.1	CAG9593782.1 Putative prophage major tail sheath protein [Peduovirus P2]	CAG9593782.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QDP43520.1	QDP43520.1 major tail sheath protein [Bacteriophage R18C]	QDP43520.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAP04458.1	AAP04458.1 gpFI [Yersinia phage L-413C]	AAP04458.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WPJ53096.1	WPJ53096.1 tail sheath protein [Klebsiella phage RCIP0057]	WPJ53096.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAN08383.1	AAN08383.1 gp21 [Salmonella phage PSP3]	AAN08383.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBQ71566.1	QBQ71566.1 tail sheath protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71566.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD39045.1	VUD39045.1 Major tail sheath protein [Peduovirus P24A7b]	VUD39045.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC09830.1	URC09830.1 tail sheath monomer [Escherichia phage vB_EcoM-720R8]	URC09830.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD38028.1	VUD38028.1 Phage tail sheath monomer [Peduovirus P24B2]	VUD38028.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UPI11520.1	UPI11520.1 putative major tail sheath protein [Yersinia phage VB-YPM-18]	UPI11520.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ56102.1	WOZ56102.1 putative prophage major tail sheath protein [Yersinia phage vB_YpM_476A]	WOZ56102.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QKE55510.1	QKE55510.1 putative major tail sheath protein [Yersinia phage vB_YpM_22]	QKE55510.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ56142.1	WOZ56142.1 putative prophage major tail sheath protein [Yersinia phage vB_YpM_476B]	WOZ56142.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QKE55646.1	QKE55646.1 putative major tail sheath protein [Yersinia phage vB_YpM_50]	QKE55646.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QIW90045.1	QIW90045.1 hypothetical protein [Yersinia phage P37]	QIW90045.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ALF02258.1	ALF02258.1 tail sheath monomer [Salmonella phage SEN1]	ALF02258.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ASD51163.1	ASD51163.1 tail sheath monomer [Erwinia phage EtG]	ASD51163.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QYC52679.1	QYC52679.1 tail sheath protein [Salmonella phage BIS20]	QYC52679.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UTC25932.1	UTC25932.1 tail sheath protein [Salmonella phage vB_Sal_PHB48]	UTC25932.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAC34166.1	AAC34166.1 tail sheath protein FI [Escherichia phage 186]	AAC34166.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WYC18459.1	WYC18459.1 tail sheath monomer [Yersinia phage vB_YpM_MHG38]	WYC18459.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WYC18390.1	WYC18390.1 tail sheath monomer [Yersinia phage vB_YpM_MDG94-186]	WYC18390.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WYC18417.1	WYC18417.1 tail sheath monomer [Yersinia phage vB_YpM_MDG45]	WYC18417.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WXX18222.1	WXX18222.1 tail sheath monomer [Yersinia phage GCS667]	WXX18222.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AFJ75495.1	AFJ75495.1 major tail sheath protein [Stenotrophomonas phage Smp131]	AFJ75495.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UGC97266.1	UGC97266.1 tail sheath monomer [Aeromonas phage vB_AsaM_LPM4]	UGC97266.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UZV40225.1	UZV40225.1 tail sheath subtilisin-like domain-containing protein [Acidovorax phage Acica]	UZV40225.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UYL85526.1	UYL85526.1 tail sheath subtilisin-like domain-containing protein [Acidovorax phage Alfacinha1]	UYL85526.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ALF02316.1	ALF02316.1 tail sheath monomer [Salmonella phage SEN4]	ALF02316.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ALF02365.1	ALF02365.1 tail sheath monomer [Salmonella phage SEN5]	ALF02365.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UYL85425.1	UYL85425.1 tail sheath subtilisin-like domain-containing protein [Acidovorax phage Alfacinha3]	UYL85425.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QBP07962.1	QBP07962.1 tail sheath monomer [Klebsiella phage ST16-OXA48phi5.4]	QBP07962.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAH15156.1	BAH15156.1 hypothetical protein [Serratia phage KSP20]	BAH15156.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AYD79772.1	AYD79772.1 putative major tail sheath protein [Enterobacter phage phiT5282H]	AYD79772.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AIZ95157.1	AIZ95157.1 tail sheath monomer [Escherichia phage P88]	AIZ95157.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	VUD40190.1	VUD40190.1 Phage tail sheath monomer [Xuanwuvirus P884B11]	VUD40190.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARB15660.1	ARB15660.1 tail sheath monomer [Klebsiella phage 3LV2017]	ARB15660.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ57119.1	WOZ57119.1 late control gene D protein [Citrobacter phage Shae_phiSM]	WOZ57119.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABD90626.1	ABD90626.1 tail sheath protein FI [Mannheimia phage phiMhaA1-BAA410]	ABD90626.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABD90576.1	ABD90576.1 tail sheath protein FI [Mannheimia phage PHL101]	ABD90576.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AJA73129.1	AJA73129.1 tail sheath protein FI [Mannheimia phage vB_MhM_2256AP1]	AJA73129.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AJA72897.1	AJA72897.1 tail sheath protein FI [Mannheimia phage vB_MhM_535AP1]	AJA72897.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AFL46473.1	AFL46473.1 phage tail sheath protein [Mannheimia phage vB_MhM_1152AP]	AFL46473.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AJA72948.1	AJA72948.1 tail sheath protein FI [Mannheimia phage vB_MhM_587AP1]	AJA72948.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AJA73076.1	AJA73076.1 tail sheath protein [Mannheimia phage vB_MhM_1127AP1]	AJA73076.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AFV81361.1	AFV81361.1 tail sheath protein [Vibrio phage vB_VpaM_MAR]	AFV81361.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	CAX65003.1	CAX65003.1 gp22 protein [Vibrio phage VP585]	CAX65003.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAN12338.1	AAN12338.1 ORF39 [Vibrio phage VHML]	AAN12338.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QXF95216.1	QXF95216.1 tail sheath protein FI [Wolbachia phage WO]	QXF95216.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADW80220.1	ADW80220.1 tail sheath [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80220.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADW80167.1	ADW80167.1 tail sheath [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80167.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AOA49524.1	AOA49524.1 tail sheath family protein [Wolbachia phage WO]	AOA49524.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QEA09554.1	QEA09554.1 tail sheath monomer [Wolbachia phage WO]	QEA09554.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QHJ75375.1	QHJ75375.1 tail sheath monomer [Wolbachia phage WO]	QHJ75375.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WID42135.1	WID42135.1 tail protein [Pseudomonas phage ZRG1]	WID42135.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AFU62900.1	AFU62900.1 phage tail sheath protein FI [Acidithiobacillus phage AcaML1]	AFU62900.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UOL51114.1	UOL51114.1 tail sheath monomer [Citrobacter phage Chris1]	UOL51114.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QXN68733.1	QXN68733.1 tail sheath protein [Hafnia phage yong2]	QXN68733.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WNY35849.1	WNY35849.1 tail sheath protein [Vibrio phage Vb_VaM_Valp1]	WNY35849.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WNY35849.1	WNY35849.1 tail sheath protein [Vibrio phage Vb_VaM_Valp1]	WNY35849.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WEV89353.1	WEV89353.1 hypothetical protein H10PHJ05_52 [Aeromonas phage HJ05]	WEV89353.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAA05467.1	BAA05467.1 tail sheath protein [Phage PS17]	BAA05467.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADE87918.1	ADE87918.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87918.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ADE87918.1	ADE87918.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87918.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WWY66200.1	WWY66200.1 major tail sheath protein [Burkholderia phage vB_HM795]	WWY66200.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ANN86128.1	ANN86128.1 putative tail sheath protein [Enterobacter phage Arya]	ANN86128.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ANN86128.1	ANN86128.1 putative tail sheath protein [Enterobacter phage Arya]	ANN86128.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	USZ80549.1	USZ80549.1 putative tail protein [Serratia phage MQ-4]	USZ80549.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	USZ80549.1	USZ80549.1 putative tail protein [Serratia phage MQ-4]	USZ80549.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARM70444.1	ARM70444.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70444.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARM70444.1	ARM70444.1 tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70444.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC09738.1	URC09738.1 tail sheath monomer [Escherichia phage vB_EcoM-720R5]	URC09738.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC09434.1	URC09434.1 tail sheath monomer [Escherichia phage vB_EcoM-569R10]	URC09434.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC10610.1	URC10610.1 tail sheath monomer [Escherichia phage vB_EcoM-705R4]	URC10610.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC10676.1	URC10676.1 tail sheath monomer [Escherichia phage vB_EcoM-783R5]	URC10676.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AIM50571.1	AIM50571.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50571.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AIM50571.1	AIM50571.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50571.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QIG65609.1	QIG65609.1 tail sheath monomer [Salmonella phage PT1]	QIG65609.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QIG65609.1	QIG65609.1 tail sheath monomer [Salmonella phage PT1]	QIG65609.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QMP19182.1	QMP19182.1 tail sheath protein [Pseudomonas phage Persinger]	QMP19182.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QMP19182.1	QMP19182.1 tail sheath protein [Pseudomonas phage Persinger]	QMP19182.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AXF38227.1	AXF38227.1 putative tail sheath protein [Ralstonia phage phiRSP]	AXF38227.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AXF38227.1	AXF38227.1 putative tail sheath protein [Ralstonia phage phiRSP]	AXF38227.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21920.1	QJB21920.1 tail sheath monomer [Xanthomonas phage FoX3]	QJB21920.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21920.1	QJB21920.1 tail sheath monomer [Xanthomonas phage FoX3]	QJB21920.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21839.1	QJB21839.1 tail sheath monomer [Xanthomonas phage FoX2]	QJB21839.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21839.1	QJB21839.1 tail sheath monomer [Xanthomonas phage FoX2]	QJB21839.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WNL50855.1	WNL50855.1 tail sheath protein [Xanthomonas phage Murka]	WNL50855.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WNL50855.1	WNL50855.1 tail sheath protein [Xanthomonas phage Murka]	WNL50855.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21998.1	QJB21998.1 tail sheath monomer [Xanthomonas phage FoX5]	QJB21998.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21998.1	QJB21998.1 tail sheath monomer [Xanthomonas phage FoX5]	QJB21998.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21758.1	QJB21758.1 tail sheath monomer [Xanthomonas phage FoX1]	QJB21758.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QJB21758.1	QJB21758.1 tail sheath monomer [Xanthomonas phage FoX1]	QJB21758.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QWY14222.1	QWY14222.1 tail sheath [Xanthomonas phage M29]	QWY14222.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QWY14222.1	QWY14222.1 tail sheath [Xanthomonas phage M29]	QWY14222.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAO20618.1	BAO20618.1 putative tail sheath protein [Pseudomonas phage PPpW-3]	BAO20618.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAO20618.1	BAO20618.1 putative tail sheath protein [Pseudomonas phage PPpW-3]	BAO20618.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WDE69799.1	WDE69799.1 tail sheath subtilisin-like domain-containing protein [Vibrio phage VPHZ6]	WDE69799.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QKN87916.1	QKN87916.1 tail sheath protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87916.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QKN87916.1	QKN87916.1 tail sheath protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87916.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QOE32751.1	QOE32751.1 tail sheath protein [Achromobacter phage Mano]	QOE32751.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QOE32751.1	QOE32751.1 tail sheath protein [Achromobacter phage Mano]	QOE32751.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAS47878.1	AAS47878.1 gp39 [Burkholderia phage BcepMu]	AAS47878.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABO60661.1	ABO60661.1 gp13, phage tail sheath protein [Burkholderia phage phiE255]	ABO60661.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNI73674.1	UNI73674.1 major tail sheath protein [Klebsiella phage KP12]	UNI73674.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	UNI73674.1	UNI73674.1 major tail sheath protein [Klebsiella phage KP12]	UNI73674.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QHJ75484.1	QHJ75484.1 tail sheath monomer [Wolbachia phage WO]	QHJ75484.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QHJ75597.1	QHJ75597.1 tail sheath monomer [Wolbachia phage WO]	QHJ75597.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARQ95331.1	ARQ95331.1 tail sheath monomer [Bradyrhizobium phage BDU-MI-1]	ARQ95331.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ARQ95331.1	ARQ95331.1 tail sheath monomer [Bradyrhizobium phage BDU-MI-1]	ARQ95331.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QPB08633.1	QPB08633.1 tail sheath protein [Burkholderia phage Mica]	QPB08633.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QPB08633.1	QPB08633.1 tail sheath protein [Burkholderia phage Mica]	QPB08633.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AOT25330.1	AOT25330.1 tail sheath protein [Ochrobactrum phage POA1180]	AOT25330.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WWQ71677.1	WWQ71677.1 tail sheath protein [Pseudomonas phage Bise]	WWQ71677.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WWQ71677.1	WWQ71677.1 tail sheath protein [Pseudomonas phage Bise]	WWQ71677.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	APU00419.1	APU00419.1 tail sheath monomer [Aeromonas phage 3]	APU00419.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	APU00840.1	APU00840.1 tail sheath monomer [Aeromonas phage 59.1]	APU00840.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AWH15330.1	AWH15330.1 putative tail sheath protein [Aeromonas phage 14AhydR10PP]	AWH15330.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AWH14532.1	AWH14532.1 putative tail sheath protein [Aeromonas phage 13AhydR10PP]	AWH14532.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AWH15044.1	AWH15044.1 putative tail sheath protein [Aeromonas phage 85AhydR10PP]	AWH15044.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	APU00755.1	APU00755.1 tail sheath monomer [Aeromonas phage Asp37]	APU00755.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AUR88220.1	AUR88220.1 tail sheath protein [Vibrio phage 1.111.A._10N.286.45.E6]	AUR88220.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AUR88282.1	AUR88282.1 tail sheath protein [Vibrio phage 1.111.B._10N.286.45.E6]	AUR88282.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ANZ52212.1	ANZ52212.1 putative tail sheath protein [Aeromonas phage Ahp2]	ANZ52212.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	APU01171.1	APU01171.1 tail sheath monomer [Aeromonas phage 32]	APU01171.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QIZ02632.1	QIZ02632.1 tail sheath protein [Aeromonas phage AhyVDH1]	QIZ02632.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AWY03253.1	AWY03253.1 tail protein [Pasteurella phage AFS-2018a]	AWY03253.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AGN38704.1	AGN38704.1 tail sheath protein [Rhizobium phage RR1-B]	AGN38704.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AZV00465.1	AZV00465.1 tail sheath monomer protein [Paracoccus phage vB_PyeM_Pyei1]	AZV00465.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAD16803.1	BAD16803.1 similar to phage-related contractile tail sheath protein [Xylella fastidiosa Temecula1] [Wolbachia phage WOcauB1]	BAD16803.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABY90388.1	ABY90388.1 putative tail sheath protein [Halomonas phage phiHAP-1]	ABY90388.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WAK43890.1	WAK43890.1 putative prophage major tail sheath protein [Sulfurimonas phage SNW-1]	WAK43890.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QHJ75485.1	QHJ75485.1 tail sheath monomer [Wolbachia phage WO]	QHJ75485.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QHJ75598.1	QHJ75598.1 tail sheath monomer [Wolbachia phage WO]	QHJ75598.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QXM18786.1	QXM18786.1 putative prophage major tail sheath protein [Vibrio phage ST2-2pr]	QXM18786.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53794.1	ABU53794.1 cje0227 [Campylobacter phage CGC-2007]	ABU53794.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AAS38494.2	AAS38494.2 phage tail sheath protein FI-like [Vibrio phage VP882]	AAS38494.2	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53811.1	ABU53811.1 cje0227 [Campylobacter phage CGC-2007]	ABU53811.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53829.1	ABU53829.1 cje0227 [Campylobacter phage CGC-2007]	ABU53829.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53714.1	ABU53714.1 cje0227 [Campylobacter phage CGC-2007]	ABU53714.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53779.1	ABU53779.1 cje0227 [Campylobacter phage CGC-2007]	ABU53779.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QVW54053.1	QVW54053.1 tail sheath family protein [Campylobacter phage PC10]	QVW54053.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QCW19932.1	QCW19932.1 tail protein [Vibrio phage Va_PF430-3_p42]	QCW19932.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53889.1	ABU53889.1 cje0227 [Campylobacter phage CGC-2007]	ABU53889.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53762.1	ABU53762.1 cje0227 [Campylobacter phage CGC-2007]	ABU53762.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53746.1	ABU53746.1 cje0227 [Campylobacter phage CGC-2007]	ABU53746.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53730.1	ABU53730.1 cje0227 [Campylobacter phage CGC-2007]	ABU53730.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53879.1	ABU53879.1 cje0227 [Campylobacter phage CGC-2007]	ABU53879.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WKW83151.1	WKW83151.1 tail sheath monomer [Campylobacter phage CAM-P21]	WKW83151.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	BAD16805.1	BAD16805.1 similar to ORF39 [Vibrio harveyi bacteriophage VHML] [Wolbachia phage WOcauB1]	BAD16805.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ABU53861.1	ABU53861.1 cje0227 [Campylobacter phage CGC-2007]	ABU53861.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ55797.1	WOZ55797.1 hypothetical protein P39_00013 [Yersinia phage vB_YpM_39]	WOZ55797.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URE76654.1	URE76654.1 tail sheath protein FI [Escherichia phage vB_EcoM-473R2]	URE76654.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	URC09224.1	URC09224.1 tail sheath protein FI [Escherichia phage vB_EcoM-613R2]	URC09224.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ55867.1	WOZ55867.1 hypothetical protein P41_00013 [Yersinia phage vB_YpM_41]	WOZ55867.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WOZ55934.1	WOZ55934.1 hypothetical protein P44_00013 [Yersinia phage vB_YpM_44]	WOZ55934.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	ALN97539.1	ALN97539.1 FI major tail sheath protein [Aeromonas phage phiARM81ld]	ALN97539.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WAK79561.1	WAK79561.1 tail sheath [Clostridium phage Saumur]	WAK79561.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	QVQ56215.1	QVQ56215.1 tail protein [Paenibacillus phage Pd_22F]	QVQ56215.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WRQ07990.1	WRQ07990.1 tail sheath protein FI [Phage nd4]	WRQ07990.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	AKC57541.1	AKC57541.1 tail sheath protein [Fusobacterium phage Funu1]	AKC57541.1	0
+d27484d1-ac0b-4e59-96ec-db3bd6316d6e	WJZ69994.1	WJZ69994.1 tail sheath protein [Vibrio phage PVP-XSN]	WJZ69994.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNY41683.1	UNY41683.1 tail tube protein [Burkholderia phage Musica]	UNY41683.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNY41742.1	UNY41742.1 tail tube protein [Burkholderia phage Milagro]	UNY41742.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNY41799.1	UNY41799.1 tail tube protein [Burkholderia phage Menos]	UNY41799.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADP02313.1	ADP02313.1 gp20 [Burkholderia phage KL3]	ADP02313.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNY41855.1	UNY41855.1 tail tube protein [Burkholderia phage Momento]	UNY41855.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UKM53788.1	UKM53788.1 major tail tube protein [Burkholderia phage PhiBP82.2]	UKM53788.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAZ72623.1	AAZ72623.1 phage major tail tube protein [Burkholderia phage phiE52237]	AAZ72623.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ABO60784.1	ABO60784.1 gp32, phage major tail tube protein [Burkholderia phage phiE12-2]	ABO60784.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WWY66166.1	WWY66166.1 major tail tube protein [Burkholderia phage vB_HM387]	WWY66166.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UPI15582.1	UPI15582.1 major tail tube protein [Burkholderia phage PhiBP82.3]	UPI15582.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QPI18563.1	QPI18563.1 major tail tube protein [Burkholderia phage phiE094]	QPI18563.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AIP84272.1	AIP84272.1 phage major tail tube protein [Burkholderia phage BEK]	AIP84272.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AFV51418.1	AFV51418.1 major tail tube protein [Burkholderia phage phiX216]	AFV51418.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QWY84970.1	QWY84970.1 major tail tube protein [Burkholderia phage PK23]	QWY84970.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ABO60720.1	ABO60720.1 gp29, phage major tail tube protein [Burkholderia phage phiE202]	ABO60720.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BCB23193.1	BCB23193.1 tail tube protein (FII) [Burkholderia phage FLC5]	BCB23193.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADP02360.1	ADP02360.1 gp15 [Burkholderia phage KS14]	ADP02360.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BDD79937.1	BDD79937.1 hypothetical protein [Burkholderia phage FLC10]	BDD79937.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AFJ75496.1	AFJ75496.1 tail core protein [Stenotrophomonas phage Smp131]	AFJ75496.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AVP40021.1	AVP40021.1 major tail tube protein [Ralstonia phage RsoM1USA]	AVP40021.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AZF87864.1	AZF87864.1 major tail tube protein [Pseudomonas phage Dobby]	AZF87864.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WWQ72107.1	WWQ72107.1 tail tube protein [Pseudomonas phage Sirocco]	WWQ72107.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBI84131.1	QBI84131.1 major tail tube protein [Pseudomonas phage vB_Pae_BR319a]	QBI84131.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAA36250.1	BAA36250.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36250.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAP28130.1	BAP28130.1 hypothetical protein [Ralstonia phage RSY1]	BAP28130.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAF52405.1	BAF52405.1 putative tail tube protein gpFII [Ralstonia phage RSA1]	BAF52405.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AGK86798.1	AGK86798.1 phage major tail tube protein [Burkholderia phage ST79]	AGK86798.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADP02265.1	ADP02265.1 gp18 [Burkholderia phage KS5]	ADP02265.1	0
+52e11861-0676-43be-8b43-912eca54e74a	USM11632.1	USM11632.1 tail tube protein [Burkholderia phage Carl1]	USM11632.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNA05988.1	UNA05988.1 major tail tube protein [Yersinia phage vB_YenM_201.16]	UNA05988.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AKA61152.1	AKA61152.1 putative major tail tube protein [Burkholderia phage AP3]	AKA61152.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNA05936.1	UNA05936.1 major tail tube protein [Yersinia phage vB_YenM_56.17]	UNA05936.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNA05882.1	UNA05882.1 major tail tube protein [Yersinia phage vB_YenM_06.16-2]	UNA05882.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UKL54264.1	UKL54264.1 major tail tube protein [Yersinia phage vB_YenM_31.17]	UKL54264.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QPB09421.1	QPB09421.1 tail tube protein [Burkholderia phage Mana]	QPB09421.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAP04459.1	AAP04459.1 FII [Yersinia phage L-413C]	AAP04459.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QDP43521.1	QDP43521.1 major tail tube protein [Bacteriophage R18C]	QDP43521.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AKH49322.1	AKH49322.1 major tail tube protein [Escherichia phage pro147]	AKH49322.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URC09829.1	URC09829.1 major tail tube protein [Escherichia phage vB_EcoM-720R8]	URC09829.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAG9593781.1	CAG9593781.1 hypothetical protein P2SIAC10_00020 [Peduovirus P2]	CAG9593781.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UPI11473.1	UPI11473.1 hypothetical protein COILCCMC_00025 [Yersinia phage VB-YPM-4]	UPI11473.1	0
+52e11861-0676-43be-8b43-912eca54e74a	API82957.1	API82957.1 Phage tail tube protein FII [Salmonella phage STYP1]	API82957.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAD03290.1	AAD03290.1 gpFII [Bacteriophage P2]	AAD03290.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QDJ98448.1	QDJ98448.1 tail tube protein [Escherichia phage vB_EcoM-12474II]	QDJ98448.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD38029.1	VUD38029.1 Phage major tail tube protein [Peduovirus P24B2]	VUD38029.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ULG01003.1	ULG01003.1 major tail tube protein [Escherichia phage 9W]	ULG01003.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AKH49397.1	AKH49397.1 major tail tube protein [Escherichia phage pro483]	AKH49397.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD37941.1	VUD37941.1 Phage major tail tube protein [Peduovirus P22H4]	VUD37941.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAN28241.1	AAN28241.1 gpFII [Escherichia phage Wphi]	AAN28241.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UPI11521.1	UPI11521.1 hypothetical protein BFNKNBEH_00031 [Yersinia phage VB-YPM-18]	UPI11521.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ56103.1	WOZ56103.1 hypothetical protein B476A_00023 [Yersinia phage vB_YpM_476A]	WOZ56103.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QDJ98580.1	QDJ98580.1 tail tube protein [Escherichia phage vB_EcoM-12474V]	QDJ98580.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QKE55604.1	QKE55604.1 hypothetical protein vBYpM46_00024 [Yersinia phage vB_YpM_46]	QKE55604.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ULG00701.1	ULG00701.1 major tail tube protein [Escherichia phage D8]	ULG00701.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD39047.1	VUD39047.1 Major tail tube protein [Peduovirus P24A7b]	VUD39047.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAG9593829.1	CAG9593829.1 hypothetical protein P2DC1_00025 [Peduovirus P2]	CAG9593829.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAH0786504.1	CAH0786504.1 hypothetical protein P2AC1_00019 [Escherichia phage P2_AC1]	CAH0786504.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD38913.1	VUD38913.1 Major tail tube protein [Peduovirus P24E6b]	VUD38913.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QKE55511.1	QKE55511.1 hypothetical protein vBYpM22_00026 [Yersinia phage vB_YpM_22]	QKE55511.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QIW90044.1	QIW90044.1 putative tail core protein [Yersinia phage P37]	QIW90044.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QXF95290.1	QXF95290.1 major tail tube protein [Yersinia phage HQ103]	QXF95290.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QDJ98536.1	QDJ98536.1 tail tube protein [Escherichia phage vB_EcoM-12474IV]	QDJ98536.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AGG36541.1	AGG36541.1 phage major tail tube protein [Escherichia phage P2]	AGG36541.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ56143.1	WOZ56143.1 hypothetical protein B476B_00023 [Yersinia phage vB_YpM_476B]	WOZ56143.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WFG40954.1	WFG40954.1 head closure [Salmonella phage MET_P1_103_31]	WFG40954.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ULG01161.1	ULG01161.1 major tail tube protein [Escherichia phage 12W]	ULG01161.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD37985.1	VUD37985.1 Major tail tube protein [Peduovirus P22H1]	VUD37985.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AGX84584.1	AGX84584.1 major tail tube [Enterobacteria phage fiAA91-ss]	AGX84584.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URP83684.1	URP83684.1 major tail tube protein [Escherichia phage S164]	URP83684.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QDJ98495.1	QDJ98495.1 tail tube protein [Escherichia phage vB_EcoM-12474III]	QDJ98495.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QKE55647.1	QKE55647.1 hypothetical protein vBYpM50_00026 [Yersinia phage vB_YpM_50]	QKE55647.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAG9593864.1	CAG9593864.1 hypothetical protein P2SIDE7_00018 [Peduovirus P2]	CAG9593864.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URC09636.1	URC09636.1 major tail tube protein [Escherichia phage vB_EcoM-569R9]	URC09636.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ULG01113.1	ULG01113.1 major tail tube protein [Escherichia phage 10W]	ULG01113.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ULG00886.1	ULG00886.1 major tail tube protein [Escherichia phage 11W]	ULG00886.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ56014.1	WOZ56014.1 hypothetical protein B115_00026 [Yersinia phage vB_YpM_115]	WOZ56014.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ56060.1	WOZ56060.1 hypothetical protein B117_00026 [Yersinia phage vB_YpM_117]	WOZ56060.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ASD51162.1	ASD51162.1 major tail tube protein [Erwinia phage EtG]	ASD51162.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UTC25931.1	UTC25931.1 major tail tube protein [Salmonella phage vB_Sal_PHB48]	UTC25931.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAC34167.1	AAC34167.1 tail tube protein FII [Escherichia phage 186]	AAC34167.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QYC52680.1	QYC52680.1 major tail tube protein [Salmonella phage BIS20]	QYC52680.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AGF88434.1	AGF88434.1 major tail tube protein [Salmonella phage FSLSP004]	AGF88434.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAN08384.1	AAN08384.1 gp22 [Salmonella phage PSP3]	AAN08384.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URE76600.1	URE76600.1 major tail tube protein [Escherichia phage vB_EcoM-613R3]	URE76600.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WPJ53095.1	WPJ53095.1 tail tube protein [Klebsiella phage RCIP0057]	WPJ53095.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WXX18221.1	WXX18221.1 major tail tube protein [Yersinia phage GCS667]	WXX18221.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNA05761.1	UNA05761.1 major tail tube protein [Yersinia phage vB_YenM_42.18]	UNA05761.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QEI25361.1	QEI25361.1 major tail tube protein [Salmonella phage SI22]	QEI25361.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QEI25406.1	QEI25406.1 major tail tube protein [Salmonella phage SW9]	QEI25406.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WYC18460.1	WYC18460.1 major tail tube protein [Yersinia phage vB_YpM_MHG38]	WYC18460.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WYC18391.1	WYC18391.1 major tail tube protein [Yersinia phage vB_YpM_MDG94-186]	WYC18391.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WYC18418.1	WYC18418.1 major tail tube protein [Yersinia phage vB_YpM_MDG45]	WYC18418.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UYL85527.1	UYL85527.1 major tail tube protein [Acidovorax phage Alfacinha1]	UYL85527.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UYL85426.1	UYL85426.1 major tail tube protein [Acidovorax phage Alfacinha3]	UYL85426.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WPJ21706.1	WPJ21706.1 tail tube protein [Bacillus phage vB_BpuM-ZY1]	WPJ21706.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADX32427.1	ADX32427.1 major tail tube protein [Erwinia phage ENT90]	ADX32427.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UZV40226.1	UZV40226.1 major tail tube protein [Acidovorax phage Acica]	UZV40226.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27440.1	QBP27440.1 putative major tail tube protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27440.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBQ72015.1	QBQ72015.1 putative major tail tube protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72015.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP07802.1	QBP07802.1 putative major tail tube protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07802.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27603.1	QBP27603.1 major tail tube protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27603.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27860.1	QBP27860.1 FIIR2 protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27860.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP08106.1	QBP08106.1 major tail tube protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08106.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27679.1	QBP27679.1 putative major tail tube protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27679.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27957.1	QBP27957.1 major tail tube protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27957.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP08024.1	QBP08024.1 major tail tube protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08024.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27752.1	QBP27752.1 putative major tail tube protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27752.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP27905.1	QBP27905.1 major tail tube protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27905.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ARB15703.1	ARB15703.1 hypothetical protein [Klebsiella phage 4LV2017]	ARB15703.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNI73712.1	UNI73712.1 putative major tail tube protein [Klebsiella phage KP12]	UNI73712.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAH1234716.1	CAH1234716.1 major tail tube protein MTP [Escherichia phage Cartapus]	CAH1234716.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD39547.1	VUD39547.1 Phage major tail tube protein [Peduovirus P24C9]	VUD39547.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBQ71567.1	QBQ71567.1 major tail tube protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71567.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AJA72949.1	AJA72949.1 tail tube protein FII [Mannheimia phage vB_MhM_587AP1]	AJA72949.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AJA73077.1	AJA73077.1 major tail tube protein FII [Mannheimia phage vB_MhM_1127AP1]	AJA73077.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ABD90627.1	ABD90627.1 tail tube protein FII [Mannheimia phage phiMhaA1-BAA410]	ABD90627.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ABD90577.1	ABD90577.1 tail tube protein FII [Mannheimia phage PHL101]	ABD90577.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AJA73130.1	AJA73130.1 tail tube protein FII [Mannheimia phage vB_MhM_2256AP1]	AJA73130.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AJA72898.1	AJA72898.1 tail tube protein FII [Mannheimia phage vB_MhM_535AP1]	AJA72898.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AFL46474.1	AFL46474.1 major tail tube protein [Mannheimia phage vB_MhM_1152AP]	AFL46474.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADQ92415.1	ADQ92415.1 major tail tube protein [Salmonella phage RE2010]	ADQ92415.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AQT27305.1	AQT27305.1 major tail tube protein [Salmonella phage SEN8]	AQT27305.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QYW06299.1	QYW06299.1 tail tube protein FII [Shewanella phage vB_SspM_M16-3]	QYW06299.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ALF02315.1	ALF02315.1 major tail tube protein [Salmonella phage SEN4]	ALF02315.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ALF02364.1	ALF02364.1 major tail tube protein [Salmonella phage SEN5]	ALF02364.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UGC97265.1	UGC97265.1 major tail tube protein [Aeromonas phage vB_AsaM_LPM4]	UGC97265.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QEA09553.1	QEA09553.1 major tail tube protein [Wolbachia phage WO]	QEA09553.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QXF95215.1	QXF95215.1 tail tube protein FII [Wolbachia phage WO]	QXF95215.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AFU62901.1	AFU62901.1 phage tail tube protein FII [Acidithiobacillus phage AcaML1]	AFU62901.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAD16806.1	BAD16806.1 similar to probable bacteriophage protein [Pseudomonas aeruginosa PA01] [Wolbachia phage WOcauB1]	BAD16806.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADW80221.1	ADW80221.1 tail tube [Wolbachia endosymbiont wVitB of Nasonia vitripennis phage WOVitB]	ADW80221.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADW80168.1	ADW80168.1 major tail tube [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80168.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AOA49545.1	AOA49545.1 major tail tube protein [Wolbachia phage WO]	AOA49545.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QHJ75483.1	QHJ75483.1 major tail tube protein [Wolbachia phage WO]	QHJ75483.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QHJ75596.1	QHJ75596.1 major tail tube protein [Wolbachia phage WO]	QHJ75596.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBP07961.1	QBP07961.1 major tail tube protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07961.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AIZ95156.1	AIZ95156.1 major tail tube protein [Escherichia phage P88]	AIZ95156.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ARB15659.1	ARB15659.1 major tail tube protein [Klebsiella phage 3LV2017]	ARB15659.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAH15157.1	BAH15157.1 gpFII-like protein [Serratia phage KSP20]	BAH15157.1	0
+52e11861-0676-43be-8b43-912eca54e74a	VUD40189.1	VUD40189.1 Phage major tail tube protein [Xuanwuvirus P884B11]	VUD40189.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ57120.1	WOZ57120.1 major tail tube protein [Citrobacter phage Shae_phiSM]	WOZ57120.1	0
+52e11861-0676-43be-8b43-912eca54e74a	CAX65004.1	CAX65004.1 gp23 protein [Vibrio phage VP585]	CAX65004.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAO20619.1	BAO20619.1 putative tail tube protein [Pseudomonas phage PPpW-3]	BAO20619.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AYD79771.1	AYD79771.1 hypothetical protein OGLPLLMI_00005 [Enterobacter phage phiT5282H]	AYD79771.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AFV81362.1	AFV81362.1 tail tube protein [Vibrio phage vB_VpaM_MAR]	AFV81362.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QPB08634.1	QPB08634.1 tail tube protein [Burkholderia phage Mica]	QPB08634.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AXF38228.1	AXF38228.1 putative tail tube protein [Ralstonia phage phiRSP]	AXF38228.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AIM50572.1	AIM50572.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50572.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAN12340.1	AAN12340.1 ORF40 [Vibrio phage VHML]	AAN12340.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QMP19183.1	QMP19183.1 tail tube protein [Pseudomonas phage Persinger]	QMP19183.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ADE87917.1	ADE87917.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87917.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QIG65610.1	QIG65610.1 major tail tube protein [Salmonella phage PT1]	QIG65610.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ARM70443.1	ARM70443.1 putative tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70443.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QJB21999.1	QJB21999.1 hypothetical protein XccvBFoX5_gp21 [Xanthomonas phage FoX5]	QJB21999.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QJB21921.1	QJB21921.1 major tail tube protein [Xanthomonas phage FoX3]	QJB21921.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QJB21759.1	QJB21759.1 hypothetical protein XccvBFoX1_gp20 [Xanthomonas phage FoX1]	QJB21759.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QJB21840.1	QJB21840.1 major tail tube protein [Xanthomonas phage FoX2]	QJB21840.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WNL50856.1	WNL50856.1 tail tube protein [Xanthomonas phage Murka]	WNL50856.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QWY14239.1	QWY14239.1 pyocin tube [Xanthomonas phage M29]	QWY14239.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WWY66201.1	WWY66201.1 major tail tube protein [Burkholderia phage vB_HM795]	WWY66201.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QKN87917.1	QKN87917.1 tail tube protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87917.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WEV89354.1	WEV89354.1 hypothetical protein H10PHJ05_53 [Aeromonas phage HJ05]	WEV89354.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ANN86129.1	ANN86129.1 putative tail tube protein [Enterobacter phage Arya]	ANN86129.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QOE32752.1	QOE32752.1 tail tube protein [Achromobacter phage Mano]	QOE32752.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WID42136.1	WID42136.1 major tail tube protein [Pseudomonas phage ZRG1]	WID42136.1	0
+52e11861-0676-43be-8b43-912eca54e74a	USZ80550.1	USZ80550.1 major tail tube protein [Serratia phage MQ-4]	USZ80550.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ALF02259.2	ALF02259.2 major tail tube protein [Salmonella phage SEN1]	ALF02259.2	0
+52e11861-0676-43be-8b43-912eca54e74a	AUV56464.1	AUV56464.1 major tail protein [Faecalibacterium phage FP_Epona]	AUV56464.1	0
+52e11861-0676-43be-8b43-912eca54e74a	APU01172.1	APU01172.1 major tail tube protein [Aeromonas phage 32]	APU01172.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AJK27738.1	AJK27738.1 tail tube [Bacteriophage Lily]	AJK27738.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNI73673.1	UNI73673.1 putative tail core protein [Klebsiella phage KP12]	UNI73673.1	0
+52e11861-0676-43be-8b43-912eca54e74a	APU00756.1	APU00756.1 major tail tube protein [Aeromonas phage Asp37]	APU00756.1	0
+52e11861-0676-43be-8b43-912eca54e74a	APU00420.1	APU00420.1 major tail tube protein [Aeromonas phage 3]	APU00420.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WNY35848.1	WNY35848.1 major tail tube protein [Vibrio phage Vb_VaM_Valp1]	WNY35848.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WDE69800.1	WDE69800.1 major tail tube protein [Vibrio phage VPHZ6]	WDE69800.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ANZ52213.1	ANZ52213.1 putative major tail tube protein [Aeromonas phage Ahp2]	ANZ52213.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AWH15331.1	AWH15331.1 major tail tube protein [Aeromonas phage 14AhydR10PP]	AWH15331.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AWH14533.1	AWH14533.1 major tail tube protein [Aeromonas phage 13AhydR10PP]	AWH14533.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QHZ54116.1	QHZ54116.1 major tail tube protein [Paenibacillus phage phiERICV]	QHZ54116.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AWH15043.1	AWH15043.1 major tail tube protein [Aeromonas phage 85AhydR10PP]	AWH15043.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ABO60658.1	ABO60658.1 gp14, phage major tail tube protein [Burkholderia phage phiE255]	ABO60658.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AAS47879.1	AAS47879.1 gp40 [Burkholderia phage BcepMu]	AAS47879.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AUV56778.1	AUV56778.1 major tail tube protein [Faecalibacterium phage FP_Toutatis]	AUV56778.1	0
+52e11861-0676-43be-8b43-912eca54e74a	ARQ95330.1	ARQ95330.1 major tail tube protein [Bradyrhizobium phage BDU-MI-1]	ARQ95330.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AYP68503.1	AYP68503.1 major tail tube protein [Exiguobacterium phage vB_EalM-137]	AYP68503.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QXN68734.1	QXN68734.1 tail tube protein FII [Hafnia phage yong2]	QXN68734.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QIZ02633.1	QIZ02633.1 tail tube protein FII [Aeromonas phage AhyVDH1]	QIZ02633.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WWQ71678.1	WWQ71678.1 major tail tube protein [Pseudomonas phage Bise]	WWQ71678.1	0
+52e11861-0676-43be-8b43-912eca54e74a	APU00841.1	APU00841.1 major tail tube protein [Aeromonas phage 59.1]	APU00841.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAA05468.1	BAA05468.1 tail tube protein [Phage PS17]	BAA05468.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ55868.1	WOZ55868.1 hypothetical protein P41_00014 [Yersinia phage vB_YpM_41]	WOZ55868.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ55798.1	WOZ55798.1 hypothetical protein P39_00014 [Yersinia phage vB_YpM_39]	WOZ55798.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WOZ55935.1	WOZ55935.1 hypothetical protein P44_00014 [Yersinia phage vB_YpM_44]	WOZ55935.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URE76655.1	URE76655.1 major tail tube protein [Escherichia phage vB_EcoM-473R2]	URE76655.1	0
+52e11861-0676-43be-8b43-912eca54e74a	URC09223.1	URC09223.1 major tail tube protein [Escherichia phage vB_EcoM-613R2]	URC09223.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WNA15506.1	WNA15506.1 tail tube protein [Acinetobacter phage HFM1]	WNA15506.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UOL51115.1	UOL51115.1 tail tube protein FII [Citrobacter phage Chris1]	UOL51115.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WAK43889.1	WAK43889.1 tail tube protein FII [Sulfurimonas phage SNW-1]	WAK43889.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AZV00466.1	AZV00466.1 major tail tube protein [Paracoccus phage vB_PyeM_Pyei1]	AZV00466.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UNY40543.1	UNY40543.1 tail tube protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40543.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AWY03254.1	AWY03254.1 major tail tube protein [Pasteurella phage AFS-2018a]	AWY03254.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AUV56856.1	AUV56856.1 major tail protein [Faecalibacterium phage FP_Taranis]	AUV56856.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WAK79560.1	WAK79560.1 head closure [Clostridium phage Saumur]	WAK79560.1	0
+52e11861-0676-43be-8b43-912eca54e74a	WJZ69995.1	WJZ69995.1 major tail tube protein [Vibrio phage PVP-XSN]	WJZ69995.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AHN84828.1	AHN84828.1 major tail tube protein [Vibrio phage phi 2]	AHN84828.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QBJ01020.1	QBJ01020.1 major tail tube protein [Vibrio phage Rostov 7]	QBJ01020.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AIA10331.1	AIA10331.1 tail tube FII family protein [Vibrio phage X29]	AIA10331.1	0
+52e11861-0676-43be-8b43-912eca54e74a	QVQ56214.1	QVQ56214.1 major tail tube protein [Paenibacillus phage Pd_22F]	QVQ56214.1	0
+52e11861-0676-43be-8b43-912eca54e74a	BAP94479.1	BAP94479.1 tail tube [Aurantimonas phage AmM-1]	BAP94479.1	0
+52e11861-0676-43be-8b43-912eca54e74a	AKC57542.1	AKC57542.1 major tail tube protein [Fusobacterium phage Funu1]	AKC57542.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UTV61021.1	UTV61021.1 major tail tube protein [Fusobacterium phage JD-Fnp2]	UTV61021.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UTV61163.1	UTV61163.1 major tail tube protein [Fusobacterium phage JD-Fnp5]	UTV61163.1	0
+52e11861-0676-43be-8b43-912eca54e74a	UTV61081.1	UTV61081.1 major tail tube protein [Fusobacterium phage JD-Fnp3]	UTV61081.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41684.1	UNY41684.1 tape measure chaperone protein [Burkholderia phage Musica]	UNY41684.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41743.1	UNY41743.1 tape measure chaperone protein [Burkholderia phage Milagro]	UNY41743.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41800.1	UNY41800.1 tape measure chaperone protein [Burkholderia phage Menos]	UNY41800.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41856.1	UNY41856.1 tape measure chaperone protein [Burkholderia phage Momento]	UNY41856.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02311.1	ADP02311.1 gp18 [Burkholderia phage KL3]	ADP02311.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41685.1	UNY41685.1 tape measure chaperone protein [Burkholderia phage Musica]	UNY41685.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41744.1	UNY41744.1 tape measure chaperone protein [Burkholderia phage Milagro]	UNY41744.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41801.1	UNY41801.1 tape measure chaperone protein [Burkholderia phage Menos]	UNY41801.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNY41857.1	UNY41857.1 tape measure chaperone protein [Burkholderia phage Momento]	UNY41857.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02312.1	ADP02312.1 gp19 [Burkholderia phage KL3]	ADP02312.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ABO60741.1	ABO60741.1 gp28, phage tail protein E [Burkholderia phage phiE202]	ABO60741.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAZ72622.1	AAZ72622.1 phage tail protein E [Burkholderia phage phiE52237]	AAZ72622.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ABO60768.1	ABO60768.1 gp31, phage tail protein E [Burkholderia phage phiE12-2]	ABO60768.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WWY66167.1	WWY66167.1 tail protein [Burkholderia phage vB_HM387]	WWY66167.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UPI15583.1	UPI15583.1 tail protein [Burkholderia phage PhiBP82.3]	UPI15583.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UKM53789.1	UKM53789.1 tail assembly protein [Burkholderia phage PhiBP82.2]	UKM53789.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AIP84299.1	AIP84299.1 mu-like prophage FluMu gp41 family protein [Burkholderia phage BEK]	AIP84299.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AFV51419.1	AFV51419.1 phage tail protein E [Burkholderia phage phiX216]	AFV51419.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QWY84971.1	QWY84971.1 tail assembly protein [Burkholderia phage PK23]	QWY84971.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QPI18564.1	QPI18564.1 tail assembly protein [Burkholderia phage phiE094]	QPI18564.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02358.1	ADP02358.1 gp13 [Burkholderia phage KS14]	ADP02358.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BCB23192.1	BCB23192.1 tail protein (E) [Burkholderia phage FLC5]	BCB23192.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BDD79940.1	BDD79940.1 hypothetical protein [Burkholderia phage FLC10]	BDD79940.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AGK86799.1	AGK86799.1 phage tail protein E [Burkholderia phage ST79]	AGK86799.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02359.1	ADP02359.1 gp14 [Burkholderia phage KS14]	ADP02359.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BCB23191.1	BCB23191.1 tail protein (E+E) [Burkholderia phage FLC5]	BCB23191.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BDD79939.1	BDD79939.1 hypothetical protein [Burkholderia phage FLC10]	BDD79939.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AFJ75497.1	AFJ75497.1 tail protein [Stenotrophomonas phage Smp131]	AFJ75497.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02263.1	ADP02263.1 gp16 [Burkholderia phage KS5]	ADP02263.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	USM11634.1	USM11634.1 tail assembly chaperone [Burkholderia phage Carl1]	USM11634.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QDP43522.1	QDP43522.1 hypothetical protein [Bacteriophage R18C]	QDP43522.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	API82958.1	API82958.1 Phage tail protein E [Salmonella phage STYP1]	API82958.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAD03291.1	AAD03291.1 gpE [Bacteriophage P2]	AAD03291.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WOZ56015.1	WOZ56015.1 hypothetical protein B115_00027 [Yersinia phage vB_YpM_115]	WOZ56015.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ULG00702.1	ULG00702.1 hypothetical protein [Escherichia phage D8]	ULG00702.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAH0786503.1	CAH0786503.1 hypothetical protein P2AC1_00018 [Escherichia phage P2_AC1]	CAH0786503.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD38916.1	VUD38916.1 GpE+E' [Peduovirus P24E6b]	VUD38916.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WOZ56061.1	WOZ56061.1 hypothetical protein B117_00027 [Yersinia phage vB_YpM_117]	WOZ56061.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ULG01162.1	ULG01162.1 hypothetical protein [Escherichia phage 12W]	ULG01162.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AKA61153.1	AKA61153.1 putative tail protein [Burkholderia phage AP3]	AKA61153.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	URC09828.1	URC09828.1 tail protein [Escherichia phage vB_EcoM-720R8]	URC09828.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAG9593780.1	CAG9593780.1 hypothetical protein P2SIAC10_00019 [Peduovirus P2]	CAG9593780.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAP04460.1	AAP04460.1 gpE [Yersinia phage L-413C]	AAP04460.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UPI11474.1	UPI11474.1 hypothetical protein COILCCMC_00026 [Yersinia phage VB-YPM-4]	UPI11474.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QDJ98447.1	QDJ98447.1 hypothetical protein LLFFHNDI_00020 [Escherichia phage vB_EcoM-12474II]	QDJ98447.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD38030.1	VUD38030.1 Tail protein [Peduovirus P24B2]	VUD38030.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ULG01004.1	ULG01004.1 tail protein [Escherichia phage 9W]	ULG01004.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAG9593863.1	CAG9593863.1 hypothetical protein P2SIDE7_00017 [Peduovirus P2]	CAG9593863.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AKH49398.1	AKH49398.1 tail protein [Escherichia phage pro483]	AKH49398.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD37942.1	VUD37942.1 Tail protein [Peduovirus P22H4]	VUD37942.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAN28242.1	AAN28242.1 gpE [Escherichia phage Wphi]	AAN28242.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UPI11522.1	UPI11522.1 hypothetical protein BFNKNBEH_00032 [Yersinia phage VB-YPM-18]	UPI11522.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WOZ56104.1	WOZ56104.1 hypothetical protein B476A_00024 [Yersinia phage vB_YpM_476A]	WOZ56104.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QDJ98579.1	QDJ98579.1 hypothetical protein OMJLAAIH_00020 [Escherichia phage vB_EcoM-12474V]	QDJ98579.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QKE55605.1	QKE55605.1 hypothetical protein vBYpM46_00025 [Yersinia phage vB_YpM_46]	QKE55605.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAG9593830.1	CAG9593830.1 hypothetical protein P2DC1_00026 [Peduovirus P2]	CAG9593830.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ULG01112.1	ULG01112.1 tail protein [Escherichia phage 10W]	ULG01112.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QKE55512.1	QKE55512.1 hypothetical protein vBYpM22_00027 [Yersinia phage vB_YpM_22]	QKE55512.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QIW90043.1	QIW90043.1 major head coat protein from bacterioorigin [Yersinia phage P37]	QIW90043.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QXF95291.1	QXF95291.1 tail protein [Yersinia phage HQ103]	QXF95291.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QDJ98535.1	QDJ98535.1 hypothetical protein PBINGOGM_00020 [Escherichia phage vB_EcoM-12474IV]	QDJ98535.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AGG36542.1	AGG36542.1 tail protein [Escherichia phage P2]	AGG36542.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WOZ56144.1	WOZ56144.1 hypothetical protein B476B_00024 [Yersinia phage vB_YpM_476B]	WOZ56144.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ULG00887.1	ULG00887.1 tail protein [Escherichia phage 11W]	ULG00887.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WFG40953.1	WFG40953.1 tail protein [Salmonella phage MET_P1_103_31]	WFG40953.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD37986.1	VUD37986.1 GpE+E' [Peduovirus P22H1]	VUD37986.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD39551.1	VUD39551.1 Tail protein [Peduovirus P24C9]	VUD39551.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	URP83685.1	URP83685.1 tail assembly protein [Escherichia phage S164]	URP83685.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QDJ98494.1	QDJ98494.1 hypothetical protein BBAMJIOM_00023 [Escherichia phage vB_EcoM-12474III]	QDJ98494.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QKE55648.1	QKE55648.1 hypothetical protein vBYpM50_00027 [Yersinia phage vB_YpM_50]	QKE55648.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AGX84585.1	AGX84585.1 tail protein [Enterobacteria phage fiAA91-ss]	AGX84585.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QPB09422.1	QPB09422.1 tape measure chaperone [Burkholderia phage Mana]	QPB09422.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	URC09637.1	URC09637.1 tail protein [Escherichia phage vB_EcoM-569R9]	URC09637.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AKH49321.1	AKH49321.1 tail protein [Escherichia phage pro147]	AKH49321.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BAF52406.1	BAF52406.1 bacteriophage gpE [Ralstonia phage RSA1]	BAF52406.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNA05762.1	UNA05762.1 tail protein [Yersinia phage vB_YenM_42.18]	UNA05762.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AFJ75516.1	AFJ75516.1 tail protein [Stenotrophomonas phage Smp131]	AFJ75516.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	USM11633.1	USM11633.1 tail assembly chaperone [Burkholderia phage Carl1]	USM11633.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADP02264.1	ADP02264.1 gp17 [Burkholderia phage KS5]	ADP02264.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAD03292.1	AAD03292.1 gpE+E' [Bacteriophage P2]	AAD03292.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAP04461.1	AAP04461.1 gpE+E' [Yersinia phage L-413C]	AAP04461.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WPJ21707.1	WPJ21707.1 tail assembly chaperone protein [Bacillus phage vB_BpuM-ZY1]	WPJ21707.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAN28243.1	AAN28243.1 gpE+E' [Escherichia phage Wphi]	AAN28243.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AVP40022.1	AVP40022.1 tail assembly protein [Ralstonia phage RsoM1USA]	AVP40022.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADQ92416.1	ADQ92416.1 tail protein E [Salmonella phage RE2010]	ADQ92416.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD39049.1	VUD39049.1 GpE+E' [Peduovirus P24A7b]	VUD39049.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBQ71568.1	QBQ71568.1 tail assembly protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71568.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ADX32451.1	ADX32451.1 hypothetical protein [Erwinia phage ENT90]	ADX32451.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AQT27306.1	AQT27306.1 tail protein [Salmonella phage SEN8]	AQT27306.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QYW06298.1	QYW06298.1 tail assembly chaperone protein [Shewanella phage vB_SspM_M16-3]	QYW06298.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QPB09423.1	QPB09423.1 tape measure chaperone [Burkholderia phage Mana]	QPB09423.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNI73711.1	UNI73711.1 putative tail protein [Klebsiella phage KP12]	UNI73711.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27602.1	QBP27602.1 tail assembly protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27602.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAH1234718.1	CAH1234718.1 tail assembly protein [Escherichia phage Cartapus]	CAH1234718.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ARB15704.1	ARB15704.1 tail protein [Klebsiella phage 4LV2017]	ARB15704.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP08023.1	QBP08023.1 tail assembly protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08023.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27751.1	QBP27751.1 tail assembly protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27751.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27904.1	QBP27904.1 tail assembly protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27904.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBQ72016.1	QBQ72016.1 tail assembly protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72016.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27441.1	QBP27441.1 tail assembly protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27441.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP07801.1	QBP07801.1 tail assembly protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07801.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27859.1	QBP27859.1 tail assembly protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27859.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP08107.1	QBP08107.1 tail assembly protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08107.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27680.1	QBP27680.1 tail assembly protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27680.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP27956.1	QBP27956.1 tail assembly protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27956.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UTC25930.1	UTC25930.1 tail assembly protein [Salmonella phage vB_Sal_PHB48]	UTC25930.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AZF87865.1	AZF87865.1 tail assembly protein [Pseudomonas phage Dobby]	AZF87865.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAC34168.1	AAC34168.1 tail protein [Escherichia phage 186]	AAC34168.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QYC52681.1	QYC52681.1 hypothetical protein [Salmonella phage BIS20]	QYC52681.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AGF88435.1	AGF88435.1 hypothetical protein SP004_00110 [Salmonella phage FSLSP004]	AGF88435.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAN08385.1	AAN08385.1 gp23 [Salmonella phage PSP3]	AAN08385.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ASD51161.1	ASD51161.1 tail assembly chaperone [Erwinia phage EtG]	ASD51161.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QEI25362.1	QEI25362.1 tail assembly protein [Salmonella phage SI22]	QEI25362.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QEI25407.1	QEI25407.1 tail assembly protein [Salmonella phage SW9]	QEI25407.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WWQ72108.1	WWQ72108.1 tail protein [Pseudomonas phage Sirocco]	WWQ72108.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WPJ53094.1	WPJ53094.1 hypothetical protein RCIP0057_00021 [Klebsiella phage RCIP0057]	WPJ53094.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WXX18220.1	WXX18220.1 tail protein [Yersinia phage GCS667]	WXX18220.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BAA36251.1	BAA36251.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36251.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WYC18461.1	WYC18461.1 tail protein [Yersinia phage vB_YpM_MHG38]	WYC18461.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WYC18392.1	WYC18392.1 tail protein [Yersinia phage vB_YpM_MDG94-186]	WYC18392.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	URE76599.1	URE76599.1 tail protein [Escherichia phage vB_EcoM-613R3]	URE76599.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WYC18419.1	WYC18419.1 tail protein [Yersinia phage vB_YpM_MDG45]	WYC18419.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ALF02260.1	ALF02260.1 tail protein [Salmonella phage SEN1]	ALF02260.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AUV47167.1	AUV47167.1 tail assembly chaperone protein [Erwinia phage EtG]	AUV47167.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAN08404.1	AAN08404.1 gp23.5 [Salmonella phage PSP3]	AAN08404.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBI84132.1	QBI84132.1 tail fibers protein [Pseudomonas phage vB_Pae_BR319a]	QBI84132.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UKL54265.1	UKL54265.1 tail protein [Yersinia phage vB_YenM_31.17]	UKL54265.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNA05989.1	UNA05989.1 tail protein [Yersinia phage vB_YenM_201.16]	UNA05989.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UYL85528.1	UYL85528.1 tail assembly protein [Acidovorax phage Alfacinha1]	UYL85528.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UYL85427.1	UYL85427.1 tail assembly protein [Acidovorax phage Alfacinha3]	UYL85427.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNA05883.1	UNA05883.1 tail protein [Yersinia phage vB_YenM_06.16-2]	UNA05883.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UNA05937.1	UNA05937.1 tail protein [Yersinia phage vB_YenM_56.17]	UNA05937.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UZV40227.1	UZV40227.1 tail assembly protein [Acidovorax phage Acica]	UZV40227.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AYD79770.1	AYD79770.1 hypothetical protein OGLPLLMI_00004 [Enterobacter phage phiT5282H]	AYD79770.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ABD90628.1	ABD90628.1 tail protein E [Mannheimia phage phiMhaA1-BAA410]	ABD90628.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ABD90578.1	ABD90578.1 tail protein E [Mannheimia phage PHL101]	ABD90578.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AJA73131.1	AJA73131.1 tail protein E [Mannheimia phage vB_MhM_2256AP1]	AJA73131.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AJA72899.1	AJA72899.1 tail protein E [Mannheimia phage vB_MhM_535AP1]	AJA72899.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AJA72950.1	AJA72950.1 tail protein E [Mannheimia phage vB_MhM_587AP1]	AJA72950.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AJA73078.1	AJA73078.1 tail protein E [Mannheimia phage vB_MhM_1127AP1]	AJA73078.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AFL46475.1	AFL46475.1 phage tail protein E [Mannheimia phage vB_MhM_1152AP]	AFL46475.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	UGC97264.1	UGC97264.1 tail protein [Aeromonas phage vB_AsaM_LPM4]	UGC97264.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	APU00842.1	APU00842.1 putative tail protein [Aeromonas phage 59.1]	APU00842.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WDE69801.1	WDE69801.1 tail assembly protein [Vibrio phage VPHZ6]	WDE69801.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	VUD40188.1	VUD40188.1 putative tail protein [Xuanwuvirus P884B11]	VUD40188.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	WOZ57121.1	WOZ57121.1 tail protein [Citrobacter phage Shae_phiSM]	WOZ57121.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QBP07960.1	QBP07960.1 tail protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07960.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ALF02314.1	ALF02314.1 tail protein [Salmonella phage SEN4]	ALF02314.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ALF02363.1	ALF02363.1 tail protein [Salmonella phage SEN5]	ALF02363.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	APU01173.1	APU01173.1 hypothetical protein [Aeromonas phage 32]	APU01173.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ANZ52214.1	ANZ52214.1 putative tail protein [Aeromonas phage Ahp2]	ANZ52214.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	APU00421.1	APU00421.1 hypothetical protein [Aeromonas phage 3]	APU00421.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	APU00757.1	APU00757.1 hypothetical protein [Aeromonas phage Asp37]	APU00757.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	BAH15158.1	BAH15158.1 gpE-like protein [Serratia phage KSP20]	BAH15158.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	QIZ02634.1	QIZ02634.1 tail protein E [Aeromonas phage AhyVDH1]	QIZ02634.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AWH15042.1	AWH15042.1 hypothetical protein [Aeromonas phage 85AhydR10PP]	AWH15042.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AWH14534.1	AWH14534.1 hypothetical protein [Aeromonas phage 13AhydR10PP]	AWH14534.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AWH15332.1	AWH15332.1 hypothetical protein [Aeromonas phage 14AhydR10PP]	AWH15332.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AAN12341.1	AAN12341.1 ORF41 [Vibrio phage VHML]	AAN12341.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	AFV81364.1	AFV81364.1 putative tail protein [Vibrio phage vB_VpaM_MAR]	AFV81364.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	CAX65005.1	CAX65005.1 gp24 protein [Vibrio phage VP585]	CAX65005.1	0
+5fdd3954-66e3-4465-b66e-5874527682a6	ARB15658.1	ARB15658.1 tail protein [Klebsiella phage 3LV2017]	ARB15658.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNY41745.1	UNY41745.1 tape measure protein [Burkholderia phage Milagro]	UNY41745.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNY41686.1	UNY41686.1 tape measure protein [Burkholderia phage Musica]	UNY41686.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADP02310.1	ADP02310.1 gp17 [Burkholderia phage KL3]	ADP02310.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNY41802.1	UNY41802.1 tape measure protein [Burkholderia phage Menos]	UNY41802.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNY41858.1	UNY41858.1 tape measure protein [Burkholderia phage Momento]	UNY41858.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKA61155.1	AKA61155.1 hypothetical protein vB_BceM_AP3_0034 [Burkholderia phage AP3]	AKA61155.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	USM11635.1	USM11635.1 tail tape measure protein [Burkholderia phage Carl1]	USM11635.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABO60736.1	ABO60736.1 gp26, bacteriophage membrane protein [Burkholderia phage phiE202]	ABO60736.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABO60736.1	ABO60736.1 gp26, bacteriophage membrane protein [Burkholderia phage phiE202]	ABO60736.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWY66168.1	WWY66168.1 tail length tape measure protein [Burkholderia phage vB_HM387]	WWY66168.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWY66168.1	WWY66168.1 tail length tape measure protein [Burkholderia phage vB_HM387]	WWY66168.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UKM53791.1	UKM53791.1 tail length tape-measure protein [Burkholderia phage PhiBP82.2]	UKM53791.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UKM53791.1	UKM53791.1 tail length tape-measure protein [Burkholderia phage PhiBP82.2]	UKM53791.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPI18566.1	QPI18566.1 tail length tape-measure protein [Burkholderia phage phiE094]	QPI18566.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPI18566.1	QPI18566.1 tail length tape-measure protein [Burkholderia phage phiE094]	QPI18566.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAZ72621.2	AAZ72621.2 bacteriophage membrane protein [Burkholderia phage phiE52237]	AAZ72621.2	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAZ72621.2	AAZ72621.2 bacteriophage membrane protein [Burkholderia phage phiE52237]	AAZ72621.2	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABO60769.1	ABO60769.1 gp29, bacteriophage membrane protein [Burkholderia phage phiE12-2]	ABO60769.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABO60769.1	ABO60769.1 gp29, bacteriophage membrane protein [Burkholderia phage phiE12-2]	ABO60769.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QWY84972.1	QWY84972.1 tail length tape-measure protein [Burkholderia phage PK23]	QWY84972.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QWY84972.1	QWY84972.1 tail length tape-measure protein [Burkholderia phage PK23]	QWY84972.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI15585.1	UPI15585.1 tail length tape-measure protein [Burkholderia phage PhiBP82.3]	UPI15585.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI15585.1	UPI15585.1 tail length tape-measure protein [Burkholderia phage PhiBP82.3]	UPI15585.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFV51420.1	AFV51420.1 phage membrane protein [Burkholderia phage phiX216]	AFV51420.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFV51420.1	AFV51420.1 phage membrane protein [Burkholderia phage phiX216]	AFV51420.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADP02262.1	ADP02262.1 gp15 [Burkholderia phage KS5]	ADP02262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADP02262.1	ADP02262.1 gp15 [Burkholderia phage KS5]	ADP02262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPB09424.1	QPB09424.1 tape measure protein [Burkholderia phage Mana]	QPB09424.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPB09424.1	QPB09424.1 tape measure protein [Burkholderia phage Mana]	QPB09424.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGK86800.1	AGK86800.1 phage tail protein E [Burkholderia phage ST79]	AGK86800.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGK86800.1	AGK86800.1 phage tail protein E [Burkholderia phage ST79]	AGK86800.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAF52407.1	BAF52407.1 bacteriophage tail protein gpT [Ralstonia phage RSA1]	BAF52407.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAF52407.1	BAF52407.1 bacteriophage tail protein gpT [Ralstonia phage RSA1]	BAF52407.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AVP40023.1	AVP40023.1 tail protein [Ralstonia phage RsoM1USA]	AVP40023.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AVP40023.1	AVP40023.1 tail protein [Ralstonia phage RsoM1USA]	AVP40023.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UZV40229.1	UZV40229.1 tail protein [Acidovorax phage Acica]	UZV40229.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UZV40229.1	UZV40229.1 tail protein [Acidovorax phage Acica]	UZV40229.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL85530.1	UYL85530.1 tail length tape-measure protein [Acidovorax phage Alfacinha1]	UYL85530.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL85530.1	UYL85530.1 tail length tape-measure protein [Acidovorax phage Alfacinha1]	UYL85530.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL85429.1	UYL85429.1 tail length tape-measure protein [Acidovorax phage Alfacinha3]	UYL85429.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL85429.1	UYL85429.1 tail length tape-measure protein [Acidovorax phage Alfacinha3]	UYL85429.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAP28133.1	BAP28133.1 hypothetical protein [Ralstonia phage RSY1]	BAP28133.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAP28133.1	BAP28133.1 hypothetical protein [Ralstonia phage RSY1]	BAP28133.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BCB23190.1	BCB23190.1 tail tape measure protein (T) [Burkholderia phage FLC5]	BCB23190.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BCB23190.1	BCB23190.1 tail tape measure protein (T) [Burkholderia phage FLC5]	BCB23190.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BDD79941.1	BDD79941.1 hypothetical protein [Burkholderia phage FLC10]	BDD79941.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BDD79941.1	BDD79941.1 hypothetical protein [Burkholderia phage FLC10]	BDD79941.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADP02357.1	ADP02357.1 gp12 [Burkholderia phage KS14]	ADP02357.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADP02357.1	ADP02357.1 gp12 [Burkholderia phage KS14]	ADP02357.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAA36253.1	BAA36253.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36253.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAA36253.1	BAA36253.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36253.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAA36253.1	BAA36253.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36253.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWY03256.1	AWY03256.1 tail tape measure protein [Pasteurella phage AFS-2018a]	AWY03256.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABD90616.1	ABD90616.1 tail protein T [Mannheimia phage phiMhaA1-BAA410]	ABD90616.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABD90616.1	ABD90616.1 tail protein T [Mannheimia phage phiMhaA1-BAA410]	ABD90616.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABD90567.1	ABD90567.1 tail protein T [Mannheimia phage PHL101]	ABD90567.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABD90567.1	ABD90567.1 tail protein T [Mannheimia phage PHL101]	ABD90567.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA73118.1	AJA73118.1 tail protein T [Mannheimia phage vB_MhM_2256AP1]	AJA73118.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA73118.1	AJA73118.1 tail protein T [Mannheimia phage vB_MhM_2256AP1]	AJA73118.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA72887.1	AJA72887.1 tail protein T [Mannheimia phage vB_MhM_535AP1]	AJA72887.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA72887.1	AJA72887.1 tail protein T [Mannheimia phage vB_MhM_535AP1]	AJA72887.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFL46462.1	AFL46462.1 phage tail protein [Mannheimia phage vB_MhM_1152AP]	AFL46462.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFL46462.1	AFL46462.1 phage tail protein [Mannheimia phage vB_MhM_1152AP]	AFL46462.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA72938.1	AJA72938.1 tail protein T [Mannheimia phage vB_MhM_587AP1]	AJA72938.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA73066.1	AJA73066.1 tail protein T [Mannheimia phage vB_MhM_1127AP1]	AJA73066.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AJA73066.1	AJA73066.1 tail protein T [Mannheimia phage vB_MhM_1127AP1]	AJA73066.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARB15706.1	ARB15706.1 tail protein [Klebsiella phage 4LV2017]	ARB15706.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARB15706.1	ARB15706.1 tail protein [Klebsiella phage 4LV2017]	ARB15706.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WPJ21709.1	WPJ21709.1 tail tape measure protein [Bacillus phage vB_BpuM-ZY1]	WPJ21709.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WPJ21709.1	WPJ21709.1 tail tape measure protein [Bacillus phage vB_BpuM-ZY1]	WPJ21709.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWQ72110.1	WWQ72110.1 tail tape measure protein [Pseudomonas phage Sirocco]	WWQ72110.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWQ72110.1	WWQ72110.1 tail tape measure protein [Pseudomonas phage Sirocco]	WWQ72110.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF87867.1	AZF87867.1 tail tape measure protein [Pseudomonas phage Dobby]	AZF87867.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF87867.1	AZF87867.1 tail tape measure protein [Pseudomonas phage Dobby]	AZF87867.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBI84134.1	QBI84134.1 tail length tape-measure protein [Pseudomonas phage vB_Pae_BR319a]	QBI84134.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBI84134.1	QBI84134.1 tail length tape-measure protein [Pseudomonas phage vB_Pae_BR319a]	QBI84134.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXF38229.1	AXF38229.1 putative tail protein [Ralstonia phage phiRSP]	AXF38229.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWQ71681.1	WWQ71681.1 tail tape measure protein [Pseudomonas phage Bise]	WWQ71681.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMV32416.1	QMV32416.1 hypothetical protein U2_00041 [Ralstonia phage Albius]	QMV32416.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMV33610.1	QMV33610.1 hypothetical protein Y2_00041 [Ralstonia phage Raharianne]	QMV33610.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMV33454.1	QMV33454.1 hypothetical protein 8G_00022 [Ralstonia phage Hyacinthe]	QMV33454.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAP28132.1	BAP28132.1 hypothetical protein [Ralstonia phage RSY1]	BAP28132.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAH1234724.1	CAH1234724.1 tail tape measure protein [Escherichia phage Cartapus]	CAH1234724.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAH1234724.1	CAH1234724.1 tail tape measure protein [Escherichia phage Cartapus]	CAH1234724.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPB08637.1	QPB08637.1 tape measure protein [Burkholderia phage Mica]	QPB08637.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP07959.1	QBP07959.1 tail tape measure protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07959.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP07959.1	QBP07959.1 tail tape measure protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07959.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADQ92418.1	ADQ92418.1 tail tape measure protein [Salmonella phage RE2010]	ADQ92418.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADQ92418.1	ADQ92418.1 tail tape measure protein [Salmonella phage RE2010]	ADQ92418.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05764.1	UNA05764.1 tail length tape-measure protein [Yersinia phage vB_YenM_42.18]	UNA05764.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05764.1	UNA05764.1 tail length tape-measure protein [Yersinia phage vB_YenM_42.18]	UNA05764.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AQT27308.1	AQT27308.1 tail tape measure protein [Salmonella phage SEN8]	AQT27308.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AQT27308.1	AQT27308.1 tail tape measure protein [Salmonella phage SEN8]	AQT27308.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	USZ80552.1	USZ80552.1 tail tape measure protein [Serratia phage MQ-4]	USZ80552.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMP19185.1	QMP19185.1 tail protein [Pseudomonas phage Persinger]	QMP19185.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WAY79749.1	WAY79749.1 putative tail protein [Klebsiella phage KP12]	WAY79749.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAX65006.1	CAX65006.1 gp25 protein [Vibrio phage VP585]	CAX65006.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAX65006.1	CAX65006.1 gp25 protein [Vibrio phage VP585]	CAX65006.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QYW06296.1	QYW06296.1 tail tape measure protein [Shewanella phage vB_SspM_M16-3]	QYW06296.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QYW06296.1	QYW06296.1 tail tape measure protein [Shewanella phage vB_SspM_M16-3]	QYW06296.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WDE69802.1	WDE69802.1 tail tape measure protein [Vibrio phage VPHZ6]	WDE69802.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WDE69802.1	WDE69802.1 tail tape measure protein [Vibrio phage VPHZ6]	WDE69802.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFV81365.1	AFV81365.1 tail length tape-measure protein [Vibrio phage vB_VpaM_MAR]	AFV81365.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFV81365.1	AFV81365.1 tail length tape-measure protein [Vibrio phage vB_VpaM_MAR]	AFV81365.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNI73669.1	UNI73669.1 tail protein [Klebsiella phage KP12]	UNI73669.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIW90041.1	QIW90041.1 tail tape measure protein [Yersinia phage P37]	QIW90041.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIW90041.1	QIW90041.1 tail tape measure protein [Yersinia phage P37]	QIW90041.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADE87915.1	ADE87915.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87915.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARB15657.1	ARB15657.1 tail tape measure protein [Klebsiella phage 3LV2017]	ARB15657.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARB15657.1	ARB15657.1 tail tape measure protein [Klebsiella phage 3LV2017]	ARB15657.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIG65612.1	QIG65612.1 hypothetical protein [Salmonella phage PT1]	QIG65612.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AIM50574.1	AIM50574.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50574.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN12342.1	AAN12342.1 ORF43 [Vibrio phage VHML]	AAN12342.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN12342.1	AAN12342.1 ORF43 [Vibrio phage VHML]	AAN12342.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02312.1	ALF02312.1 tail length tape-measure protein [Salmonella phage SEN4]	ALF02312.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02312.1	ALF02312.1 tail length tape-measure protein [Salmonella phage SEN4]	ALF02312.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02361.1	ALF02361.1 tail length tape-measure protein [Salmonella phage SEN5]	ALF02361.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02361.1	ALF02361.1 tail length tape-measure protein [Salmonella phage SEN5]	ALF02361.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABO60657.1	ABO60657.1 gp18 [Burkholderia phage phiE255]	ABO60657.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNT44335.1	WNT44335.1 tape measure protein [Microbacterium phage Mabodamaca]	WNT44335.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARM70441.1	ARM70441.1 putative tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70441.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMT83792.1	WMT83792.1 tape measure [Pseudoalteromonas phage proACA1-A]	WMT83792.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMT83740.1	WMT83740.1 tape measure [Pseudoalteromonas phage ACA2]	WMT83740.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMT83688.1	WMT83688.1 tape measure [Pseudoalteromonas phage ACA1]	WMT83688.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UKL54267.1	UKL54267.1 tail length tape-measure protein [Yersinia phage vB_YenM_31.17]	UKL54267.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UKL54267.1	UKL54267.1 tail length tape-measure protein [Yersinia phage vB_YenM_31.17]	UKL54267.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05991.1	UNA05991.1 tail length tape-measure protein [Yersinia phage vB_YenM_201.16]	UNA05991.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05991.1	UNA05991.1 tail length tape-measure protein [Yersinia phage vB_YenM_201.16]	UNA05991.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05885.1	UNA05885.1 tail length tape-measure protein [Yersinia phage vB_YenM_06.16-2]	UNA05885.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05885.1	UNA05885.1 tail length tape-measure protein [Yersinia phage vB_YenM_06.16-2]	UNA05885.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05939.1	UNA05939.1 tail length tape-measure protein [Yersinia phage vB_YenM_56.17]	UNA05939.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNA05939.1	UNA05939.1 tail length tape-measure protein [Yersinia phage vB_YenM_56.17]	UNA05939.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYD79769.1	AYD79769.1 hypothetical protein OGLPLLMI_00003 [Enterobacter phage phiT5282H]	AYD79769.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYD79769.1	AYD79769.1 hypothetical protein OGLPLLMI_00003 [Enterobacter phage phiT5282H]	AYD79769.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD39053.1	VUD39053.1 Phage protein [Peduovirus P24A7b]	VUD39053.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD39053.1	VUD39053.1 Phage protein [Peduovirus P24A7b]	VUD39053.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGF88436.1	AGF88436.1 phage tail tape measure protein [Salmonella phage FSLSP004]	AGF88436.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGF88436.1	AGF88436.1 phage tail tape measure protein [Salmonella phage FSLSP004]	AGF88436.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBQ71570.1	QBQ71570.1 tail tape measure protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71570.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBQ71570.1	QBQ71570.1 tail tape measure protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71570.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QWY14216.2	QWY14216.2 tail length-measure protein [Xanthomonas phage M29]	QWY14216.2	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJB21925.1	QJB21925.1 tail length tape-measure protein [Xanthomonas phage FoX3]	QJB21925.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJB21763.1	QJB21763.1 hypothetical protein XccvBFoX1_gp24 [Xanthomonas phage FoX1]	QJB21763.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAO20621.1	BAO20621.1 putative tail protein [Pseudomonas phage PPpW-3]	BAO20621.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJB21844.1	QJB21844.1 tail length tape-measure protein [Xanthomonas phage FoX2]	QJB21844.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJB22003.1	QJB22003.1 tail length tape-measure protein [Xanthomonas phage FoX5]	QJB22003.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WPJ53093.1	WPJ53093.1 hypothetical protein RCIP0057_00020 [Klebsiella phage RCIP0057]	WPJ53093.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WPJ53093.1	WPJ53093.1 hypothetical protein RCIP0057_00020 [Klebsiella phage RCIP0057]	WPJ53093.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFJ75500.1	AFJ75500.1 phage tail tape measure protein [Stenotrophomonas phage Smp131]	AFJ75500.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFJ75500.1	AFJ75500.1 phage tail tape measure protein [Stenotrophomonas phage Smp131]	AFJ75500.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QYC52682.1	QYC52682.1 tail tape measure protein [Salmonella phage BIS20]	QYC52682.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QYC52682.1	QYC52682.1 tail tape measure protein [Salmonella phage BIS20]	QYC52682.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKH49400.1	AKH49400.1 hypothetical protein pro483_40 [Escherichia phage pro483]	AKH49400.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKH49400.1	AKH49400.1 hypothetical protein pro483_40 [Escherichia phage pro483]	AKH49400.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01006.1	ULG01006.1 tail length tape-measure protein [Escherichia phage 9W]	ULG01006.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01006.1	ULG01006.1 tail length tape-measure protein [Escherichia phage 9W]	ULG01006.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD37944.1	VUD37944.1 Phage protein [Peduovirus P22H4]	VUD37944.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD37944.1	VUD37944.1 Phage protein [Peduovirus P22H4]	VUD37944.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UTC25928.1	UTC25928.1 tail tape measure [Salmonella phage vB_Sal_PHB48]	UTC25928.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UTC25928.1	UTC25928.1 tail tape measure [Salmonella phage vB_Sal_PHB48]	UTC25928.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WXX18218.1	WXX18218.1 hypothetical protein [Yersinia phage GCS667]	WXX18218.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WXX18218.1	WXX18218.1 hypothetical protein [Yersinia phage GCS667]	WXX18218.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18463.1	WYC18463.1 tail fiber assembly protein [Yersinia phage vB_YpM_MHG38]	WYC18463.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18463.1	WYC18463.1 tail fiber assembly protein [Yersinia phage vB_YpM_MHG38]	WYC18463.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18394.1	WYC18394.1 hypothetical protein [Yersinia phage vB_YpM_MDG94-186]	WYC18394.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18394.1	WYC18394.1 hypothetical protein [Yersinia phage vB_YpM_MDG94-186]	WYC18394.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18421.1	WYC18421.1 tail fiber assembly protein [Yersinia phage vB_YpM_MDG45]	WYC18421.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WYC18421.1	WYC18421.1 tail fiber assembly protein [Yersinia phage vB_YpM_MDG45]	WYC18421.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	API82959.1	API82959.1 Phage-related minor tail protein [Salmonella phage STYP1]	API82959.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	API82959.1	API82959.1 Phage-related minor tail protein [Salmonella phage STYP1]	API82959.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGX84586.1	AGX84586.1 tail length determinator [Enterobacteria phage fiAA91-ss]	AGX84586.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGX84586.1	AGX84586.1 tail length determinator [Enterobacteria phage fiAA91-ss]	AGX84586.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URC09639.1	URC09639.1 tail length tape-measure protein [Escherichia phage vB_EcoM-569R9]	URC09639.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URC09639.1	URC09639.1 tail length tape-measure protein [Escherichia phage vB_EcoM-569R9]	URC09639.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFG40952.1	WFG40952.1 tail length tape measure protein [Salmonella phage MET_P1_103_31]	WFG40952.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFG40952.1	WFG40952.1 tail length tape measure protein [Salmonella phage MET_P1_103_31]	WFG40952.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02262.1	ALF02262.1 tail tape measure protein [Salmonella phage SEN1]	ALF02262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALF02262.1	ALF02262.1 tail tape measure protein [Salmonella phage SEN1]	ALF02262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URP83686.1	URP83686.1 tail tape measure protein [Escherichia phage S164]	URP83686.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URP83686.1	URP83686.1 tail tape measure protein [Escherichia phage S164]	URP83686.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593779.1	CAG9593779.1 hypothetical protein P2SIAC10_00018 [Peduovirus P2]	CAG9593779.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593779.1	CAG9593779.1 hypothetical protein P2SIAC10_00018 [Peduovirus P2]	CAG9593779.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAH0786502.1	CAH0786502.1 hypothetical protein P2AC1_00017 [Escherichia phage P2_AC1]	CAH0786502.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAH0786502.1	CAH0786502.1 hypothetical protein P2AC1_00017 [Escherichia phage P2_AC1]	CAH0786502.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAC34170.1	AAC34170.1 G protein [Escherichia phage 186]	AAC34170.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAC34170.1	AAC34170.1 G protein [Escherichia phage 186]	AAC34170.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKN87919.1	QKN87919.1 tape measure protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87919.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN08386.1	AAN08386.1 gp24 [Salmonella phage PSP3]	AAN08386.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN08386.1	AAN08386.1 gp24 [Salmonella phage PSP3]	AAN08386.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593862.1	CAG9593862.1 hypothetical protein P2SIDE7_00016 [Peduovirus P2]	CAG9593862.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593862.1	CAG9593862.1 hypothetical protein P2SIDE7_00016 [Peduovirus P2]	CAG9593862.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDP43524.1	QDP43524.1 hypothetical protein [Bacteriophage R18C]	QDP43524.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDP43524.1	QDP43524.1 hypothetical protein [Bacteriophage R18C]	QDP43524.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKH49319.1	AKH49319.1 hypothetical protein pro147_3 [Escherichia phage pro147]	AKH49319.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKH49319.1	AKH49319.1 hypothetical protein pro147_3 [Escherichia phage pro147]	AKH49319.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG00704.1	ULG00704.1 tail length tape-measure protein [Escherichia phage D8]	ULG00704.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG00704.1	ULG00704.1 tail length tape-measure protein [Escherichia phage D8]	ULG00704.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD38922.1	VUD38922.1 Phage protein [Peduovirus P24E6b]	VUD38922.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD38922.1	VUD38922.1 Phage protein [Peduovirus P24E6b]	VUD38922.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01164.1	ULG01164.1 tail length tape-measure protein [Escherichia phage 12W]	ULG01164.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01164.1	ULG01164.1 tail length tape-measure protein [Escherichia phage 12W]	ULG01164.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56016.1	WOZ56016.1 hypothetical protein B115_00028 [Yersinia phage vB_YpM_115]	WOZ56016.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56016.1	WOZ56016.1 hypothetical protein B115_00028 [Yersinia phage vB_YpM_115]	WOZ56016.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56062.1	WOZ56062.1 hypothetical protein B117_00028 [Yersinia phage vB_YpM_117]	WOZ56062.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56062.1	WOZ56062.1 hypothetical protein B117_00028 [Yersinia phage vB_YpM_117]	WOZ56062.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI11523.1	UPI11523.1 hypothetical protein BFNKNBEH_00033 [Yersinia phage VB-YPM-18]	UPI11523.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI11523.1	UPI11523.1 hypothetical protein BFNKNBEH_00033 [Yersinia phage VB-YPM-18]	UPI11523.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56105.1	WOZ56105.1 hypothetical protein B476A_00025 [Yersinia phage vB_YpM_476A]	WOZ56105.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56105.1	WOZ56105.1 hypothetical protein B476A_00025 [Yersinia phage vB_YpM_476A]	WOZ56105.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01110.1	ULG01110.1 tail length tape-measure protein [Escherichia phage 10W]	ULG01110.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG01110.1	ULG01110.1 tail length tape-measure protein [Escherichia phage 10W]	ULG01110.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55513.1	QKE55513.1 chromosome partition protein [Yersinia phage vB_YpM_22]	QKE55513.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55513.1	QKE55513.1 chromosome partition protein [Yersinia phage vB_YpM_22]	QKE55513.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56145.1	WOZ56145.1 hypothetical protein B476B_00025 [Yersinia phage vB_YpM_476B]	WOZ56145.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ56145.1	WOZ56145.1 hypothetical protein B476B_00025 [Yersinia phage vB_YpM_476B]	WOZ56145.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD39559.1	VUD39559.1 Phage protein [Peduovirus P24C9]	VUD39559.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD39559.1	VUD39559.1 Phage protein [Peduovirus P24C9]	VUD39559.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAP04462.1	AAP04462.1 gpT [Yersinia phage L-413C]	AAP04462.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAP04462.1	AAP04462.1 gpT [Yersinia phage L-413C]	AAP04462.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98446.1	QDJ98446.1 hypothetical protein LLFFHNDI_00019 [Escherichia phage vB_EcoM-12474II]	QDJ98446.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98446.1	QDJ98446.1 hypothetical protein LLFFHNDI_00019 [Escherichia phage vB_EcoM-12474II]	QDJ98446.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98578.1	QDJ98578.1 hypothetical protein OMJLAAIH_00019 [Escherichia phage vB_EcoM-12474V]	QDJ98578.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98578.1	QDJ98578.1 hypothetical protein OMJLAAIH_00019 [Escherichia phage vB_EcoM-12474V]	QDJ98578.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98534.1	QDJ98534.1 hypothetical protein PBINGOGM_00019 [Escherichia phage vB_EcoM-12474IV]	QDJ98534.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98534.1	QDJ98534.1 hypothetical protein PBINGOGM_00019 [Escherichia phage vB_EcoM-12474IV]	QDJ98534.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98493.1	QDJ98493.1 hypothetical protein BBAMJIOM_00022 [Escherichia phage vB_EcoM-12474III]	QDJ98493.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDJ98493.1	QDJ98493.1 hypothetical protein BBAMJIOM_00022 [Escherichia phage vB_EcoM-12474III]	QDJ98493.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URE76597.1	URE76597.1 tail length tape-measure protein [Escherichia phage vB_EcoM-613R3]	URE76597.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URE76597.1	URE76597.1 tail length tape-measure protein [Escherichia phage vB_EcoM-613R3]	URE76597.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URC09826.1	URC09826.1 tail length tape-measure protein [Escherichia phage vB_EcoM-720R8]	URC09826.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URC09826.1	URC09826.1 tail length tape-measure protein [Escherichia phage vB_EcoM-720R8]	URC09826.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAD03293.1	AAD03293.1 gpT [Bacteriophage P2]	AAD03293.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAD03293.1	AAD03293.1 gpT [Bacteriophage P2]	AAD03293.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD38032.1	VUD38032.1 Phage protein [Peduovirus P24B2]	VUD38032.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD38032.1	VUD38032.1 Phage protein [Peduovirus P24B2]	VUD38032.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNL50860.1	WNL50860.1 tail length tape measure protein [Xanthomonas phage Murka]	WNL50860.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI11475.1	UPI11475.1 hypothetical protein COILCCMC_00027 [Yersinia phage VB-YPM-4]	UPI11475.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UPI11475.1	UPI11475.1 hypothetical protein COILCCMC_00027 [Yersinia phage VB-YPM-4]	UPI11475.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55606.1	QKE55606.1 hypothetical protein vBYpM46_00026 [Yersinia phage vB_YpM_46]	QKE55606.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55606.1	QKE55606.1 hypothetical protein vBYpM46_00026 [Yersinia phage vB_YpM_46]	QKE55606.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASD51159.1	ASD51159.1 tail tape measure protein [Erwinia phage EtG]	ASD51159.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASD51159.1	ASD51159.1 tail tape measure protein [Erwinia phage EtG]	ASD51159.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEI25364.1	QEI25364.1 tail tape measure protein [Salmonella phage SI22]	QEI25364.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEI25364.1	QEI25364.1 tail tape measure protein [Salmonella phage SI22]	QEI25364.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEI25409.1	QEI25409.1 tail tape measure protein [Salmonella phage SW9]	QEI25409.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEI25409.1	QEI25409.1 tail tape measure protein [Salmonella phage SW9]	QEI25409.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55649.1	QKE55649.1 chromosome partition protein [Yersinia phage vB_YpM_50]	QKE55649.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKE55649.1	QKE55649.1 chromosome partition protein [Yersinia phage vB_YpM_50]	QKE55649.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD37988.1	VUD37988.1 Phage protein [Peduovirus P22H1]	VUD37988.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD37988.1	VUD37988.1 Phage protein [Peduovirus P22H1]	VUD37988.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAS47883.1	AAS47883.1 gp44 [Burkholderia phage BcepMu]	AAS47883.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGG36544.1	AGG36544.1 hypothetical protein [Escherichia phage P2]	AGG36544.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGG36544.1	AGG36544.1 hypothetical protein [Escherichia phage P2]	AGG36544.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QXF95293.1	QXF95293.1 tail length tape-measure protein [Yersinia phage HQ103]	QXF95293.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QXF95293.1	QXF95293.1 tail length tape-measure protein [Yersinia phage HQ103]	QXF95293.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN28244.1	AAN28244.1 gpT [Escherichia phage Wphi]	AAN28244.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAN28244.1	AAN28244.1 gpT [Escherichia phage Wphi]	AAN28244.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593831.1	CAG9593831.1 hypothetical protein P2DC1_00027 [Peduovirus P2]	CAG9593831.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAG9593831.1	CAG9593831.1 hypothetical protein P2DC1_00027 [Peduovirus P2]	CAG9593831.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG00889.1	ULG00889.1 tail length tape-measure protein [Escherichia phage 11W]	ULG00889.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADX32408.1	ADX32408.1 phage tail measure protein [Erwinia phage ENT90]	ADX32408.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADX32408.1	ADX32408.1 phage tail measure protein [Erwinia phage ENT90]	ADX32408.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WID42138.1	WID42138.1 tape measure protein [Pseudomonas phage ZRG1]	WID42138.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AQY55119.1	AQY55119.1 tail length tape measure protein [Geobacillus phage TP-84]	AQY55119.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL93855.1	UYL93855.1 tape measure protein [Geobacillus phage vB_GthS_PK2.1]	UYL93855.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYD87362.1	AYD87362.1 tape measure protein [Microbacterium phage ValentiniPuff]	AYD87362.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ULG00890.1	ULG00890.1 tail length tape-measure protein [Escherichia phage 11W]	ULG00890.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WEV89356.1	WEV89356.1 hypothetical protein H10PHJ05_55 [Aeromonas phage HJ05]	WEV89356.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AIZ95153.1	AIZ95153.1 tail tape measure protein [Escherichia phage P88]	AIZ95153.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	VUD40186.1	VUD40186.1 Phage protein [Xuanwuvirus P884B11]	VUD40186.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFU62903.1	AFU62903.1 phage tail length tape measure protein [Acidithiobacillus phage AcaML1]	AFU62903.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WOZ57122.1	WOZ57122.1 tail tape measure protein, TP901 family [Citrobacter phage Shae_phiSM]	WOZ57122.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFG79328.1	WFG79328.1 hypothetical protein JPGLOODI_00011 [Clostridioides phage AR1075-1]	WFG79328.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AEF56891.1	AEF56891.1 tail tape measure [Clostridium phage phiCD38-2]	AEF56891.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABI36833.1	ABI36833.1 putative tail tape measure protein [Geobacillus virus E2]	ABI36833.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27443.1	QBP27443.1 tail tape measure protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27443.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27443.1	QBP27443.1 tail tape measure protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27443.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP07799.1	QBP07799.1 tail tape measure protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07799.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP07799.1	QBP07799.1 tail tape measure protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07799.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27857.1	QBP27857.1 tail tape measure protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27857.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27857.1	QBP27857.1 tail tape measure protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27857.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP08109.1	QBP08109.1 tail tape measure protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08109.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP08109.1	QBP08109.1 tail tape measure protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08109.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27682.1	QBP27682.1 tail tape measure protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27682.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27682.1	QBP27682.1 tail tape measure protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27682.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27954.1	QBP27954.1 tail tape measure protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27954.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27954.1	QBP27954.1 tail tape measure protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27954.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QNO12677.1	QNO12677.1 tape measure protein [Arthrobacter phage Tweety19]	QNO12677.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WVX87936.1	WVX87936.1 tape measure protein [Arthrobacter phage Snek]	WVX87936.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UGC97262.1	UGC97262.1 tail length tape-measure protein [Aeromonas phage vB_AsaM_LPM4]	UGC97262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27600.1	QBP27600.1 tail tape measure protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27600.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27600.1	QBP27600.1 tail tape measure protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27600.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QVQ56163.1	QVQ56163.1 tail tape measure protein [Paenibacillus phage Pd_22F]	QVQ56163.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WIC90165.1	WIC90165.1 tape measure protein [Arthrobacter phage VroomVroom]	WIC90165.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBQ72018.1	QBQ72018.1 tail tape measure protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72018.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBQ72018.1	QBQ72018.1 tail tape measure protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72018.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CEK40345.1	CEK40345.1 Tail tape measure [Clostridium phage phiCD146]	CEK40345.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WKW85412.1	WKW85412.1 tape measure protein [Microbacterium phage Milani]	WKW85412.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWY05703.1	AWY05703.1 tape measure protein [Microbacterium phage Percival]	AWY05703.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWY04852.1	AWY04852.1 tape measure protein [Microbacterium phage Floof]	AWY04852.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UDL14789.1	UDL14789.1 tape measure protein [Microbacterium phage Gretchen]	UDL14789.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CEK40291.1	CEK40291.1 Tail tape measure [Clostridium phage phiCD111]	CEK40291.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY06960.1	ALY06960.1 tail tape measure [Clostridium phage CDSH1]	ALY06960.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CUL03808.1	CUL03808.1 Phage-related minor tail protein [Clostridium phage slur17]	CUL03808.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WAY79745.1	WAY79745.1 putative tail protein, partial [Klebsiella phage KP12]	WAY79745.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIZ02636.1	QIZ02636.1 tail length tape-measure protein [Aeromonas phage AhyVDH1]	QIZ02636.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWV91848.1	WWV91848.1 tail length tape measure protein [Microbacterium phage phiMiGM15]	WWV91848.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF88198.1	AZF88198.1 tape measure protein [Rothia phage Spartoi]	AZF88198.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP08021.1	QBP08021.1 tail tape measure protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08021.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP08021.1	QBP08021.1 tail tape measure protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08021.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27749.1	QBP27749.1 tail tape measure protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27749.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27749.1	QBP27749.1 tail tape measure protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27749.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27902.1	QBP27902.1 tail tape measure protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27902.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP27902.1	QBP27902.1 tail tape measure protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27902.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH20307.1	WGH20307.1 tape measure protein [Arthrobacter phage MaGuCo]	WGH20307.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QCQ57461.1	QCQ57461.1 tape measure protein [Microbacterium phage Sucha]	QCQ57461.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APD18492.1	APD18492.1 tape measure protein [Streptomyces phage Ididsumtinwong]	APD18492.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APD18713.1	APD18713.1 tape measure protein [Streptomyces phage Bioscum]	APD18713.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QOI66927.1	QOI66927.1 tape measure protein [Microbacterium phage GardenState]	QOI66927.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBZ73583.1	QBZ73583.1 tape measure protein [Streptomyces phage RosaAsantewaa]	QBZ73583.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBZ73583.1	QBZ73583.1 tape measure protein [Streptomyces phage RosaAsantewaa]	QBZ73583.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFD22271.1	AFD22271.1 tail tape measure protein [Staphylococcus phage StB12]	AFD22271.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WDS52120.1	WDS52120.1 tape measure protein [Microbacterium phage UtzChips]	WDS52120.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WDS51651.1	WDS51651.1 tape measure protein [Microbacterium phage Barnstormer]	WDS51651.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL87621.1	UYL87621.1 tape measure protein [Arthrobacter phage VResidence]	UYL87621.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URG17392.1	URG17392.1 tape measure protein [Rhodococcus phage Mbo2]	URG17392.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URG17392.1	URG17392.1 tape measure protein [Rhodococcus phage Mbo2]	URG17392.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHB36598.1	QHB36598.1 tape measure protein [Arthrobacter phage Adolin]	QHB36598.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYN57736.1	AYN57736.1 tape measure protein [Arthrobacter phage DrManhattan]	AYN57736.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH21192.1	WGH21192.1 tape measure protein [Arthrobacter phage ObiToo]	WGH21192.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UIW13269.1	UIW13269.1 tape measure protein [Arthrobacter phage Crewmate]	UIW13269.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYN58496.1	AYN58496.1 tape measure protein [Arthrobacter phage Maureen]	AYN58496.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF93748.1	AZF93748.1 tape measure protein [Arthrobacter phage Liebe]	AZF93748.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNO26036.1	WNO26036.1 tape measure protein [Arthrobacter phage Wildwest]	WNO26036.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWH15040.1	AWH15040.1 tail length tape-measure protein [Aeromonas phage 85AhydR10PP]	AWH15040.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMU95065.1	WMU95065.1 chromosome partition protein [Clostridioides phage AR1074-1]	WMU95065.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WJN62641.1	WJN62641.1 tape measure protein [Streptomyces phage phiScoe10]	WJN62641.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WVX87867.1	WVX87867.1 tape measure protein [Arthrobacter phage Berrie]	WVX87867.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIG58494.1	QIG58494.1 tape measure protein [Arthrobacter phage DrSierra]	QIG58494.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANN86131.1	ANN86131.1 putative tail tape measure protein [Enterobacter phage Arya]	ANN86131.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CAJ1312483.1	CAJ1312483.1 tail length tape measure protein [Siphoviridae sp. ctl617]	CAJ1312483.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAX92777.1	QAX92777.1 tape measure protein [Streptomyces phage Austintatious]	QAX92777.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	URQ05004.1	URQ05004.1 tape measure protein [Arthrobacter phage Iter]	URQ05004.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABM73395.1	ABM73395.1 phage-related tail protein [Vibrio phage VP882]	ABM73395.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHJ73555.1	QHJ73555.1 tape measure protein [Butyrivibrio phage Arawn]	QHJ73555.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHJ73827.1	QHJ73827.1 tape measure protein [Butyrivibrio phage Idris]	QHJ73827.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH21539.1	WGH21539.1 tape measure protein [Arthrobacter phage Ascela]	WGH21539.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARM68518.1	ARM68518.1 tail length tape-measure protein [Staphylococcus phage IME1365_01]	ARM68518.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	USL85077.1	USL85077.1 tape measure protein [Arthrobacter phage SWEP2]	USL85077.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH21364.1	WGH21364.1 tape measure protein [Arthrobacter phage Emotion]	WGH21364.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACH86138.1	ACH86138.1 phage tail tape measure protein [Pseudomonas phage DVM-2008]	ACH86138.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QCG77521.1	QCG77521.1 tape measure protein [Microbacterium phage DizzyRudy]	QCG77521.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QGZ17314.1	QGZ17314.1 tape measure protein [Arthrobacter phage Powerpuff]	QGZ17314.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIN94507.1	QIN94507.1 tape measure protein [Arthrobacter phage YesChef]	QIN94507.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS49223.1	AZS49223.1 hypothetical protein BpsS140_00030 [Bacillus phage vB_BpsS-140]	AZS49223.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXF40315.1	AXF40315.1 tail tape measure protein [Paenibacillus phage LincolnB]	AXF40315.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AUS03419.1	AUS03419.1 tail tape measure protein [Paenibacillus phage Dragolir]	AUS03419.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXF39431.1	AXF39431.1 tail tape measure protein [Paenibacillus phage Wanderer]	AXF39431.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY09228.1	ALY09228.1 tape measure protein [Arthrobacter phage Immaculata]	ALY09228.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APU00843.1	APU00843.1 tail length tape-measure protein [Aeromonas phage 59.1]	APU00843.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS09710.1	AZS09710.1 tape measure protein [Arthrobacter phage Riverdale]	AZS09710.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFU62156.1	AFU62156.1 tape measure protein [Streptomyces phage SV1]	AFU62156.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFJ96071.1	AFJ96071.1 gp13 [Clostridium phage PhiS63]	AFJ96071.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WAB10066.1	WAB10066.1 tape measure protein [Arthrobacter phage Jumboset]	WAB10066.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOT24108.1	AOT24108.1 tape measure protein [Arthrobacter phage Vallejo]	AOT24108.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF97395.1	AZF97395.1 tape measure protein [Arthrobacter phage Carpal]	AZF97395.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY10037.1	ALY10037.1 tape measure protein [Arthrobacter phage RAP15]	ALY10037.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS07062.1	AZS07062.1 tape measure protein [Arthrobacter phage Cholula]	AZS07062.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY08929.1	ALY08929.1 tape measure protein [Arthrobacter phage Glenn]	ALY08929.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QCG76966.1	QCG76966.1 tape measure protein [Arthrobacter phage Scuttle]	QCG76966.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS11841.1	AZS11841.1 tape measure protein [Arthrobacter phage Potatoes]	AZS11841.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATW58953.1	ATW58953.1 tape measure protein [Arthrobacter phage MeganNoll]	ATW58953.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83463.1	ASR83463.1 tape measure protein [Arthrobacter phage Dino]	ASR83463.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS11125.1	AZS11125.1 tape measure protein [Arthrobacter phage Wawa]	AZS11125.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBZ73270.1	QBZ73270.1 tape measure protein [Arthrobacter phage MrGloopy]	QBZ73270.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ARE89873.1	ARE89873.1 tape measure protein [Arthrobacter phage Korra]	ARE89873.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS11466.1	AZS11466.1 tape measure protein [Arthrobacter phage Zorro]	AZS11466.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPB09618.1	QPB09618.1 tape measure protein [Streptomyces phage Spernnie]	QPB09618.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF98482.1	AZF98482.1 tape measure protein [Arthrobacter phage Beethoven]	AZF98482.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS09771.1	AZS09771.1 tape measure protein [Arthrobacter phage Rozby]	AZS09771.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS10558.1	AZS10558.1 tape measure protein [Arthrobacter phage TattModd]	AZS10558.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKJ71924.1	AKJ71924.1 putative major tail protein [Tsukamurella phage TIN4]	AKJ71924.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKJ71815.1	AKJ71815.1 putative tape measure protein [Tsukamurella phage TIN3]	AKJ71815.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWH14536.1	AWH14536.1 tail length tape-measure protein [Aeromonas phage 13AhydR10PP]	AWH14536.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UNY40518.1	UNY40518.1 tape measure protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40518.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WAB10791.1	WAB10791.1 tape measure protein [Arthrobacter phage Tuck]	WAB10791.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	CCI88335.1	CCI88335.1 minor tail protein gp26-like [Lactobacillus phage phiAQ113]	CCI88335.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNO27801.1	WNO27801.1 tape measure protein [Microbacterium phage Huwbert]	WNO27801.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPX62348.1	QPX62348.1 tape measure protein [Arthrobacter phage Tbone]	QPX62348.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WJN62562.1	WJN62562.1 tape measure protein [Streptomyces phage phiScoe1]	WJN62562.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBI99382.1	QBI99382.1 tape measure protein [Streptomyces phage Caelum]	QBI99382.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDF14188.1	QDF14188.1 tape measure protein [Microbacterium phage IAmGroot]	QDF14188.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATI18640.1	ATI18640.1 tape measure protein [Streptomyces phage Amethyst]	ATI18640.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACZ63951.1	ACZ63951.1 PblA-like tail protein [Enterococcus phage phiFL2A]	ACZ63951.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPB09847.1	QPB09847.1 tape measure protein [Streptomyces phage Sentinel]	QPB09847.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYN59102.1	AYN59102.1 tape measure protein [Arthrobacter phage Yang]	AYN59102.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWH15334.1	AWH15334.1 tail length tape-measure protein [Aeromonas phage 14AhydR10PP]	AWH15334.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AUG87203.1	AUG87203.1 tape measure protein [Streptomyces phage Omar]	AUG87203.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADK37877.1	ADK37877.1 putative phage tail tape measure protein [Clostridium phage phiCD6356]	ADK37877.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS10133.1	AZS10133.1 tape measure protein [Arthrobacter phage Savage2526]	AZS10133.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATW58890.1	ATW58890.1 tape measure protein [Arthrobacter phage Fluke]	ATW58890.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UVK63537.1	UVK63537.1 tape measure protein [Arthrobacter phage Janeemi]	UVK63537.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHB47188.1	QHB47188.1 tape measure protein [Arthrobacter phage AppleCider]	QHB47188.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF97654.1	AZF97654.1 tape measure protein [Arthrobacter phage CallieOMalley]	AZF97654.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UIW13432.1	UIW13432.1 tape measure protein [Arthrobacter phage Amyev]	UIW13432.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFD22202.1	AFD22202.1 tail tape measure protein [Staphylococcus phage StB27]	AFD22202.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QNJ56516.1	QNJ56516.1 tape measure protein [Arthrobacter phage Elezi]	QNJ56516.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QOP64319.1	QOP64319.1 tape measure protein [Arthrobacter phage London]	QOP64319.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UAJ15377.1	UAJ15377.1 tape measure protein [Arthrobacter phage Asa16]	UAJ15377.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWM22352.1	WWM22352.1 tape measure protein [Arthrobacter phage Niobe]	WWM22352.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WWM22282.1	WWM22282.1 tape measure protein [Arthrobacter phage Eraser]	WWM22282.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UIW13500.1	UIW13500.1 tape measure protein [Arthrobacter phage Lizalica]	UIW13500.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UIW13198.1	UIW13198.1 tape measure protein [Arthrobacter phage Warda]	UIW13198.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOT24046.1	AOT24046.1 tape measure protein [Arthrobacter phage Suppi]	AOT24046.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83254.1	ASR83254.1 tape measure protein [Arthrobacter phage Canowicakte]	ASR83254.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS08739.1	AZS08739.1 tape measure protein [Arthrobacter phage Litotes]	AZS08739.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY10743.1	ALY10743.1 tape measure protein [Arthrobacter phage Wayne]	ALY10743.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXF39329.1	AXF39329.1 tape measure protein [Bifidobacterium phage PMBT6]	AXF39329.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDF14881.1	QDF14881.1 tape measure protein [Bifidobacterium phage PMBT6]	QDF14881.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY09421.1	ALY09421.1 tape measure protein [Arthrobacter phage Joann]	ALY09421.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAY15759.1	QAY15759.1 tape measure protein [Streptomyces phage Nishikigoi]	QAY15759.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXH70222.1	AXH70222.1 tape measure protein [Streptomyces phage Haizum]	AXH70222.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATI18958.1	ATI18958.1 tape measure protein [Streptomyces phage Tefunt]	ATI18958.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACZ63888.1	ACZ63888.1 PblA-like tail protein [Enterococcus phage phiFL1C]	ACZ63888.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BAH15159.1	BAH15159.1 hypothetical protein, partial [Serratia phage KSP20]	BAH15159.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UVK59033.1	UVK59033.1 tape measure protein [Microbacterium phage Cen1621]	UVK59033.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATI18802.1	ATI18802.1 tape measure protein [Streptomyces phage Diane]	ATI18802.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACZ64012.1	ACZ64012.1 PblA-like tail protein [Enterococcus phage phiFL2B]	ACZ64012.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACZ63753.1	ACZ63753.1 PblA-like tail protein [Enterococcus phage phiFL1A]	ACZ63753.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACZ63816.1	ACZ63816.1 PblA-like tail protein [Enterococcus phage phiFL1B]	ACZ63816.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJD50665.1	QJD50665.1 tape measure protein [Streptomyces phage Issmi]	QJD50665.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QIN94416.1	QIN94416.1 tape measure protein [Arthrobacter phage Lego]	QIN94416.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH20729.1	WGH20729.1 tape measure protein [Arthrobacter phage JohnDoe]	WGH20729.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APU00759.1	APU00759.1 tail length tape-measure protein [Aeromonas phage Asp37]	APU00759.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AVR56922.1	AVR56922.1 tape measure protein [Microbacterium phage Triscuit]	AVR56922.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG12846.1	QFG12846.1 tape measure protein [Arthrobacter phage Mimi]	QFG12846.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG12218.1	QFG12218.1 tape measure protein [Arthrobacter phage Racecar]	QFG12218.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNN93972.1	WNN93972.1 tape measure protein [Arthrobacter phage Nitro]	WNN93972.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA49628.1	ANA49628.1 tail length tape-measure protein [Lactococcus phage PLgT-1]	ANA49628.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFD53049.1	WFD53049.1 minor tail protein [Lactobacillus phage S16]	WFD53049.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS09483.1	AZS09483.1 tape measure protein [Arthrobacter phage Pterodactyl]	AZS09483.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAX91264.1	AAX91264.1 ORF001 [Staphylococcus phage 37]	AAX91264.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF98416.1	AZF98416.1 tape measure protein [Arthrobacter phage BigMack]	AZF98416.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOQ28288.1	AOQ28288.1 tape measure protein [Arthrobacter phage Lucy]	AOQ28288.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AAX90679.1	AAX90679.1 ORF001 [Staphylococcus phage 187]	AAX90679.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS12388.1	AZS12388.1 tape measure protein [Arthrobacter phage HeadNerd]	AZS12388.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS08156.1	AZS08156.1 tape measure protein [Arthrobacter phage Huckleberry]	AZS08156.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AYD81710.1	AYD81710.1 tape measure protein [Arthrobacter phage Moki]	AYD81710.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY08551.1	ALY08551.1 tape measure protein [Arthrobacter phage Bennie]	ALY08551.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83809.1	ASR83809.1 tape measure protein [Arthrobacter phage PitaDog]	ASR83809.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNM67592.1	WNM67592.1 tape measure protein [Arthrobacter phage Makoto]	WNM67592.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF98270.1	AZF98270.1 tape measure protein [Arthrobacter phage Bodacious]	AZF98270.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS09101.1	AZS09101.1 tape measure protein [Arthrobacter phage Nancia]	AZS09101.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS07222.1	AZS07222.1 tape measure protein [Arthrobacter phage CristinaYang]	AZS07222.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WKW86741.1	WKW86741.1 tape measure protein [Arthrobacter phage WonderBoy]	WKW86741.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS08512.1	AZS08512.1 tape measure protein [Arthrobacter phage Lasagna]	AZS08512.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHB36848.1	QHB36848.1 tape measure protein [Arthrobacter phage LilStuart]	QHB36848.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83398.1	ASR83398.1 tape measure protein [Arthrobacter phage Christian]	ASR83398.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS09222.1	AZS09222.1 tape measure protein [Arthrobacter phage OurGirlNessie]	AZS09222.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS08674.1	AZS08674.1 tape measure protein [Arthrobacter phage Lennox]	AZS08674.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXH46476.1	AXH46476.1 tape measure protein [Gordonia phage RobinSparkles]	AXH46476.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS06997.1	AZS06997.1 tape measure protein [Arthrobacter phage ChewChew]	AZS06997.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALY08801.1	ALY08801.1 tape measure protein [Arthrobacter phage DrRobert]	ALY08801.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFY98431.1	AFY98431.1 phage tail tape measure protein [Leuconostoc phage LN34]	AFY98431.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QSL99670.1	QSL99670.1 tape measure protein [Gordonia phage Austin]	QSL99670.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG08513.1	QFG08513.1 tape measure protein [Gordonia phage ASerpRocky]	QFG08513.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA85996.1	ANA85996.1 tape measure protein [Gordonia phage Demosthenes]	ANA85996.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXH68180.1	AXH68180.1 tape measure protein [Gordonia phage Teatealatte]	AXH68180.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKN86177.1	QKN86177.1 putative tail length tape-measure protein [Staphylococcus virus pSp_SNUABM-J]	QKN86177.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA86091.1	ANA86091.1 tape measure protein [Gordonia phage Kvothe]	ANA86091.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOZ65120.1	AOZ65120.1 tape measure protein [Arthrobacter phage Greenhouse]	AOZ65120.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMI34462.1	WMI34462.1 tape measure protein [Microbacterium phage Damascus]	WMI34462.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBP29584.1	QBP29584.1 tape measure protein [Gordonia phage Tredge]	QBP29584.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AMS03736.1	AMS03736.1 tape measure protein [Gordonia phage Benczkowski14]	AMS03736.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AMS03419.1	AMS03419.1 tape measure protein [Gordonia phage Katyusha]	AMS03419.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QOP65076.1	QOP65076.1 tape measure protein [Arthrobacter phage Adumb2043]	QOP65076.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA87485.1	ANA87485.1 tape measure protein [Gordonia phage Kampe]	ANA87485.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA87258.1	ANA87258.1 tape measure protein [Gordonia phage PatrickStar]	ANA87258.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ANA87371.1	ANA87371.1 tape measure protein [Gordonia phage Orchid]	ANA87371.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UVT35098.1	UVT35098.1 tail protein [Staphylococcus phage vB_SpsS_VL4]	UVT35098.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPO16946.1	QPO16946.1 tape measure protein [Arthrobacter phage Kittykat]	QPO16946.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QOP65145.1	QOP65145.1 tape measure protein [Arthrobacter phage Phives]	QOP65145.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WGH21089.1	WGH21089.1 tape measure protein [Arthrobacter phage Cassia]	WGH21089.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZB66867.1	AZB66867.1 tail length tape-measure protein [Staphylococcus phage phiSP119-3]	AZB66867.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APD19873.1	APD19873.1 tail tape measure protein [Staphylococcus phage SpT152]	APD19873.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL87047.1	UYL87047.1 tape measure protein [Gordonia phage Hollow]	UYL87047.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QXO14550.1	QXO14550.1 tape measure protein [Arthrobacter phage Kaylissa]	QXO14550.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APU00423.1	APU00423.1 tail length tape-measure protein [Aeromonas phage 3]	APU00423.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNO29719.1	WNO29719.1 TMP repeat protein [Bacillus phage SDFMU_Pfc]	WNO29719.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WMC01322.1	WMC01322.1 hypothetical protein [Caudovirus D_HF4_2]	WMC01322.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UJD20664.1	UJD20664.1 tape measure protein [Gordonia phage Niagara]	UJD20664.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZB66670.1	AZB66670.1 tail length tape-measure protein [Staphylococcus phage phiSP44-1]	AZB66670.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWY06648.1	AWY06648.1 tape measure protein [Microbacterium phage Zeta1847]	AWY06648.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BBJ33943.1	BBJ33943.1 tape measure protein [Staphylococcus phage SP120]	BBJ33943.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BBJ34044.1	BBJ34044.1 tape measure protein [Staphylococcus phage SP197]	BBJ34044.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEA09994.1	QEA09994.1 tail protein [Staphylococcus phage vB_SpsM_WIS42]	QEA09994.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU01332.1	ASU01332.1 tail length tape-measure protein [Staphylococcus phage SN10]	ASU01332.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU01400.1	ASU01400.1 tail length tape-measure protein [Staphylococcus phage SN8]	ASU01400.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU01191.1	ASU01191.1 tail length tape-measure protein [Staphylococcus phage SN13]	ASU01191.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU01262.1	ASU01262.1 tail length tape-measure protein [Staphylococcus phage SN11]	ASU01262.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QYC53957.1	QYC53957.1 tape measure protein [Gordonia phage Nithya]	QYC53957.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZS07997.1	AZS07997.1 tape measure protein [Arthrobacter phage GreenHearts]	AZS07997.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83751.1	ASR83751.1 tape measure protein [Arthrobacter phage Nubia]	ASR83751.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFR56238.1	QFR56238.1 tape measure protein [Bacillus phage 000TH010]	QFR56238.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QXO14056.1	QXO14056.1 tape measure protein [Gordonia phage AlainaMarie]	QXO14056.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFY98347.1	AFY98347.1 putative phage tail tape measure protein [Leuconostoc phage phiLN12]	AFY98347.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNN94353.1	WNN94353.1 tape measure protein [Gordonia phage EndAve]	WNN94353.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOZ65059.1	AOZ65059.1 tape measure protein [Arthrobacter phage Oxynfrius]	AOZ65059.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WKW85575.1	WKW85575.1 tape measure protein [Arthrobacter phage Lakshmi]	WKW85575.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL86745.1	UYL86745.1 tape measure protein [Arthrobacter phage Albanese]	UYL86745.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU04019.1	ASU04019.1 tape measure protein [Streptomyces phage Spectropatronm]	ASU04019.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDM56524.1	QDM56524.1 tape measure protein [Streptomyces phage Esketit]	QDM56524.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ94240.1	QEQ94240.1 tape measure protein [Streptomyces phage Hoshi]	QEQ94240.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WVX88004.1	WVX88004.1 tape measure protein [Arthrobacter phage TforTroy]	WVX88004.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJD49904.1	QJD49904.1 tape measure protein [Streptomyces phage CricKo]	QJD49904.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WIC89358.1	WIC89358.1 tape measure protein [Streptomyces phage Miek]	WIC89358.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QNL30636.1	QNL30636.1 tape measure protein [Streptomyces phage Thiqqums]	QNL30636.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWN05887.1	AWN05887.1 tape measure protein [Streptomyces phage Rainydai]	AWN05887.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWN06123.1	AWN06123.1 tape measure protein [Streptomyces phage SendItCS]	AWN06123.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QNN98188.1	QNN98188.1 tape measure protein [Streptomyces phage Maya]	QNN98188.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ93971.1	QEQ93971.1 tape measure protein [Streptomyces phage Meibysrarus]	QEQ93971.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QPX62050.1	QPX62050.1 tape measure protein [Streptomyces phage Indigenous]	QPX62050.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ93716.1	QEQ93716.1 tape measure protein [Streptomyces phage Jaylociraptor]	QEQ93716.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASR83944.1	ASR83944.1 tape measure protein [Arthrobacter phage Shrooms]	ASR83944.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QNN99498.1	QNN99498.1 tape measure protein [Streptomyces phage TieDye]	QNN99498.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UOW93172.1	UOW93172.1 tape measure protein [Streptomyces phage TonyStarch]	UOW93172.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAY16235.1	QAY16235.1 tape measure protein [Streptomyces phage IceWarrior]	QAY16235.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOZ64977.1	AOZ64977.1 tape measure protein [Streptomyces phage Rima]	AOZ64977.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAY16321.1	QAY16321.1 tape measure protein [Streptomyces phage Namo]	QAY16321.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFD52990.1	WFD52990.1 tape measure protein [Lactobacillus phage P185]	WFD52990.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QHB37025.1	QHB37025.1 tape measure protein [Microbacterium phage Matzah]	QHB37025.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG14935.1	QFG14935.1 tape measure protein [Mycobacterium phage BogosyJay]	QFG14935.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ93802.1	QEQ93802.1 tape measure protein [Streptomyces phage CherryBlossom]	QEQ93802.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QGJ96722.1	QGJ96722.1 tape measure protein [Streptomyces phage FidgetOrca]	QGJ96722.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFY98191.1	AFY98191.1 putative phage tail tape measure protein [Leuconostoc phage P793]	AFY98191.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOZ64888.1	AOZ64888.1 tape measure protein [Streptomyces phage OlympicHelado]	AOZ64888.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG11540.1	QFG11540.1 tape measure protein [Mycobacterium phage Maminiaina]	QFG11540.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QWY81422.1	QWY81422.1 tape measure protein [Streptomyces phage TaidaOne]	QWY81422.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WPJ30764.1	WPJ30764.1 tape measure protein [Streptomyces phage Psst4]	WPJ30764.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDP43571.1	QDP43571.1 tape measure protein [Microbacterium phage Tyrumbra]	QDP43571.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QDP43571.1	QDP43571.1 tape measure protein [Microbacterium phage Tyrumbra]	QDP43571.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WCZ54807.1	WCZ54807.1 tape measure protein [Latilactobacillus phage TMW 1.591 P1]	WCZ54807.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QBX21435.1	QBX21435.1 tail length tape-measure protein [Streptococcus phage Javan573]	QBX21435.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AZF88278.1	AZF88278.1 tape measure protein [Meiothermus phage MMP7]	AZF88278.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAY18059.1	QAY18059.1 tape measure domain protein [Meiothermus phage MMP17]	QAY18059.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WJN66830.1	WJN66830.1 hypothetical protein CFHODIGL_00015 [Edwardsiella phage EPP-1]	WJN66830.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFD53125.1	WFD53125.1 tape measure protein [Lactobacillus phage S193]	WFD53125.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WDS52040.1	WDS52040.1 tape measure protein [Microbacterium phage Caron]	WDS52040.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABK91882.2	ABK91882.2 tail tape measure protein [Streptococcus phage SMP]	ABK91882.2	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AER26562.1	AER26562.1 phage tape measure protein [Gordonia phage GTE7]	AER26562.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ94335.1	QEQ94335.1 tape measure protein [Gordonia phage Chikenjars]	QEQ94335.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ACH42319.1	ACH42319.1 carbamoyl-phosphate synthase large subunit [Bacillus phage IEBH]	ACH42319.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKJ72456.1	AKJ72456.1 putative tape measure protein [Gordonia phage GMA7]	AKJ72456.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ADB28368.1	ADB28368.1 carbamoyl-phosphate synthase large subunit [Bacillus phage 250]	ADB28368.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG08606.1	QFG08606.1 tape measure protein [Mycobacterium phage Vanisoa]	QFG08606.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AKI27555.1	AKI27555.1 tail protein [Moraxella phage Mcat13]	AKI27555.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALO79395.1	ALO79395.1 tail length tape-measure protein [Streptomyces phage phiSAJS1]	ALO79395.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AGJ71986.1	AGJ71986.1 putative tail measure protein [Leuconostoc phage 1 HN-2013]	AGJ71986.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UVK58687.1	UVK58687.1 tape measure protein [Arthrobacter phage GantcherGoblin]	UVK58687.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AWY05286.1	AWY05286.1 tape measure protein [Microbacterium phage MementoMori]	AWY05286.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UVK62848.1	UVK62848.1 tape measure protein [Arthrobacter phage Uzumaki]	UVK62848.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFD52852.1	WFD52852.1 tape measure protein [Lactobacillus phage CR191]	WFD52852.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFY98229.1	AFY98229.1 putative phage tail tape measure protein [Leuconostoc phage LN03]	AFY98229.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOT27940.1	AOT27940.1 tail tape measure protein [Leuconostoc phage CHB]	AOT27940.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QLF82772.1	QLF82772.1 tape measure protein [Mycobacterium phage Georgie2]	QLF82772.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AIS73789.1	AIS73789.1 tape measure protein [Mycobacterium phage Power]	AIS73789.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATN91871.1	ATN91871.1 tape measure protein [Mycobacterium phage SnapTap]	ATN91871.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXC33215.1	AXC33215.1 tape measure protein [Mycobacterium phage Crucio]	AXC33215.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QFG11828.1	QFG11828.1 tape measure protein [Mycobacterium phage SemperFi]	QFG11828.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QKY80091.1	QKY80091.1 tape measure protein [Mycobacterium Phage FiringLine]	QKY80091.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AXQ52952.1	AXQ52952.1 tape measure protein [Mycobacterium phage QueenBeesly]	AXQ52952.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WNT45409.1	WNT45409.1 tape measure protein [Arthrobacter phage Argan]	WNT45409.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UQS94700.1	UQS94700.1 tape measure protein [Arthrobacter phage Zeina]	UQS94700.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATW59225.1	ATW59225.1 tape measure protein [Arthrobacter phage Huntingdon]	ATW59225.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AOQ28230.1	AOQ28230.1 tape measure protein [Arthrobacter phage RcigaStruga]	AOQ28230.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WEU69939.1	WEU69939.1 tail length tape measure protein [Staphylococcus phage vB_SepS_BE20]	WEU69939.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	USH44844.1	USH44844.1 tape measure protein [Gordonia phage Amore2]	USH44844.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATN93668.1	ATN93668.1 tape measure protein [Streptomyces phage Scap1]	ATN93668.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ATN93668.1	ATN93668.1 tape measure protein [Streptomyces phage Scap1]	ATN93668.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMP84480.1	QMP84480.1 tape measure protein [Streptomyces phage Endor1]	QMP84480.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WFF43784.1	WFF43784.1 baseplate J-like protein [Lactobacillus phage CR28]	WFF43784.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QQV93366.1	QQV93366.1 tape measure protein [Staphylococcus virus vB_SepS_459]	QQV93366.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QQV93164.1	QQV93164.1 tape measure protein [Staphylococcus virus vB_SepS_27]	QQV93164.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMP81541.1	QMP81541.1 hypothetical protein SAP3_32 [Staphylococcus phage SAP3]	QMP81541.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ABD78825.1	ABD78825.1 putative minor tail protein [Lactobacillus phage KC5a]	ABD78825.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WEU70785.1	WEU70785.1 tail length tape measure protein [Staphylococcus phage vB_SepS_BE28]	WEU70785.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92713.1	UYL92713.1 tail tape measure protein [Paenibacillus phage Rae2Bee1]	UYL92713.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QMP84117.1	QMP84117.1 tape measure protein [Streptomyces phage Alderaan]	QMP84117.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92222.1	UYL92222.1 tail tape measure protein [Paenibacillus phage GIW2016]	UYL92222.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92875.1	UYL92875.1 tail tape measure protein [Paenibacillus phage Ted]	UYL92875.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12580.1	ALA12580.1 tail tape-measure protein [Paenibacillus phage Paisley]	ALA12580.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92795.1	UYL92795.1 tail tape measure protein [Paenibacillus phage Rosalind]	UYL92795.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYE92120.1	UYE92120.1 tail tape measure protein [Paenibacillus phage BarryFoster_Benicio]	UYE92120.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92384.1	UYL92384.1 tail tape measure protein [Paenibacillus phage Lena]	UYL92384.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91812.1	UYL91812.1 tail tape measure protein [Paenibacillus phage Bob]	UYL91812.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYE92038.1	UYE92038.1 tail tape measure protein [Paenibacillus phage LunBun]	UYE92038.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92302.1	UYL92302.1 tail tape measure protein [Paenibacillus phage Jacinda]	UYL92302.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92140.1	UYL92140.1 tail tape measure protein [Paenibacillus phage GaryLarson]	UYL92140.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92957.1	UYL92957.1 tail tape measure protein [Paenibacillus phage TonyLawson77]	UYL92957.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL93121.1	UYL93121.1 tail tape measure protein [Paenibacillus phage WildCape]	UYL93121.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91892.1	UYL91892.1 tail tape measure protein [Paenibacillus phage Carlos]	UYL91892.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91975.1	UYL91975.1 tail tape measure protein [Paenibacillus phage Dante]	UYL91975.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92548.1	UYL92548.1 tail tape measure protein [Paenibacillus phage NHScienceFair]	UYL92548.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92057.1	UYL92057.1 tail tape measure protein [Paenibacillus phage FutureBee]	UYL92057.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92466.1	UYL92466.1 tail tape measure protein [Paenibacillus phage Logan]	UYL92466.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL92630.1	UYL92630.1 tail tape measure protein [Paenibacillus phage Ollie]	UYL92630.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91484.1	UYL91484.1 tail tape measure protein [Paenibacillus phage ABAtENZ]	UYL91484.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91566.1	UYL91566.1 tail tape measure protein [Paenibacillus phage AJG77]	UYL91566.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL93039.1	UYL93039.1 tail tape measure protein [Paenibacillus phage UtuhinaGold_Zacery]	UYL93039.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91730.1	UYL91730.1 tail tape measure protein [Paenibacillus phage Bloomfield]	UYL91730.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	UYL91648.1	UYL91648.1 tail tape measure protein [Paenibacillus phage ApiWellbeing]	UYL91648.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	BBJ34078.1	BBJ34078.1 phage tail length tape-measure protein [Staphylococcus phage SP276]	BBJ34078.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QJD49746.1	QJD49746.1 tape measure protein [Streptomyces phage ClubPenguin]	QJD49746.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QLF86565.1	QLF86565.1 terminase [Staphylococcus phage vB_SepS_BE01]	QLF86565.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	AFM73719.1	AFM73719.1 tail tape measure protein [Staphylococcus phage vB_SepiS-phiIPLA5]	AFM73719.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12664.1	ALA12664.1 tail tape-measure protein [Paenibacillus phage Vegas]	ALA12664.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12419.1	ALA12419.1 tail tape-measure protein [Paenibacillus phage Harrison]	ALA12419.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12920.1	ALA12920.1 tail tape-measure protein [Paenibacillus phage Diane]	ALA12920.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12749.1	ALA12749.1 tail tape-measure protein [Paenibacillus phage Hayley]	ALA12749.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ALA12834.1	ALA12834.1 tail tape-measure protein [Paenibacillus phage Vadim]	ALA12834.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APD19884.1	APD19884.1 tail tape measure protein [Staphylococcus phage SpT252]	APD19884.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	APD19749.1	APD19749.1 tail tape measure protein [Staphylococcus phage SpT5]	APD19749.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	WJN63033.1	WJN63033.1 tape measure protein [Streptomyces phage phiScoe3]	WJN63033.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ93887.1	QEQ93887.1 tape measure protein [Streptomyces phage Kardashian]	QEQ93887.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	ASU03936.1	ASU03936.1 tape measure protein [Streptomyces phage DrGrey]	ASU03936.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QEQ94636.1	QEQ94636.1 tape measure protein [Streptomyces phage Soshi]	QEQ94636.1	0
+16314a3b-6979-4dd0-a106-2ce960af0b08	QAU06738.1	QAU06738.1 tape measure protein [Gordonia phage Duffington]	QAU06738.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNY41746.1	UNY41746.1 tail protein [Burkholderia phage Milagro]	UNY41746.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNY41687.1	UNY41687.1 tail protein [Burkholderia phage Musica]	UNY41687.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNY41859.1	UNY41859.1 tail protein [Burkholderia phage Momento]	UNY41859.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNY41803.1	UNY41803.1 tail protein [Burkholderia phage Menos]	UNY41803.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADP02309.1	ADP02309.1 gp16 [Burkholderia phage KL3]	ADP02309.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WWY66169.1	WWY66169.1 tail protein [Burkholderia phage vB_HM387]	WWY66169.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UKM53792.1	UKM53792.1 tail protein [Burkholderia phage PhiBP82.2]	UKM53792.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QWY84973.1	QWY84973.1 tail protein [Burkholderia phage PK23]	QWY84973.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABO60791.1	ABO60791.1 gp28, fels-2 prophage protein [Burkholderia phage phiE12-2]	ABO60791.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABO60738.1	ABO60738.1 gp25, fels-2 prophage protein [Burkholderia phage phiE202]	ABO60738.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAZ72620.1	AAZ72620.1 fels-2 prophage protein [Burkholderia phage phiE52237]	AAZ72620.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UPI15586.1	UPI15586.1 putative tail protein [Burkholderia phage PhiBP82.3]	UPI15586.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AIP84261.1	AIP84261.1 phage P2 GpU family protein [Burkholderia phage BEK]	AIP84261.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AFV51421.1	AFV51421.1 DNA methyltransferase [Burkholderia phage phiX216]	AFV51421.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADP02356.1	ADP02356.1 gp11 [Burkholderia phage KS14]	ADP02356.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AGK86801.1	AGK86801.1 phage tail protein U [Burkholderia phage ST79]	AGK86801.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BCB23189.1	BCB23189.1 tail protein (U) [Burkholderia phage FLC5]	BCB23189.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BDD79942.1	BDD79942.1 hypothetical protein [Burkholderia phage FLC10]	BDD79942.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UYL85531.1	UYL85531.1 tail protein [Acidovorax phage Alfacinha1]	UYL85531.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UYL85430.1	UYL85430.1 tail protein [Acidovorax phage Alfacinha3]	UYL85430.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BAF52408.1	BAF52408.1 bacteriophage gpU [Ralstonia phage RSA1]	BAF52408.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AZF87868.1	AZF87868.1 tail protein [Pseudomonas phage Dobby]	AZF87868.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BAA36254.1	BAA36254.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36254.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WWQ72111.1	WWQ72111.1 tail protein [Pseudomonas phage Sirocco]	WWQ72111.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBI84135.1	QBI84135.1 tail protein [Pseudomonas phage vB_Pae_BR319a]	QBI84135.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AVP40024.1	AVP40024.1 tail protein [Ralstonia phage RsoM1USA]	AVP40024.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BAP28134.1	BAP28134.1 hypothetical protein [Ralstonia phage RSY1]	BAP28134.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UZV40230.1	UZV40230.1 tail protein [Acidovorax phage Acica]	UZV40230.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AFJ75501.1	AFJ75501.1 phage tail protein [Stenotrophomonas phage Smp131]	AFJ75501.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AKA61156.1	AKA61156.1 Putative P2 GpU family protein [Burkholderia phage AP3]	AKA61156.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNI73754.1	UNI73754.1 putative tail protein [Klebsiella phage KP12]	UNI73754.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ARB15707.1	ARB15707.1 tail protein [Klebsiella phage 4LV2017]	ARB15707.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAH1234727.1	CAH1234727.1 tail assembly protein [Escherichia phage Cartapus]	CAH1234727.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP07958.1	QBP07958.1 tail protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07958.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WPJ21711.1	WPJ21711.1 tail protein [Bacillus phage vB_BpuM-ZY1]	WPJ21711.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QPB09425.1	QPB09425.1 tail protein [Burkholderia phage Mana]	QPB09425.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27444.1	QBP27444.1 putative tail protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27444.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP07798.1	QBP07798.1 tail protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07798.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27856.1	QBP27856.1 tail protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27856.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP08110.1	QBP08110.1 tail protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08110.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27683.1	QBP27683.1 tail protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27683.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27953.1	QBP27953.1 tail protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27953.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADP02261.1	ADP02261.1 gp14 [Burkholderia phage KS5]	ADP02261.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	USM11636.1	USM11636.1 tail protein [Burkholderia phage Carl1]	USM11636.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AQT27309.1	AQT27309.1 tail protein [Salmonella phage SEN8]	AQT27309.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADQ92419.1	ADQ92419.1 tail protein [Salmonella phage RE2010]	ADQ92419.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNA05765.1	UNA05765.1 tail protein [Yersinia phage vB_YenM_42.18]	UNA05765.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AIZ95152.1	AIZ95152.1 tail protein [Escherichia phage P88]	AIZ95152.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QYW06295.1	QYW06295.1 tail assembly protein [Shewanella phage vB_SspM_M16-3]	QYW06295.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27599.1	QBP27599.1 tail protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27599.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP08020.1	QBP08020.1 tail protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08020.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27748.1	QBP27748.1 tail protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27748.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBP27901.1	QBP27901.1 tail protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27901.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBQ71571.1	QBQ71571.1 tail protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71571.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QBQ72019.1	QBQ72019.1 tail protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72019.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WOZ57123.1	WOZ57123.1 tail protein [Citrobacter phage Shae_phiSM]	WOZ57123.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD40185.1	VUD40185.1 putative tail protein [Xuanwuvirus P884B11]	VUD40185.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNA05940.1	UNA05940.1 tail protein [Yersinia phage vB_YenM_56.17]	UNA05940.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNA05992.1	UNA05992.1 tail protein [Yersinia phage vB_YenM_201.16]	UNA05992.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UNA05886.1	UNA05886.1 tail protein [Yersinia phage vB_YenM_06.16-2]	UNA05886.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UGC97259.1	UGC97259.1 tail protein [Aeromonas phage vB_AsaM_LPM4]	UGC97259.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ARB15656.1	ARB15656.1 tail protein [Klebsiella phage 3LV2017]	ARB15656.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC09640.1	URC09640.1 tail protein [Escherichia phage vB_EcoM-569R9]	URC09640.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD38033.1	VUD38033.1 Phage tail protein [Peduovirus P24B2]	VUD38033.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AKH49401.1	AKH49401.1 tape measure [Escherichia phage pro483]	AKH49401.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAP04463.1	AAP04463.1 gpU [Yersinia phage L-413C]	AAP04463.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QDJ98445.1	QDJ98445.1 hypothetical protein LLFFHNDI_00018 [Escherichia phage vB_EcoM-12474II]	QDJ98445.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QDJ98577.1	QDJ98577.1 hypothetical protein OMJLAAIH_00018 [Escherichia phage vB_EcoM-12474V]	QDJ98577.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QDJ98533.1	QDJ98533.1 hypothetical protein PBINGOGM_00018 [Escherichia phage vB_EcoM-12474IV]	QDJ98533.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QDJ98492.1	QDJ98492.1 hypothetical protein BBAMJIOM_00021 [Escherichia phage vB_EcoM-12474III]	QDJ98492.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAG9593861.1	CAG9593861.1 hypothetical protein P2SIDE7_00015 [Peduovirus P2]	CAG9593861.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QDP43525.1	QDP43525.1 tail protein [Bacteriophage R18C]	QDP43525.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UPI11524.1	UPI11524.1 hypothetical protein BFNKNBEH_00034 [Yersinia phage VB-YPM-18]	UPI11524.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WOZ56106.1	WOZ56106.1 hypothetical protein B476A_00026 [Yersinia phage vB_YpM_476A]	WOZ56106.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QKE55514.1	QKE55514.1 hypothetical protein vBYpM22_00029 [Yersinia phage vB_YpM_22]	QKE55514.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WOZ56146.1	WOZ56146.1 hypothetical protein B476B_00026 [Yersinia phage vB_YpM_476B]	WOZ56146.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QKE55650.1	QKE55650.1 hypothetical protein vBYpM50_00029 [Yersinia phage vB_YpM_50]	QKE55650.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD39055.1	VUD39055.1 Phage-related tail protein [Peduovirus P24A7b]	VUD39055.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AKH49318.1	AKH49318.1 tail protein [Escherichia phage pro147]	AKH49318.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WOZ56017.1	WOZ56017.1 hypothetical protein B115_00029 [Yersinia phage vB_YpM_115]	WOZ56017.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAG9593832.1	CAG9593832.1 hypothetical protein P2DC1_00028 [Peduovirus P2]	CAG9593832.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QIW90040.1	QIW90040.1 hypothetical protein [Yersinia phage P37]	QIW90040.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WOZ56063.1	WOZ56063.1 hypothetical protein B117_00029 [Yersinia phage vB_YpM_117]	WOZ56063.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WFG40951.1	WFG40951.1 tail protein [Salmonella phage MET_P1_103_31]	WFG40951.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD37989.1	VUD37989.1 Phage-related tail protein [Peduovirus P22H1]	VUD37989.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URP83687.1	URP83687.1 tail protein [Escherichia phage S164]	URP83687.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAD03294.1	AAD03294.1 gpU [Bacteriophage P2]	AAD03294.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAH0786501.1	CAH0786501.1 hypothetical protein P2AC1_00016 [Escherichia phage P2_AC1]	CAH0786501.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UPI11476.1	UPI11476.1 hypothetical protein COILCCMC_00028 [Yersinia phage VB-YPM-4]	UPI11476.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QKE55607.1	QKE55607.1 hypothetical protein vBYpM46_00027 [Yersinia phage vB_YpM_46]	QKE55607.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AGG36545.1	AGG36545.1 gpU [Escherichia phage P2]	AGG36545.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ULG00705.1	ULG00705.1 tail protein [Escherichia phage D8]	ULG00705.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD38925.1	VUD38925.1 Phage-related tail protein [Peduovirus P24E6b]	VUD38925.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ULG01165.1	ULG01165.1 tail protein [Escherichia phage 12W]	ULG01165.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ULG01109.1	ULG01109.1 tail protein [Escherichia phage 10W]	ULG01109.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ULG00891.1	ULG00891.1 tail protein [Escherichia phage 11W]	ULG00891.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD39564.1	VUD39564.1 Phage tail protein [Peduovirus P24C9]	VUD39564.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ULG01007.1	ULG01007.1 tail protein [Escherichia phage 9W]	ULG01007.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	VUD37945.1	VUD37945.1 Phage tail protein [Peduovirus P22H4]	VUD37945.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	API82960.1	API82960.1 Phage P2 GpU [Salmonella phage STYP1]	API82960.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAN28245.1	AAN28245.1 gpU [Escherichia phage Wphi]	AAN28245.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAG9593778.1	CAG9593778.1 hypothetical protein P2SIAC10_00017 [Peduovirus P2]	CAG9593778.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QXF95294.1	QXF95294.1 tail protein [Yersinia phage HQ103]	QXF95294.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QPB08638.1	QPB08638.1 baseplate protein [Burkholderia phage Mica]	QPB08638.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UKL54268.1	UKL54268.1 tail protein [Yersinia phage vB_YenM_31.17]	UKL54268.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AGX84587.1	AGX84587.1 tail protein [Enterobacteria phage fiAA91-ss]	AGX84587.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AYD79768.1	AYD79768.1 hypothetical protein OGLPLLMI_00002 [Enterobacter phage phiT5282H]	AYD79768.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	USZ80553.1	USZ80553.1 tail protein [Serratia phage MQ-4]	USZ80553.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ANN86132.1	ANN86132.1 putative tail protein [Enterobacter phage Arya]	ANN86132.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AXF38230.1	AXF38230.1 putative tail protein [Ralstonia phage phiRSP]	AXF38230.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC09825.1	URC09825.1 tail protein [Escherichia phage vB_EcoM-720R8]	URC09825.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADE87914.1	ADE87914.1 putative phage tail protein [Escherichia phage vB_EcoM_ECO1230-10]	ADE87914.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QJB21764.1	QJB21764.1 tail protein [Xanthomonas phage FoX1]	QJB21764.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ARM70440.1	ARM70440.1 putative tail protein [Escherichia phage vB_EcoM_ECOO78]	ARM70440.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WNL50861.1	WNL50861.1 tail protein [Xanthomonas phage Murka]	WNL50861.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AIM50575.1	AIM50575.1 tail protein [Escherichia phage vB_EcoM-ep3]	AIM50575.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URE76596.1	URE76596.1 tail protein [Escherichia phage vB_EcoM-613R3]	URE76596.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QIG65613.1	QIG65613.1 hypothetical protein [Salmonella phage PT1]	QIG65613.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	APC62523.1	APC62523.1 tail assembly protein U [Salmonella phage SEN4]	APC62523.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	APC62519.1	APC62519.1 tail assembly protein U [Salmonella phage SEN5]	APC62519.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QOE32756.1	QOE32756.1 baseplate protein [Achromobacter phage Mano]	QOE32756.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADX32425.1	ADX32425.1 hypothetical protein [Erwinia phage ENT90]	ADX32425.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WYC18464.1	WYC18464.1 tail - tube initiator [Yersinia phage vB_YpM_MHG38]	WYC18464.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WXX18217.1	WXX18217.1 tail protein [Yersinia phage GCS667]	WXX18217.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WYC18422.1	WYC18422.1 tail - tube initiator [Yersinia phage vB_YpM_MDG45]	WYC18422.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ALF02263.1	ALF02263.1 tail protein [Salmonella phage SEN1]	ALF02263.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAC34171.1	AAC34171.1 F protein [Escherichia phage 186]	AAC34171.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QMP19186.1	QMP19186.1 tail protein [Pseudomonas phage Persinger]	QMP19186.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAN08387.1	AAN08387.1 gp25 [Salmonella phage PSP3]	AAN08387.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AGF88437.1	AGF88437.1 hypothetical protein SP004_00120 [Salmonella phage FSLSP004]	AGF88437.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WYC18395.1	WYC18395.1 tail protein [Yersinia phage vB_YpM_MDG94-186]	WYC18395.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QEI25365.1	QEI25365.1 tail assembly protein [Salmonella phage SI22]	QEI25365.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QEI25410.1	QEI25410.1 tail assembly protein [Salmonella phage SW9]	QEI25410.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QYC52683.1	QYC52683.1 tail assembly protein [Salmonella phage BIS20]	QYC52683.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AFU62904.1	AFU62904.1 phage tail formation protein U [Acidithiobacillus phage AcaML1]	AFU62904.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WID42139.1	WID42139.1 tail protein [Pseudomonas phage ZRG1]	WID42139.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WPJ53092.1	WPJ53092.1 hypothetical protein RCIP0057_00019 [Klebsiella phage RCIP0057]	WPJ53092.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QPI18567.1	QPI18567.1 tail protein [Burkholderia phage phiE094]	QPI18567.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QJB21845.1	QJB21845.1 tail protein [Xanthomonas phage FoX2]	QJB21845.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QEA09549.1	QEA09549.1 tail protein [Wolbachia phage WO]	QEA09549.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QHJ75364.1	QHJ75364.1 tail protein [Wolbachia phage WO]	QHJ75364.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UTC25927.1	UTC25927.1 tail protein [Salmonella phage vB_Sal_PHB48]	UTC25927.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QJB22004.1	QJB22004.1 tail protein [Xanthomonas phage FoX5]	QJB22004.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QWY14244.1	QWY14244.1 tail protein [Xanthomonas phage M29]	QWY14244.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AJA72952.1	AJA72952.1 tail protein U [Mannheimia phage vB_MhM_587AP1]	AJA72952.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AJA73080.1	AJA73080.1 tail protein U [Mannheimia phage vB_MhM_1127AP1]	AJA73080.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABD90630.1	ABD90630.1 tail protein U [Mannheimia phage phiMhaA1-BAA410]	ABD90630.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABD90580.1	ABD90580.1 tail protein U [Mannheimia phage PHL101]	ABD90580.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AJA73133.1	AJA73133.1 tail protein U [Mannheimia phage vB_MhM_2256AP1]	AJA73133.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AJA72901.1	AJA72901.1 tail protein U [Mannheimia phage vB_MhM_535AP1]	AJA72901.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AFL46477.1	AFL46477.1 phage tail protein U [Mannheimia phage vB_MhM_1152AP]	AFL46477.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QJB21926.1	QJB21926.1 tail protein [Xanthomonas phage FoX3]	QJB21926.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ASD51158.1	ASD51158.1 tail protein [Erwinia phage EtG]	ASD51158.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	CAX65007.1	CAX65007.1 gp26 protein [Vibrio phage VP585]	CAX65007.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AFV81366.1	AFV81366.1 putative tail protein [Vibrio phage vB_VpaM_MAR]	AFV81366.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WNY35844.1	WNY35844.1 tail protein [Vibrio phage Vb_VaM_Valp1]	WNY35844.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC10606.1	URC10606.1 tail protein [Escherichia phage vB_EcoM-705R4]	URC10606.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AAN12343.1	AAN12343.1 ORF44 [Vibrio phage VHML]	AAN12343.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC09734.1	URC09734.1 tail protein [Escherichia phage vB_EcoM-720R5]	URC09734.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC09430.1	URC09430.1 tail protein [Escherichia phage vB_EcoM-569R10]	URC09430.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	URC10671.1	URC10671.1 tail protein [Escherichia phage vB_EcoM-783R5]	URC10671.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QKN87920.1	QKN87920.1 tail tube initiation protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87920.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AOT25334.1	AOT25334.1 tail protein [Ochrobactrum phage POA1180]	AOT25334.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	UOL51118.1	UOL51118.1 tail protein [Citrobacter phage Chris1]	UOL51118.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QHJ75476.1	QHJ75476.1 tail protein U [Wolbachia phage WO]	QHJ75476.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QHJ75589.1	QHJ75589.1 tail protein U [Wolbachia phage WO]	QHJ75589.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BAO20622.1	BAO20622.1 putative tail protein GpU [Pseudomonas phage PPpW-3]	BAO20622.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QXN68738.1	QXN68738.1 tail protein [Hafnia phage yong2]	QXN68738.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ADW80172.1	ADW80172.1 hypothetical protein [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80172.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	AOA49556.1	AOA49556.1 hypothetical protein gwv_1110 [Wolbachia phage WO]	AOA49556.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WDE69803.1	WDE69803.1 tail protein [Vibrio phage VPHZ6]	WDE69803.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QXF95212.1	QXF95212.1 tail protein U [Wolbachia phage WO]	QXF95212.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WEV89357.1	WEV89357.1 hypothetical protein H10PHJ05_56 [Aeromonas phage HJ05]	WEV89357.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABY90392.1	ABY90392.1 putative tail protein [Halomonas phage phiHAP-1]	ABY90392.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABM73396.1	ABM73396.1 phage protein U-like [Vibrio phage VP882]	ABM73396.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ABY90391.1	ABY90391.1 putative tail tape measure [Halomonas phage phiHAP-1]	ABY90391.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	BAP94482.1	BAP94482.1 tail assembly protein [Aurantimonas phage AmM-1]	BAP94482.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WKW83126.1	WKW83126.1 tail protein [Campylobacter phage CAM-P21]	WKW83126.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	ARQ95327.1	ARQ95327.1 tail protein [Bradyrhizobium phage BDU-MI-1]	ARQ95327.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WWY66204.1	WWY66204.1 putative tail protein [Burkholderia phage vB_HM795]	WWY66204.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	QXM18791.1	QXM18791.1 tail protein [Vibrio phage ST2-2pr]	QXM18791.1	0
+c72c0158-29e2-4503-acc1-8705743c3cae	WNA15514.1	WNA15514.1 hypothetical protein [Acinetobacter phage HFM1]	WNA15514.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNY41688.1	UNY41688.1 baseplate hub protein [Burkholderia phage Musica]	UNY41688.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNY41747.1	UNY41747.1 baseplate hub protein [Burkholderia phage Milagro]	UNY41747.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNY41804.1	UNY41804.1 baseplate hub protein [Burkholderia phage Menos]	UNY41804.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNY41860.1	UNY41860.1 baseplate hub protein [Burkholderia phage Momento]	UNY41860.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADP02308.1	ADP02308.1 gp15 [Burkholderia phage KL3]	ADP02308.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAZ72619.1	AAZ72619.1 bacteriophage late control gene D protein [Burkholderia phage phiE52237]	AAZ72619.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UPI15587.1	UPI15587.1 tail formation protein [Burkholderia phage PhiBP82.3]	UPI15587.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AIP84296.1	AIP84296.1 phage late control protein [Burkholderia phage BEK]	AIP84296.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AFV51422.1	AFV51422.1 D tail protein [Burkholderia phage phiX216]	AFV51422.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QWY84974.1	QWY84974.1 tail formation protein [Burkholderia phage PK23]	QWY84974.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABO60787.1	ABO60787.1 gp27, putative bacteriophage late control gene D protein [Burkholderia phage phiE12-2]	ABO60787.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WWY66170.1	WWY66170.1 tail protein [Burkholderia phage vB_HM387]	WWY66170.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QPI18568.1	QPI18568.1 tail formation protein [Burkholderia phage phiE094]	QPI18568.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABO60728.1	ABO60728.1 gp24, fels-2 prophage protein [Burkholderia phage phiE202]	ABO60728.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UKM53793.1	UKM53793.1 tail formation protein [Burkholderia phage PhiBP82.2]	UKM53793.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BCB23188.1	BCB23188.1 tail protein (D) [Burkholderia phage FLC5]	BCB23188.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AGK86802.1	AGK86802.1 phage tail protein D [Burkholderia phage ST79]	AGK86802.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BDD79943.1	BDD79943.1 hypothetical protein [Burkholderia phage FLC10]	BDD79943.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADP02355.1	ADP02355.1 gp10 [Burkholderia phage KS14]	ADP02355.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WPJ21712.1	WPJ21712.1 late control D family protein [Bacillus phage vB_BpuM-ZY1]	WPJ21712.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QYW06294.1	QYW06294.1 late control D family protein [Shewanella phage vB_SspM_M16-3]	QYW06294.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UGC97258.1	UGC97258.1 tail formation protein [Aeromonas phage vB_AsaM_LPM4]	UGC97258.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UYL85532.1	UYL85532.1 late control D family protein [Acidovorax phage Alfacinha1]	UYL85532.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UYL85431.1	UYL85431.1 late control D family protein [Acidovorax phage Alfacinha3]	UYL85431.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADP02260.1	ADP02260.1 gp13 [Burkholderia phage KS5]	ADP02260.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	USM11637.1	USM11637.1 baseplate hub protein [Burkholderia phage Carl1]	USM11637.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QPB09426.1	QPB09426.1 baseplate hub protein [Burkholderia phage Mana]	QPB09426.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBQ72020.1	QBQ72020.1 late control D family protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ72020.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AKA61157.1	AKA61157.1 putative late control geneD protein [Burkholderia phage AP3]	AKA61157.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAF52409.1	BAF52409.1 bacteriophage gpD [Ralstonia phage RSA1]	BAF52409.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27598.1	QBP27598.1 hypothetical protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27598.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27900.1	QBP27900.1 late control D family protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27900.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP08019.1	QBP08019.1 late control D family protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08019.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27747.1	QBP27747.1 late control D family protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27747.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAH1234730.1	CAH1234730.1 Probable baseplate hub protein D (GPD) [Escherichia phage Cartapus]	CAH1234730.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNI73753.1	UNI73753.1 putative regulator of late gene expression [Klebsiella phage KP12]	UNI73753.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UZV40231.1	UZV40231.1 late control D family protein [Acidovorax phage Acica]	UZV40231.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27445.1	QBP27445.1 late control D family protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27445.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP07797.1	QBP07797.1 late control D family protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07797.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27855.1	QBP27855.1 late control D family protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27855.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP08111.1	QBP08111.1 late control protein D [Klebsiella phage ST11-OXA245phi3.1]	QBP08111.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27684.1	QBP27684.1 late control D family protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27684.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP27952.1	QBP27952.1 late control D family protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27952.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAP28135.1	BAP28135.1 hypothetical protein [Ralstonia phage RSY1]	BAP28135.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ARB15708.1	ARB15708.1 tail protein [Klebsiella phage 4LV2017]	ARB15708.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AQT27310.1	AQT27310.1 late control protein D [Salmonella phage SEN8]	AQT27310.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAA36255.1	BAA36255.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36255.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WPJ53091.1	WPJ53091.1 hypothetical protein RCIP0057_00018 [Klebsiella phage RCIP0057]	WPJ53091.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UTC25926.1	UTC25926.1 tail formation protein [Salmonella phage vB_Sal_PHB48]	UTC25926.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QYC52684.1	QYC52684.1 type VI secretion system Vgr family protein [Salmonella phage BIS20]	QYC52684.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AVP40025.1	AVP40025.1 tail protein [Ralstonia phage RsoM1USA]	AVP40025.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WYC18465.1	WYC18465.1 baseplate hub protein [Yersinia phage vB_YpM_MHG38]	WYC18465.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WYC18396.1	WYC18396.1 baseplate hub protein [Yersinia phage vB_YpM_MDG94-186]	WYC18396.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ASD51157.1	ASD51157.1 tail protein [Erwinia phage EtG]	ASD51157.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WYC18423.1	WYC18423.1 baseplate hub protein [Yersinia phage vB_YpM_MDG45]	WYC18423.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WXX18216.1	WXX18216.1 D protein [Yersinia phage GCS667]	WXX18216.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AGF88438.1	AGF88438.1 tail protein [Salmonella phage FSLSP004]	AGF88438.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AZF87869.1	AZF87869.1 late control D family protein [Pseudomonas phage Dobby]	AZF87869.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAC34172.1	AAC34172.1 D protein [Escherichia phage 186]	AAC34172.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URE76595.1	URE76595.1 tail formation protein [Escherichia phage vB_EcoM-613R3]	URE76595.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAN08388.1	AAN08388.1 gp26 [Salmonella phage PSP3]	AAN08388.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADQ92420.1	ADQ92420.1 gene D protein [Salmonella phage RE2010]	ADQ92420.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBI84136.1	QBI84136.1 gene D protein [Pseudomonas phage vB_Pae_BR319a]	QBI84136.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNA05766.1	UNA05766.1 tail formation protein [Yersinia phage vB_YenM_42.18]	UNA05766.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNA05887.1	UNA05887.1 tail formation protein [Yersinia phage vB_YenM_06.16-2]	UNA05887.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNA05941.1	UNA05941.1 tail formation protein [Yersinia phage vB_YenM_56.17]	UNA05941.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNA05993.1	UNA05993.1 tail formation protein [Yersinia phage vB_YenM_201.16]	UNA05993.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WWQ72112.1	WWQ72112.1 tail formation protein [Pseudomonas phage Sirocco]	WWQ72112.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD38034.1	VUD38034.1 Gene D protein [Peduovirus P24B2]	VUD38034.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ALF02264.1	ALF02264.1 late control D protein [Salmonella phage SEN1]	ALF02264.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAG9593860.1	CAG9593860.1 hypothetical protein P2SIDE7_00014 [Peduovirus P2]	CAG9593860.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QDJ98444.1	QDJ98444.1 hypothetical protein LLFFHNDI_00017 [Escherichia phage vB_EcoM-12474II]	QDJ98444.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QDJ98576.1	QDJ98576.1 hypothetical protein OMJLAAIH_00017 [Escherichia phage vB_EcoM-12474V]	QDJ98576.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QDJ98532.1	QDJ98532.1 hypothetical protein PBINGOGM_00017 [Escherichia phage vB_EcoM-12474IV]	QDJ98532.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QDJ98491.1	QDJ98491.1 hypothetical protein BBAMJIOM_00020 [Escherichia phage vB_EcoM-12474III]	QDJ98491.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09824.1	URC09824.1 tail formation protein [Escherichia phage vB_EcoM-720R8]	URC09824.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WFG40950.1	WFG40950.1 tail protein [Salmonella phage MET_P1_103_31]	WFG40950.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QEI25366.1	QEI25366.1 late control D family protein [Salmonella phage SI22]	QEI25366.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QEI25411.1	QEI25411.1 late control D family protein [Salmonella phage SW9]	QEI25411.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AKH49317.1	AKH49317.1 gene D protein [Escherichia phage pro147]	AKH49317.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AFL46478.1	AFL46478.1 phage tail protein D [Mannheimia phage vB_MhM_1152AP]	AFL46478.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAD03295.1	AAD03295.1 gpD [Bacteriophage P2]	AAD03295.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AGX84588.1	AGX84588.1 putative phage control protein D [Enterobacteria phage fiAA91-ss]	AGX84588.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AKH49402.1	AKH49402.1 gene D protein [Escherichia phage pro483]	AKH49402.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ULG01108.1	ULG01108.1 tail formation protein [Escherichia phage 10W]	ULG01108.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ULG00892.1	ULG00892.1 tail formation protein [Escherichia phage 11W]	ULG00892.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD39568.1	VUD39568.1 Gene D protein [Peduovirus P24C9]	VUD39568.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAH0786500.1	CAH0786500.1 hypothetical protein P2AC1_00015 [Escherichia phage P2_AC1]	CAH0786500.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	API82961.1	API82961.1 Phage late control gene D protein (GPD) [Salmonella phage STYP1]	API82961.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD37990.1	VUD37990.1 Gene D protein [Peduovirus P22H1]	VUD37990.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UPI11477.1	UPI11477.1 hypothetical protein COILCCMC_00029 [Yersinia phage VB-YPM-4]	UPI11477.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QKE55608.1	QKE55608.1 hypothetical protein vBYpM46_00028 [Yersinia phage vB_YpM_46]	QKE55608.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QDP43526.1	QDP43526.1 gene D protein [Bacteriophage R18C]	QDP43526.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UPI11525.1	UPI11525.1 hypothetical protein BFNKNBEH_00035 [Yersinia phage VB-YPM-18]	UPI11525.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ56107.1	WOZ56107.1 hypothetical protein B476A_00027 [Yersinia phage vB_YpM_476A]	WOZ56107.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QKE55515.1	QKE55515.1 hypothetical protein vBYpM22_00030 [Yersinia phage vB_YpM_22]	QKE55515.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ56147.1	WOZ56147.1 hypothetical protein B476B_00027 [Yersinia phage vB_YpM_476B]	WOZ56147.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QKE55651.1	QKE55651.1 hypothetical protein vBYpM50_00030 [Yersinia phage vB_YpM_50]	QKE55651.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ARB15661.1	ARB15661.1 late control D protein [Klebsiella phage 3LV2017]	ARB15661.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ULG01008.1	ULG01008.1 tail formation protein [Escherichia phage 9W]	ULG01008.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD37946.1	VUD37946.1 Gene D protein [Peduovirus P22H4]	VUD37946.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ56018.1	WOZ56018.1 hypothetical protein B115_00030 [Yersinia phage vB_YpM_115]	WOZ56018.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ56064.1	WOZ56064.1 hypothetical protein B117_00030 [Yersinia phage vB_YpM_117]	WOZ56064.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QXF95295.1	QXF95295.1 tail formation protein [Yersinia phage HQ103]	QXF95295.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URP83688.1	URP83688.1 late control D family protein/ baseplate hub protein [Escherichia phage S164]	URP83688.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UKL54269.1	UKL54269.1 tail formation protein [Yersinia phage vB_YenM_31.17]	UKL54269.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABD90631.1	ABD90631.1 tail protein D [Mannheimia phage phiMhaA1-BAA410]	ABD90631.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABD90581.1	ABD90581.1 tail protein D [Mannheimia phage PHL101]	ABD90581.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AJA73134.1	AJA73134.1 tail protein D [Mannheimia phage vB_MhM_2256AP1]	AJA73134.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AJA72902.1	AJA72902.1 tail protein D [Mannheimia phage vB_MhM_535AP1]	AJA72902.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAN28246.1	AAN28246.1 gpD [Escherichia phage Wphi]	AAN28246.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAP04464.1	AAP04464.1 gpD [Yersinia phage L-413C]	AAP04464.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAG9593833.1	CAG9593833.1 hypothetical protein P2DC1_00029 [Peduovirus P2]	CAG9593833.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QIW90039.1	QIW90039.1 late control protein D [Yersinia phage P37]	QIW90039.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AGG36546.1	AGG36546.1 gene D protein [Escherichia phage P2]	AGG36546.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD39057.1	VUD39057.1 Gene D protein [Peduovirus P24A7b]	VUD39057.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ULG00706.1	ULG00706.1 tail formation protein [Escherichia phage D8]	ULG00706.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD38928.1	VUD38928.1 Gene D protein [Peduovirus P24E6b]	VUD38928.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ULG01166.1	ULG01166.1 tail formation protein [Escherichia phage 12W]	ULG01166.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBQ71572.1	QBQ71572.1 late control D family protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71572.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ALF02318.1	ALF02318.1 late control D protein [Salmonella phage SEN4]	ALF02318.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ALF02367.1	ALF02367.1 late control D protein [Salmonella phage SEN5]	ALF02367.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBP07963.1	QBP07963.1 late control D family protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07963.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AJA72953.1	AJA72953.1 tail protein D [Mannheimia phage vB_MhM_587AP1]	AJA72953.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AJA73081.1	AJA73081.1 tail protein D [Mannheimia phage vB_MhM_1127AP1]	AJA73081.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AIZ95159.1	AIZ95159.1 gene D protein [Escherichia phage P88]	AIZ95159.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAG9593777.1	CAG9593777.1 hypothetical protein P2SIAC10_00016 [Peduovirus P2]	CAG9593777.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	VUD40191.1	VUD40191.1 Gene D protein [Xuanwuvirus P884B11]	VUD40191.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAH15155.1	BAH15155.1 hypothetical protein [Serratia phage KSP20]	BAH15155.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ57118.1	WOZ57118.1 ogr/Delta-like zinc finger family protein [Citrobacter phage Shae_phiSM]	WOZ57118.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AYD79773.1	AYD79773.1 hypothetical protein OGLPLLMI_00007 [Enterobacter phage phiT5282H]	AYD79773.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AFJ75502.1	AFJ75502.1 phage late gene control protein [Stenotrophomonas phage Smp131]	AFJ75502.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	CAX65009.1	CAX65009.1 gp28 protein [Vibrio phage VP585]	CAX65009.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AFV81368.1	AFV81368.1 putative tail protein [Vibrio phage vB_VpaM_MAR]	AFV81368.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAO20624.1	BAO20624.1 putative transcriptional regulator [Pseudomonas phage PPpW-3]	BAO20624.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAN12345.1	AAN12345.1 ORF46 [Vibrio phage VHML]	AAN12345.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QPB08640.1	QPB08640.1 baseplate hub protein [Burkholderia phage Mica]	QPB08640.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	USZ80555.1	USZ80555.1 putative transcriptional regulator [Serratia phage MQ-4]	USZ80555.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ARM70438.1	ARM70438.1 putative transcriptional regulator [Escherichia phage vB_EcoM_ECOO78]	ARM70438.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AIM50577.1	AIM50577.1 transcriptional regulator [Escherichia phage vB_EcoM-ep3]	AIM50577.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADE87912.1	ADE87912.1 putative transcriptional regulator [Escherichia phage vB_EcoM_ECO1230-10]	ADE87912.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QMP19188.1	QMP19188.1 transcription regulator [Pseudomonas phage Persinger]	QMP19188.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QJB22006.1	QJB22006.1 gene D protein [Xanthomonas phage FoX5]	QJB22006.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QJB21928.1	QJB21928.1 gene D protein [Xanthomonas phage FoX3]	QJB21928.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WID42063.1	WID42063.1 late control protein D [Pseudomonas phage ZRG1]	WID42063.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QJB21847.1	QJB21847.1 gene D protein [Xanthomonas phage FoX2]	QJB21847.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QEA09547.1	QEA09547.1 gene D protein [Wolbachia phage WO]	QEA09547.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QHJ75366.1	QHJ75366.1 gene D protein [Wolbachia phage WO]	QHJ75366.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ANN86134.1	ANN86134.1 putative transcriptional regulator [Enterobacter phage Arya]	ANN86134.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UFZ21860.1	UFZ21860.1 tail protein [Xanthomonas phage M29]	UFZ21860.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QKN87922.1	QKN87922.1 baseplate protein [Acinetobacter phage vB_AbaP_Alexa]	QKN87922.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QOE32758.1	QOE32758.1 baseplate hub protein [Achromobacter phage Mano]	QOE32758.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QIG65615.1	QIG65615.1 hypothetical protein [Salmonella phage PT1]	QIG65615.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AXF38232.1	AXF38232.1 putative transcriptional regulator [Ralstonia phage phiRSP]	AXF38232.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADW80174.1	ADW80174.1 phage late control D protein [Wolbachia endosymbiont wVitA of Nasonia vitripennis phage WOVitA1]	ADW80174.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AOA49531.1	AOA49531.1 late control D protein [Wolbachia phage WO]	AOA49531.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	APU00426.1	APU00426.1 hypothetical protein [Aeromonas phage 3]	APU00426.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	APU01178.1	APU01178.1 hypothetical protein [Aeromonas phage 32]	APU01178.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AWH15037.1	AWH15037.1 hypothetical protein [Aeromonas phage 85AhydR10PP]	AWH15037.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AWH14539.1	AWH14539.1 hypothetical protein [Aeromonas phage 13AhydR10PP]	AWH14539.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AWH15337.1	AWH15337.1 hypothetical protein [Aeromonas phage 14AhydR10PP]	AWH15337.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WDE69805.1	WDE69805.1 contractile injection system protein, VgrG/Pvc8 family [Vibrio phage VPHZ6]	WDE69805.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	APU00846.1	APU00846.1 hypothetical protein [Aeromonas phage 59.1]	APU00846.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QJB21766.1	QJB21766.1 gene D protein [Xanthomonas phage FoX1]	QJB21766.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AFU62905.1	AFU62905.1 phage tail protein X [Acidithiobacillus phage AcaML1]	AFU62905.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	APU00762.1	APU00762.1 hypothetical protein [Aeromonas phage Asp37]	APU00762.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WWY66206.1	WWY66206.1 putative tail protein [Burkholderia phage vB_HM795]	WWY66206.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WNL50863.1	WNL50863.1 tail protein [Xanthomonas phage Murka]	WNL50863.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QXF95210.1	QXF95210.1 tail formation protein D [Wolbachia phage WO]	QXF95210.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WNY35842.1	WNY35842.1 tail protein [Vibrio phage Vb_VaM_Valp1]	WNY35842.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QIZ02639.1	QIZ02639.1 late control gene D protein [Aeromonas phage AhyVDH1]	QIZ02639.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09642.1	URC09642.1 tail formation protein [Escherichia phage vB_EcoM-569R9]	URC09642.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QHJ75474.1	QHJ75474.1 gene D protein [Wolbachia phage WO]	QHJ75474.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QHJ75587.1	QHJ75587.1 gene D protein [Wolbachia phage WO]	QHJ75587.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABY90393.1	ABY90393.1 putative tail protein [Halomonas phage phiHAP-1]	ABY90393.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QXN68740.1	QXN68740.1 tail protein [Hafnia phage yong2]	QXN68740.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AZV00478.1	AZV00478.1 tail protein D [Paracoccus phage vB_PyeM_Pyei1]	AZV00478.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ANZ52219.1	ANZ52219.1 putative late control protein GpD [Aeromonas phage Ahp2]	ANZ52219.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09641.1	URC09641.1 tail formation protein [Escherichia phage vB_EcoM-569R9]	URC09641.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UOL51120.1	UOL51120.1 tail formation protein D [Citrobacter phage Chris1]	UOL51120.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WWQ71684.1	WWQ71684.1 contractile tail injection system protein [Pseudomonas phage Bise]	WWQ71684.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09732.1	URC09732.1 tail formation protein D [Escherichia phage vB_EcoM-720R5]	URC09732.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AOT25336.1	AOT25336.1 hypothetical protein POA1180_28 [Ochrobactrum phage POA1180]	AOT25336.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABM73399.1	ABM73399.1 phage protein D-like [Vibrio phage VP882]	ABM73399.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09427.1	URC09427.1 tail formation protein D [Escherichia phage vB_EcoM-569R10]	URC09427.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC10603.1	URC10603.1 tail formation protein D [Escherichia phage vB_EcoM-705R4]	URC10603.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC10668.1	URC10668.1 tail formation protein D [Escherichia phage vB_EcoM-783R5]	URC10668.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WEV89359.1	WEV89359.1 hypothetical protein H10PHJ05_58 [Aeromonas phage HJ05]	WEV89359.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AWY03259.1	AWY03259.1 tail protein [Pasteurella phage AFS-2018a]	AWY03259.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ALN97545.1	ALN97545.1 tail protein [Aeromonas phage phiARM81ld]	ALN97545.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QXM18793.1	QXM18793.1 tail protein [Vibrio phage ST2-2pr]	QXM18793.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WAK43881.1	WAK43881.1 tail baseplate hub [Sulfurimonas phage SNW-1]	WAK43881.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AAS47886.1	AAS47886.1 gp47 [Burkholderia phage BcepMu]	AAS47886.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ABO60697.1	ABO60697.1 gp21 [Burkholderia phage phiE255]	ABO60697.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QCW19679.1	QCW19679.1 hypothetical protein [Vibrio phage Va_90-11-286_p16]	QCW19679.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QCW19938.1	QCW19938.1 hypothetical protein [Vibrio phage Va_PF430-3_p42]	QCW19938.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNI73666.1	UNI73666.1 gene D protein [Klebsiella phage KP12]	UNI73666.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ADX32454.1	ADX32454.1 late control protein D protein [Erwinia phage ENT90]	ADX32454.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	ARQ95325.1	ARQ95325.1 protein D [Bradyrhizobium phage BDU-MI-1]	ARQ95325.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AUR88226.1	AUR88226.1 coil containing protein [Vibrio phage 1.111.A._10N.286.45.E6]	AUR88226.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AUR88288.1	AUR88288.1 coil containing protein [Vibrio phage 1.111.B._10N.286.45.E6]	AUR88288.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QVQ56209.1	QVQ56209.1 late control gene D protein [Paenibacillus phage Pd_22F]	QVQ56209.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AGN38712.1	AGN38712.1 hypothetical protein RHYG_00043 [Rhizobium phage RR1-B]	AGN38712.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WKW83124.1	WKW83124.1 tail formation protein [Campylobacter phage CAM-P21]	WKW83124.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ55802.1	WOZ55802.1 hypothetical protein P39_00018 [Yersinia phage vB_YpM_39]	WOZ55802.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URE76659.1	URE76659.1 tail formation protein [Escherichia phage vB_EcoM-473R2]	URE76659.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	URC09219.1	URC09219.1 tail formation protein [Escherichia phage vB_EcoM-613R2]	URC09219.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ55872.1	WOZ55872.1 hypothetical protein P41_00018 [Yersinia phage vB_YpM_41]	WOZ55872.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WOZ55939.1	WOZ55939.1 hypothetical protein P44_00018 [Yersinia phage vB_YpM_44]	WOZ55939.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AUV56468.1	AUV56468.1 tail protein [Faecalibacterium phage FP_Epona]	AUV56468.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AHN84834.1	AHN84834.1 late control D family protein [Vibrio phage phi 2]	AHN84834.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QBJ01022.1	QBJ01022.1 hypothetical protein Rostov7_00128 [Vibrio phage Rostov 7]	QBJ01022.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AIA10325.1	AIA10325.1 late control D family protein [Vibrio phage X29]	AIA10325.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AUV56782.1	AUV56782.1 tail protein [Faecalibacterium phage FP_Toutatis]	AUV56782.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	UNY40532.1	UNY40532.1 baseplate protein [Pararheinheimera phage vB_PsoM_KLER1-1]	UNY40532.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AJK27743.1	AJK27743.1 late control protein [Bacteriophage Lily]	AJK27743.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AYP68507.1	AYP68507.1 tail protein [Exiguobacterium phage vB_EalM-137]	AYP68507.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	WNA15512.1	WNA15512.1 hypothetical protein [Acinetobacter phage HFM1]	WNA15512.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	QHZ54120.1	QHZ54120.1 tail protein [Paenibacillus phage phiERICV]	QHZ54120.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	AKC57546.1	AKC57546.1 late control gene D protein [Fusobacterium phage Funu1]	AKC57546.1	0
+fa572a21-467e-4d91-b5e2-d6cdd8f79c39	BAP94484.1	BAP94484.1 late control protein [Aurantimonas phage AmM-1]	BAP94484.1	0
+f7dd79b9-269f-436a-8e2c-675f25af4fcc	UNY41748.1	UNY41748.1 hypothetical protein CPT_Milagro_029 [Burkholderia phage Milagro]	UNY41748.1	0
+f7dd79b9-269f-436a-8e2c-675f25af4fcc	UNY41861.1	UNY41861.1 hypothetical protein CPT_Momento_031 [Burkholderia phage Momento]	UNY41861.1	0
+f7dd79b9-269f-436a-8e2c-675f25af4fcc	ADP02307.1	ADP02307.1 gp14 [Burkholderia phage KL3]	ADP02307.1	0
+f7dd79b9-269f-436a-8e2c-675f25af4fcc	UNY41805.1	UNY41805.1 hypothetical protein CPT_Menos_030 [Burkholderia phage Menos]	UNY41805.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41749.1	UNY41749.1 repressor protein [Burkholderia phage Milagro]	UNY41749.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	ADP02306.1	ADP02306.1 gp13 [Burkholderia phage KL3]	ADP02306.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41690.1	UNY41690.1 lambda repressor-like protein [Burkholderia phage Musica]	UNY41690.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41862.1	UNY41862.1 lambda repressor-like protein [Burkholderia phage Momento]	UNY41862.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41806.1	UNY41806.1 lambda repressor-like protein [Burkholderia phage Menos]	UNY41806.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41863.1	UNY41863.1 hypothetical protein CPT_Momento_033 [Burkholderia phage Momento]	UNY41863.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UNY41691.1	UNY41691.1 hypothetical protein CPT_Musica_032 [Burkholderia phage Musica]	UNY41691.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QPB09430.1	QPB09430.1 immunity repressor [Burkholderia phage Mana]	QPB09430.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	ADP02258.1	ADP02258.1 gp11 [Burkholderia phage KS5]	ADP02258.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	USM11640.1	USM11640.1 immunity repressor [Burkholderia phage Carl1]	USM11640.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	ACH72932.1	ACH72932.1 gp13 [Burkholderia phage KS10]	ACH72932.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AKA61160.1	AKA61160.1 putative transcriptional regulator [Burkholderia phage AP3]	AKA61160.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QPI18571.1	QPI18571.1 Cro/CI family transcriptional regulator [Burkholderia phage phiE094]	QPI18571.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UKM53796.1	UKM53796.1 putative transcriptional regulator [Burkholderia phage PhiBP82.2]	UKM53796.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	ABO60726.1	ABO60726.1 gp21 [Burkholderia phage phiE202]	ABO60726.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AZF87874.1	AZF87874.1 XRE family transcriptional regulator [Pseudomonas phage Dobby]	AZF87874.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AAZ72617.1	AAZ72617.1 helix-turn-helix domain protein [Burkholderia phage phiE52237]	AAZ72617.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UPI15590.1	UPI15590.1 repressor protein cI [Burkholderia phage PhiBP82.3]	UPI15590.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AIP84260.1	AIP84260.1 helix-turn-helix family protein [Burkholderia phage BEK]	AIP84260.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AFV51424.1	AFV51424.1 helix-turn-helix domain protein [Burkholderia phage phiX216]	AFV51424.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QBI83920.1	QBI83920.1 hypothetical protein [Pseudomonas phage vB_Pae_CF127b]	QBI83920.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QBI84023.1	QBI84023.1 hypothetical protein [Pseudomonas phage vB_Pae_BR58a]	QBI84023.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QBI83712.1	QBI83712.1 hypothetical protein [Pseudomonas phage vB_Pae_CF53b]	QBI83712.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	BAF52412.1	BAF52412.1 putative phage DNA-binding protein [Ralstonia phage RSA1]	BAF52412.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80441.1	AYD80441.1 repressor [Pseudomonas phage Ps56]	AYD80441.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QDB70118.1	QDB70118.1 Cro/CI family transcriptional regulator [Curvibacter phage TJ1]	QDB70118.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UZV40235.1	UZV40235.1 helix-turn-helix transcriptional regulator [Acidovorax phage Acica]	UZV40235.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80605.1	AYD80605.1 repressor [Pseudomonas phage Ps59]	AYD80605.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	CUS27802.1	CUS27802.1 putative repressor protein [Pseudomonas phage vB_PaeS_PM105]	CUS27802.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AAQ13936.1	AAQ13936.1 transcriptional regulator [Pseudomonas phage B3]	AAQ13936.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UYL85433.1	UYL85433.1 helix-turn-helix transcriptional regulator [Acidovorax phage Alfacinha3]	UYL85433.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80552.1	AYD80552.1 repressor [Pseudomonas phage Ps60]	AYD80552.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	WWQ72117.1	WWQ72117.1 CI-like repressor [Pseudomonas phage Sirocco]	WWQ72117.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	UYL85534.1	UYL85534.1 helix-turn-helix transcriptional regulator [Acidovorax phage Alfacinha1]	UYL85534.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	WPJ21718.1	WPJ21718.1 peptidase S24-like protein [Bacillus phage vB_BpuM-ZY1]	WPJ21718.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AAS47857.1	AAS47857.1 gp17 [Burkholderia phage BcepMu]	AAS47857.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	QGF21190.1	QGF21190.1 DNA-binding protein [Pseudomonas phage vB_Pae-SS2019XII]	QGF21190.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80497.1	AYD80497.1 repressor [Pseudomonas phage H72]	AYD80497.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	WWQ71757.1	WWQ71757.1 CI-like repressor [Pseudomonas phage Gregale]	WWQ71757.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AEG42256.1	AEG42256.1 transcription regulator [Haemophilus phage SuMu]	AEG42256.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80333.1	AYD80333.1 repressor [Pseudomonas phage H71]	AYD80333.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	ABO60647.1	ABO60647.1 gp46 [Burkholderia phage phiE255]	ABO60647.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	BAP28139.1	BAP28139.1 hypothetical protein [Ralstonia phage RSY1]	BAP28139.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80386.1	AYD80386.1 repressor [Pseudomonas phage Fc22]	AYD80386.1	0
+0a06a00d-474f-46aa-8b6d-8cfaa38dbada	AYD80278.1	AYD80278.1 repressor [Pseudomonas phage Fc02]	AYD80278.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UNY41751.1	UNY41751.1 transcriptional regulator [Burkholderia phage Milagro]	UNY41751.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UNY41864.1	UNY41864.1 hypothetical protein CPT_Momento_034 [Burkholderia phage Momento]	UNY41864.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UNY41692.1	UNY41692.1 hypothetical protein CPT_Musica_033 [Burkholderia phage Musica]	UNY41692.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UNY41808.1	UNY41808.1 hypothetical protein CPT_Menos_033 [Burkholderia phage Menos]	UNY41808.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	ADP02304.1	ADP02304.1 gp11 [Burkholderia phage KL3]	ADP02304.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	QPB09432.1	QPB09432.1 hypothetical protein CPT_Mana_037 [Burkholderia phage Mana]	QPB09432.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	AVP40031.1	AVP40031.1 hypothetical protein RsoM1USA_39 [Ralstonia phage RsoM1USA]	AVP40031.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	QIV64697.1	QIV64697.1 hypothetical protein [Alteromonas phage P24]	QIV64697.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	WPJ21721.1	WPJ21721.1 hypothetical protein [Bacillus phage vB_BpuM-ZY1]	WPJ21721.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UZV40236.1	UZV40236.1 hypothetical protein Acica_31 [Acidovorax phage Acica]	UZV40236.1	0
+f0181f31-8cc5-49d8-8993-94c3a9806f8f	UAW53916.1	UAW53916.1 hypothetical protein psageK9_46 [Pseudomonas phage psageK9]	UAW53916.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	UNY41752.1	UNY41752.1 transcriptional regulator [Burkholderia phage Milagro]	UNY41752.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	UNY41693.1	UNY41693.1 hypothetical protein CPT_Musica_034 [Burkholderia phage Musica]	UNY41693.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	UNY41809.1	UNY41809.1 hypothetical protein CPT_Menos_034 [Burkholderia phage Menos]	UNY41809.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	ADP02303.1	ADP02303.1 gp10 [Burkholderia phage KL3]	ADP02303.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	UNY41865.1	UNY41865.1 hypothetical protein CPT_Momento_035 [Burkholderia phage Momento]	UNY41865.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	QPB09433.1	QPB09433.1 hypothetical protein CPT_Mana_038 [Burkholderia phage Mana]	QPB09433.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	WPJ21722.1	WPJ21722.1 hypothetical protein [Bacillus phage vB_BpuM-ZY1]	WPJ21722.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	BAF52414.1	BAF52414.1 hypothetical protein [Ralstonia phage RSA1]	BAF52414.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	AVP40032.1	AVP40032.1 hypothetical protein RsoM1USA_40 [Ralstonia phage RsoM1USA]	AVP40032.1	0
+61e7babc-fd5c-4e87-bda9-76289e2dceff	BAP28140.1	BAP28140.1 hypothetical protein [Ralstonia phage RSY1]	BAP28140.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNY41753.1	UNY41753.1 Ogr/Delta-like zinc finger family protein [Burkholderia phage Milagro]	UNY41753.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNY41810.1	UNY41810.1 Ogr/Delta-like zinc finger family protein [Burkholderia phage Menos]	UNY41810.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ADP02302.1	ADP02302.1 gp9 [Burkholderia phage KL3]	ADP02302.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNY41866.1	UNY41866.1 Ogr/Delta-like zinc finger family protein [Burkholderia phage Momento]	UNY41866.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNY41694.1	UNY41694.1 Ogr/Delta-like zinc finger family protein [Burkholderia phage Musica]	UNY41694.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	WWY66174.1	WWY66174.1 transcriptional regulator [Burkholderia phage vB_HM387]	WWY66174.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QPI18574.1	QPI18574.1 Ogr/Delta-like zinc finger family transcriptional activator [Burkholderia phage phiE094]	QPI18574.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UKM53798.1	UKM53798.1 protein Ogr [Burkholderia phage PhiBP82.2]	UKM53798.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ABO60732.1	ABO60732.1 gp19, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60732.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UPI15593.1	UPI15593.1 protein Ogr [Burkholderia phage PhiBP82.3]	UPI15593.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AIP84279.1	AIP84279.1 ogr/Delta-like zinc finger family protein [Burkholderia phage BEK]	AIP84279.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AAZ72614.1	AAZ72614.1 putative phage transcriptional activator Ogr/Delta [Burkholderia phage phiE52237]	AAZ72614.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AFV51427.1	AFV51427.1 putative Ogr/Delta phage transcriptional activator [Burkholderia phage phiX216]	AFV51427.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	BCB23182.1	BCB23182.1 ogr/Delta-like zinc finger family protein [Burkholderia phage FLC5]	BCB23182.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UZV40239.1	UZV40239.1 Ogr/delta-like zinc finger family protein [Acidovorax phage Acica]	UZV40239.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UYL85437.1	UYL85437.1 ogr/Delta-like zinc finger family protein [Acidovorax phage Alfacinha3]	UYL85437.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UYL85538.1	UYL85538.1 ogr/Delta-like zinc finger family protein [Acidovorax phage Alfacinha1]	UYL85538.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ADP02255.1	ADP02255.1 gp8 [Burkholderia phage KS5]	ADP02255.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	BAP28141.1	BAP28141.1 hypothetical protein [Ralstonia phage RSY1]	BAP28141.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	WPJ21723.1	WPJ21723.1 transcriptional activator [Bacillus phage vB_BpuM-ZY1]	WPJ21723.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	USM11643.1	USM11643.1 transcriptional regulator [Burkholderia phage Carl1]	USM11643.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AVP40033.1	AVP40033.1 transcriptional regulator [Ralstonia phage RsoM1USA]	AVP40033.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	VUF53582.1	VUF53582.1 putative phage gene [Escherichia phage ESSI2_ev129]	VUF53582.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	VUF53549.1	VUF53549.1 putative phage gene [Escherichia phage ESSI2_ev040]	VUF53549.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	VUF53510.1	VUF53510.1 putative phage gene [Escherichia phage ESSI2_ev015]	VUF53510.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AKA61163.1	AKA61163.1 putative transcriptional regulator [Burkholderia phage AP3]	AKA61163.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QPB09434.1	QPB09434.1 zinc finger domain-containing protein [Burkholderia phage Mana]	QPB09434.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	BAF52415.1	BAF52415.1 phage transcription activator Ogr/Delta [Ralstonia phage RSA1]	BAF52415.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ADX32403.1	ADX32403.1 hypothetical protein [Cronobacter phage ESSI-2]	ADX32403.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	VUF53493.1	VUF53493.1 putative phage gene [Escherichia phage ESSI2_ev239]	VUF53493.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AGW43557.1	AGW43557.1 zinc-finger protein [Vibrio phage VPUSM 8]	AGW43557.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	BAF98812.1	BAF98812.1 hypothetical zinc-finger protein [Vibrio phage Kappa]	BAF98812.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AAL47512.1	AAL47512.1 orf13 [Bacteriophage K139]	AAL47512.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ANA87651.1	ANA87651.1 zinc-finger protein [Vibrio phage VcP032]	ANA87651.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AAN73997.1	AAN73997.1 ORF13 [Vibrio phage Ch457]	AAN73997.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AAN74013.1	AAN74013.1 ORF13 [Vibrio phage O395]	AAN74013.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QYW06292.1	QYW06292.1 ogr/Delta-like zinc finger family protein [Shewanella phage vB_SspM_M16-3]	QYW06292.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QEI25467.1	QEI25467.1 transcriptional regulator [Salmonella phage SI7]	QEI25467.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AAN74006.1	AAN74006.1 ORF13 [Vibrio phage E8498]	AAN74006.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QEI25520.1	QEI25520.1 transcriptional regulator [Salmonella phage SW3]	QEI25520.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QEI25482.1	QEI25482.1 transcriptional regulator [Salmonella phage SW5]	QEI25482.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ABO60794.1	ABO60794.1 gp13, phage transcriptional activator, Ogr/Delta [Burkholderia phage phiE12-2]	ABO60794.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QWY84987.1	QWY84987.1 Ogr/Delta-like zinc finger family protein [Burkholderia phage PK23]	QWY84987.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UKL54198.1	UKL54198.1 regulator [Yersinia phage vB_YenM_324]	UKL54198.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ABG73171.1	ABG73171.1 conserved hypothetical protein [Aeromonas phage phiO18P]	ABG73171.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AGK86771.1	AGK86771.1 transcriptional regulator [Burkholderia phage ST79]	AGK86771.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	BAA36262.1	BAA36262.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36262.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UGC97305.1	UGC97305.1 Ogr/Delta-like zinc finger family protein [Aeromonas phage vB_AsaM_LPM4]	UGC97305.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBI84143.1	QBI84143.1 transcriptional activator Ogr/delta [Pseudomonas phage vB_Pae_BR319a]	QBI84143.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AZF87877.1	AZF87877.1 hypothetical protein [Pseudomonas phage Dobby]	AZF87877.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AGK86770.1	AGK86770.1 transcriptional regulator, Ogr/Delta [Burkholderia phage ST79]	AGK86770.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNA05767.1	UNA05767.1 DNA-binding protein [Yersinia phage vB_YenM_42.18]	UNA05767.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AOY11830.1	AOY11830.1 zinc-finger protein [Salinivibrio phage SMHB1]	AOY11830.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBP27446.1	QBP27446.1 Ogr/Delta transcriptional activator [Klebsiella phage ST512-KPC3phi13.2]	QBP27446.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBP27854.1	QBP27854.1 Ogr/Delta transcriptional activator [Klebsiella phage ST11-OXA48phi15.3]	QBP27854.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBP08112.1	QBP08112.1 hypothetical protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08112.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBP27685.1	QBP27685.1 Ogr/Delta transcriptional activator [Klebsiella phage ST340-VIM1phi10.2]	QBP27685.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNI73752.1	UNI73752.1 OGR protein [Klebsiella phage KP12]	UNI73752.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QBP27951.1	QBP27951.1 Ogr/Delta transcriptional activator [Klebsiella phage ST258-KPC3phi16.2]	QBP27951.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AUR95196.1	AUR95196.1 Ogr/Delta-type zinc finger protein [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95196.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ARB15709.1	ARB15709.1 hypothetical protein [Klebsiella phage 4LV2017]	ARB15709.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ADQ92421.1	ADQ92421.1 OGR regulator of late gene transcription [Salmonella phage RE2010]	ADQ92421.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	WWQ72120.1	WWQ72120.1 ogr/Delta-like zinc finger family protein [Pseudomonas phage Sirocco]	WWQ72120.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	ABO60789.1	ABO60789.1 gp14, hypothetical-acquired protein [Burkholderia phage phiE12-2]	ABO60789.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	AFJ75504.1	AFJ75504.1 putative bacteriophage transcriptional activator [Stenotrophomonas phage Smp131]	AFJ75504.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	QWY84986.1	QWY84986.1 transcriptional activator [Burkholderia phage PK23]	QWY84986.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNA05942.1	UNA05942.1 transcriptional regulator [Yersinia phage vB_YenM_56.17]	UNA05942.1	0
+4c7d3a53-f152-4957-8b87-dbd5ec26e768	UNA05994.1	UNA05994.1 transcriptional regulator [Yersinia phage vB_YenM_201.16]	UNA05994.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UNY41754.1	UNY41754.1 hypothetical protein CPT_Milagro_035 [Burkholderia phage Milagro]	UNY41754.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UNY41811.1	UNY41811.1 hypothetical protein CPT_Menos_036 [Burkholderia phage Menos]	UNY41811.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UNY41695.1	UNY41695.1 hypothetical protein CPT_Musica_036 [Burkholderia phage Musica]	UNY41695.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	ADP02301.1	ADP02301.1 gp8 [Burkholderia phage KL3]	ADP02301.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UNY41867.1	UNY41867.1 hypothetical protein CPT_Momento_037 [Burkholderia phage Momento]	UNY41867.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	WWY66175.1	WWY66175.1 hypothetical protein vBHM387_00035 [Burkholderia phage vB_HM387]	WWY66175.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	QPI18575.1	QPI18575.1 hypothetical protein BTHphiE094_038 [Burkholderia phage phiE094]	QPI18575.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UKM53799.1	UKM53799.1 hypothetical protein PhiBP822_41 [Burkholderia phage PhiBP82.2]	UKM53799.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	ABO60722.1	ABO60722.1 gp18, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60722.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	AAZ72612.1	AAZ72612.1 hypothetical phage protein [Burkholderia phage phiE52237]	AAZ72612.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	UPI15595.1	UPI15595.1 hypothetical protein PhiBP823_44 [Burkholderia phage PhiBP82.3]	UPI15595.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	AIP84295.1	AIP84295.1 hypothetical protein DP46_6036 [Burkholderia phage BEK]	AIP84295.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	AFV51429.1	AFV51429.1 hypothetical protein BPSphiX216_0011 [Burkholderia phage phiX216]	AFV51429.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	USM11644.1	USM11644.1 hypothetical protein Carl1_43 [Burkholderia phage Carl1]	USM11644.1	0
+900b6e3d-e895-4b61-b980-1c33beca93de	AKA61164.1	AKA61164.1 hypothetical protein vB_BceM_AP3_0043 [Burkholderia phage AP3]	AKA61164.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	UNY41755.1	UNY41755.1 hypothetical protein CPT_Milagro_036 [Burkholderia phage Milagro]	UNY41755.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	AKA61165.1	AKA61165.1 hypothetical protein vB_BceM_AP3_0044 [Burkholderia phage AP3]	AKA61165.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	UNY41868.1	UNY41868.1 hypothetical protein CPT_Momento_038 [Burkholderia phage Momento]	UNY41868.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	ADP02300.1	ADP02300.1 gp7 [Burkholderia phage KL3]	ADP02300.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	QPB09436.1	QPB09436.1 hypothetical protein CPT_Mana_041 [Burkholderia phage Mana]	QPB09436.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	USM11645.1	USM11645.1 hypothetical protein Carl1_44 [Burkholderia phage Carl1]	USM11645.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	ADP02253.1	ADP02253.1 gp6 [Burkholderia phage KS5]	ADP02253.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	AAZ72611.1	AAZ72611.1 conserved hypothetical phage protein [Burkholderia phage phiE52237]	AAZ72611.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	UPI15596.1	UPI15596.1 hypothetical protein PhiBP823_45 [Burkholderia phage PhiBP82.3]	UPI15596.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	QPI18576.1	QPI18576.1 hypothetical protein BTHphiE094_039 [Burkholderia phage phiE094]	QPI18576.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	UKM53800.1	UKM53800.1 hypothetical protein PhiBP822_42 [Burkholderia phage PhiBP82.2]	UKM53800.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	AFV51430.1	AFV51430.1 hypothetical protein BPSphiX216_0009 [Burkholderia phage phiX216]	AFV51430.1	0
+51a779cc-294f-41b1-bcab-f98e1f9ec9a3	ABO60735.1	ABO60735.1 gp17, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60735.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UNY41756.1	UNY41756.1 hypothetical protein CPT_Milagro_037 [Burkholderia phage Milagro]	UNY41756.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	ADP02299.1	ADP02299.1 gp6 [Burkholderia phage KL3]	ADP02299.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UNY41813.1	UNY41813.1 hypothetical protein CPT_Menos_038 [Burkholderia phage Menos]	UNY41813.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	QPB09437.1	QPB09437.1 putative membrane protein [Burkholderia phage Mana]	QPB09437.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	USM11646.1	USM11646.1 hypothetical protein Carl1_45 [Burkholderia phage Carl1]	USM11646.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UNY41697.1	UNY41697.1 hypothetical protein CPT_Musica_038 [Burkholderia phage Musica]	UNY41697.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UNY41869.1	UNY41869.1 hypothetical protein CPT_Momento_039 [Burkholderia phage Momento]	UNY41869.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	ABK56724.1	ABK56724.1 conserved hypothetical protein [Burkholderia phage phiE52237]	ABK56724.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	AFV51431.1	AFV51431.1 hypothetical protein BPSphiX216_0051 [Burkholderia phage phiX216]	AFV51431.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	WWY66176.1	WWY66176.1 membrane protein [Burkholderia phage vB_HM387]	WWY66176.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	QPI18577.1	QPI18577.1 hypothetical protein BTHphiE094_040 [Burkholderia phage phiE094]	QPI18577.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	AIP84263.1	AIP84263.1 putative membrane protein [Burkholderia phage BEK]	AIP84263.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	ABO60717.1	ABO60717.1 gp16, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60717.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UPI15597.1	UPI15597.1 hypothetical protein PhiBP823_46 [Burkholderia phage PhiBP82.3]	UPI15597.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	UKM53801.1	UKM53801.1 hypothetical protein PhiBP822_43 [Burkholderia phage PhiBP82.2]	UKM53801.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	AKA61166.1	AKA61166.1 hypothetical protein vB_BceM_AP3_0045 [Burkholderia phage AP3]	AKA61166.1	0
+fbfddcc4-5d01-4fab-82dd-67e7535dbcd1	ADP02252.1	ADP02252.1 gp5 [Burkholderia phage KS5]	ADP02252.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UNY41757.1	UNY41757.1 hypothetical protein CPT_Milagro_038 [Burkholderia phage Milagro]	UNY41757.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UNY41814.1	UNY41814.1 hypothetical protein CPT_Menos_039 [Burkholderia phage Menos]	UNY41814.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UNY41698.1	UNY41698.1 hypothetical protein CPT_Musica_039 [Burkholderia phage Musica]	UNY41698.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	ADP02298.1	ADP02298.1 gp5 [Burkholderia phage KL3]	ADP02298.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UNY41870.1	UNY41870.1 hypothetical protein CPT_Momento_040 [Burkholderia phage Momento]	UNY41870.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	QPB09438.1	QPB09438.1 hypothetical protein CPT_Mana_043 [Burkholderia phage Mana]	QPB09438.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	AKA61168.1	AKA61168.1 hypothetical protein vB_BceM_AP3_0047 [Burkholderia phage AP3]	AKA61168.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	USM11647.1	USM11647.1 hypothetical protein Carl1_46 [Burkholderia phage Carl1]	USM11647.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	ADP02251.1	ADP02251.1 gp4 [Burkholderia phage KS5]	ADP02251.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	WWY66179.1	WWY66179.1 hypothetical protein vBHM387_00039 [Burkholderia phage vB_HM387]	WWY66179.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UPI15600.1	UPI15600.1 hypothetical protein PhiBP823_49 [Burkholderia phage PhiBP82.3]	UPI15600.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	QPI18580.1	QPI18580.1 hypothetical protein BTHphiE094_043 [Burkholderia phage phiE094]	QPI18580.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	UKM53804.1	UKM53804.1 hypothetical protein PhiBP822_46 [Burkholderia phage PhiBP82.2]	UKM53804.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	AIP84284.1	AIP84284.1 hypothetical protein DP46_6040 [Burkholderia phage BEK]	AIP84284.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	ABO60744.1	ABO60744.1 gp13, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60744.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	AAZ72607.2	AAZ72607.2 hypothetical phage protein [Burkholderia phage phiE52237]	AAZ72607.2	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	AFV51434.1	AFV51434.1 hypothetical protein BPSphiX216_0006 [Burkholderia phage phiX216]	AFV51434.1	0
+9d764d0c-80cd-4a6d-afab-2e27d77cf196	ACH72944.1	ACH72944.1 gp25 [Burkholderia phage KS10]	ACH72944.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	UNY41758.1	UNY41758.1 hypothetical protein CPT_Milagro_039 [Burkholderia phage Milagro]	UNY41758.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	ADP02297.1	ADP02297.1 gp4 [Burkholderia phage KL3]	ADP02297.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	UNY41699.1	UNY41699.1 hypothetical protein CPT_Musica_040 [Burkholderia phage Musica]	UNY41699.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	UNY41815.1	UNY41815.1 hypothetical protein CPT_Menos_040 [Burkholderia phage Menos]	UNY41815.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	AKA61169.1	AKA61169.1 hypothetical protein vB_BceM_AP3_0048 [Burkholderia phage AP3]	AKA61169.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	QPB09439.1	QPB09439.1 hypothetical protein CPT_Mana_044 [Burkholderia phage Mana]	QPB09439.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	UNY41871.1	UNY41871.1 hypothetical protein CPT_Momento_041 [Burkholderia phage Momento]	UNY41871.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	ADP02250.1	ADP02250.1 gp3 [Burkholderia phage KS5]	ADP02250.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	ABO60748.1	ABO60748.1 gp12, hypothetical protein [Burkholderia phage phiE202]	ABO60748.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	AAZ72606.1	AAZ72606.1 hypothetical phage protein [Burkholderia phage phiE52237]	AAZ72606.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	WWY66180.1	WWY66180.1 DNA primase [Burkholderia phage vB_HM387]	WWY66180.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	QPI18581.1	QPI18581.1 DNA primase [Burkholderia phage phiE094]	QPI18581.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	UKM53805.1	UKM53805.1 hypothetical protein PhiBP822_47 [Burkholderia phage PhiBP82.2]	UKM53805.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	AIP84273.1	AIP84273.1 hypothetical protein DP46_6041 [Burkholderia phage BEK]	AIP84273.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	AFV51435.1	AFV51435.1 hypothetical protein BPSphiX216_0005 [Burkholderia phage phiX216]	AFV51435.1	0
+cb0a8364-978f-48d2-a260-02e45dbc88c5	USM11648.1	USM11648.1 hypothetical protein Carl1_47 [Burkholderia phage Carl1]	USM11648.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UNY41759.1	UNY41759.1 DNA primase/helicase [Burkholderia phage Milagro]	UNY41759.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UNY41816.1	UNY41816.1 DNA primase/helicase [Burkholderia phage Menos]	UNY41816.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UNY41700.1	UNY41700.1 DNA primase/helicase [Burkholderia phage Musica]	UNY41700.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	QPB09440.1	QPB09440.1 DNA primase/helicase [Burkholderia phage Mana]	QPB09440.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AKA61170.1	AKA61170.1 hypothetical protein vB_BceM_AP3_0049 [Burkholderia phage AP3]	AKA61170.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ADP02249.1	ADP02249.1 gp2 [Burkholderia phage KS5]	ADP02249.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ADP02296.1	ADP02296.1 gp3 [Burkholderia phage KL3]	ADP02296.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UNY41872.1	UNY41872.1 DNA primase/helicase [Burkholderia phage Momento]	UNY41872.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	USM11649.1	USM11649.1 primase [Burkholderia phage Carl1]	USM11649.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	WWY66181.1	WWY66181.1 DNA primase [Burkholderia phage vB_HM387]	WWY66181.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UPI15601.1	UPI15601.1 DNA segregation ATPase [Burkholderia phage PhiBP82.3]	UPI15601.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	QPI18582.1	QPI18582.1 topoisomerase-primase [Burkholderia phage phiE094]	QPI18582.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	UKM53806.1	UKM53806.1 DNA segregation ATPase [Burkholderia phage PhiBP82.2]	UKM53806.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AAZ72605.1	AAZ72605.1 conserved hypothetical phage protein [Burkholderia phage phiE52237]	AAZ72605.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AIP84305.1	AIP84305.1 CHC2 zinc finger family protein [Burkholderia phage BEK]	AIP84305.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AFV51436.1	AFV51436.1 DNA primase domain-containing protein [Burkholderia phage phiX216]	AFV51436.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ABO60740.1	ABO60740.1 gp11, conserved hypothetical protein [Burkholderia phage phiE202]	ABO60740.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AVP40043.1	AVP40043.1 hypothetical protein RsoM1USA_51 [Ralstonia phage RsoM1USA]	AVP40043.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	BAF52424.1	BAF52424.1 conserved hypothetical phage protein [Ralstonia phage RSA1]	BAF52424.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ADP02347.1	ADP02347.1 gp2 [Burkholderia phage KS14]	ADP02347.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	BCB23180.1	BCB23180.1 zinc finger CHC2-family protein [Burkholderia phage FLC5]	BCB23180.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	BDD79950.1	BDD79950.1 hypothetical protein [Burkholderia phage FLC10]	BDD79950.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	QNL13355.1	QNL13355.1 active ring shaped helicase [Microcystis phage vB_MaeS-yong1]	QNL13355.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	AVR75867.1	AVR75867.1 DNA primase/helicase [Vibrio phage ValSw3-3]	AVR75867.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ACY75811.1	ACY75811.1 predicted protein [Cyanophage PSS2]	ACY75811.1	0
+bf60ae3f-f071-44fb-8b67-988f065e89c5	ACT65671.1	ACT65671.1 DNA primase [Cyanophage PSS2]	ACT65671.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UNY41760.1	UNY41760.1 hypothetical protein CPT_Milagro_041 [Burkholderia phage Milagro]	UNY41760.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	QPB09441.1	QPB09441.1 putative membrane protein [Burkholderia phage Mana]	QPB09441.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UNY41701.1	UNY41701.1 hypothetical protein CPT_Musica_042 [Burkholderia phage Musica]	UNY41701.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UNY41817.1	UNY41817.1 hypothetical protein CPT_Menos_042 [Burkholderia phage Menos]	UNY41817.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UPI15602.1	UPI15602.1 hypothetical protein PhiBP823_51 [Burkholderia phage PhiBP82.3]	UPI15602.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UNY41873.1	UNY41873.1 hypothetical protein CPT_Momento_043 [Burkholderia phage Momento]	UNY41873.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	UKM53807.1	UKM53807.1 hypothetical protein PhiBP822_49 [Burkholderia phage PhiBP82.2]	UKM53807.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	AKA61171.1	AKA61171.1 putative baseplate J family protein [Burkholderia phage AP3]	AKA61171.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	AIP84258.1	AIP84258.1 hypothetical protein DP46_6043 [Burkholderia phage BEK]	AIP84258.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	AVP40044.1	AVP40044.1 hypothetical protein RsoM1USA_54 [Ralstonia phage RsoM1USA]	AVP40044.1	0
+6b3372db-46a6-4075-9559-92c16d5e3a55	BAF52426.1	BAF52426.1 hypothetical protein [Ralstonia phage RSA1]	BAF52426.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNY41761.1	UNY41761.1 tyrosine integrase [Burkholderia phage Milagro]	UNY41761.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNY41874.1	UNY41874.1 tyrosine integrase [Burkholderia phage Momento]	UNY41874.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNY41818.1	UNY41818.1 tyrosine integrase [Burkholderia phage Menos]	UNY41818.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNY41702.1	UNY41702.1 tyrosine integrase [Burkholderia phage Musica]	UNY41702.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKA61172.1	AKA61172.1 putative integrase [Burkholderia phage AP3]	AKA61172.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WWY66182.1	WWY66182.1 integrase [Burkholderia phage vB_HM387]	WWY66182.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QPI18587.1	QPI18587.1 integrase [Burkholderia phage phiE094]	QPI18587.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UKM53809.1	UKM53809.1 integrase [Burkholderia phage PhiBP82.2]	UKM53809.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QPB09443.1	QPB09443.1 tyrosine integrase [Burkholderia phage Mana]	QPB09443.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BAF52427.1	BAF52427.1 site-specific recombinase [Ralstonia phage RSA1]	BAF52427.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIP84259.1	AIP84259.1 phage integrase family protein [Burkholderia phage BEK]	AIP84259.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ABO60708.1	ABO60708.1 gp10, site-specific recombinase, phage integrase family [Burkholderia phage phiE202]	ABO60708.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UPI15603.1	UPI15603.1 integrase [Burkholderia phage PhiBP82.3]	UPI15603.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAZ72603.1	AAZ72603.1 prophage integrase [Burkholderia phage phiE52237]	AAZ72603.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFV51437.1	AFV51437.1 prophage integrase [Burkholderia phage phiX216]	AFV51437.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADO67652.1	ADO67652.1 phage integrase family protein [Escherichia phage HK75]	ADO67652.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFM75930.1	AFM75930.1 integrase [Escherichia phage mEpX2]	AFM75930.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFM76364.1	AFM76364.1 integrase [Enterobacteria phage mEp213]	AFM76364.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASJ79502.1	ASJ79502.1 helix-turn-helix domain-containing protein [Escherichia phage ECP1]	ASJ79502.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFH20653.1	AFH20653.1 integrase [Escherichia phage HK446]	AFH20653.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFM76438.1	AFM76438.1 integrase [Enterobacteria phage mEp043 c-1]	AFM76438.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFH20405.1	AFH20405.1 integrase [Escherichia phage HK542]	AFH20405.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAD10295.1	AAD10295.1 integrase [Shigella phage SfX]	AAD10295.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QIQ67949.1	QIQ67949.1 integrase [Hafnia phage yong1]	QIQ67949.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAD90776.1	CAD90776.1 putative integrase [Haemophilus phage Aaphi23]	CAD90776.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACX80346.1	ACX80346.1 putative integrase [Aggregatibacter phage S1249]	ACX80346.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADZ13628.1	ADZ13628.1 integrase [Cronobacter phage ENT47670]	ADZ13628.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WJN66840.1	WJN66840.1 tyrosine recombinase [Edwardsiella phage EPP-1]	WJN66840.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UXQ90493.1	UXQ90493.1 integrase [Salmonella phage P6]	UXQ90493.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADC81102.1	ADC81102.1 Int [Salmonella phage ST160]	ADC81102.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23712.1	QEI23712.1 integrase [Salmonella phage SE22]	QEI23712.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAY46456.1	AAY46456.1 Int [Salmonella phage SE1Spa]	AAY46456.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDH45319.1	QDH45319.1 mobile element protein [Salmonella phage SF11]	QDH45319.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23687.1	QEI23687.1 integrase [Salmonella phage SI23]	QEI23687.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QMP81745.1	QMP81745.1 integrase [Salmonella phage MG40]	QMP81745.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23129.1	QEI23129.1 mobile element protein [Salmonella phage SE1 (in:P22virus)]	QEI23129.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23070.1	QEI23070.1 mobile element protein [Salmonella phage SF3]	QEI23070.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23574.1	QEI23574.1 integrase [Salmonella phage SE21]	QEI23574.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AUG84781.1	AUG84781.1 integrase [Salmonella phage Bp96115]	AUG84781.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEI23004.1	QEI23004.1 mobile element protein [Salmonella phage SE10]	QEI23004.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDH45251.1	QDH45251.1 mobile element protein [Salmonella phage SE16]	QDH45251.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDH45182.1	QDH45182.1 mobile element protein [Salmonella phage SE16]	QDH45182.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QTZ83117.1	QTZ83117.1 site-specific integrase [Salmonella phage S9-5]	QTZ83117.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QXH32940.1	QXH32940.1 site-specific integrase [Salmonella phage vB_SalP_ABTNLsp11242]	QXH32940.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACJ10191.1	ACJ10191.1 integrase [Bacteriophage APSE-2]	ACJ10191.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOV06025.1	QOV06025.1 integrase [Salmonella phage L cII-101]	QOV06025.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAL15478.1	AAL15478.1 Int [Salmonella phage ST64T]	AAL15478.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOV05954.1	QOV05954.1 integrase [Salmonella phage L cI-40 13-am43]	QOV05954.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASJ79017.1	ASJ79017.1 mobile element protein [Salmonella phage vB_SalP_PM43]	ASJ79017.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAW70505.1	AAW70505.1 gp34 [Enterobacteria phage ES18]	AAW70505.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WJZ70097.1	WJZ70097.1 integrase [Pantoea phage PA-1]	WJZ70097.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	VUD36883.1	VUD36883.1 integrase [Escherichia phage 2G7b]	VUD36883.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	VUF53586.1	VUF53586.1 Phage integrase [Escherichia phage ev243]	VUF53586.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BAD15167.1	BAD15167.1 Int [Enterobacteria phage ST104]	BAD15167.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WDS50873.1	WDS50873.1 integrase [Salmonella phage Salfasec13b]	WDS50873.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXC42615.1	AXC42615.1 integrase [Salmonella phage S149]	AXC42615.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3775378.1	CAB3775378.1 Integrase [Bacteriophage APSE-3]	CAB3775378.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3623603.1	CAB3623603.1 Integrase [Bacteriophage APSE-7]	CAB3623603.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXC42187.1	AXC42187.1 mobile element protein [Salmonella phage S135]	AXC42187.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXC42271.1	AXC42271.1 mobile element protein [Salmonella phage S137]	AXC42271.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXC39908.1	AXC39908.1 integrase [Salmonella phage S107]	AXC39908.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFR52475.1	AFR52475.1 phage integrase family site-specific recombinase [Enterobacteria phage SfI]	AFR52475.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3775416.1	CAB3775416.1 Integrase [Bacteriophage APSE-7]	CAB3775416.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGQ45520.1	AGQ45520.1 integrase [Shigella phage SfII]	AGQ45520.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYE91734.1	UYE91734.1 integrase [Escherichia phage phi458]	UYE91734.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAF03981.1	AAF03981.1 P38 [Hamiltonella phage APSE-1]	AAF03981.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEW47733.1	AEW47733.1 integrase [Salmonella phage SPN9CC]	AEW47733.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45130.1	ANM45130.1 mobile element protein [Salmonella phage 146851_sal5]	ANM45130.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45330.1	ANM45330.1 mobile element protein [Salmonella phage 103203_sal5]	ANM45330.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45216.1	ANM45216.1 mobile element protein [Salmonella phage 146851_sal4]	ANM45216.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANA49972.1	ANA49972.1 mobile element protein [Salmonella phage 118970_sal4]	ANA49972.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45687.1	ANM45687.1 mobile element protein [Salmonella phage 64795_sal4]	ANM45687.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45432.1	ANM45432.1 mobile element protein [Salmonella phage 101962B_sal5]	ANM45432.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANM45368.1	ANM45368.1 mobile element protein [Salmonella phage 103203_sal4]	ANM45368.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3745627.1	CAB3745627.1 Integrase [Bacteriophage APSE-7]	CAB3745627.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAM81400.1	AAM81400.1 Int protein [Salmonella phage P22-pbi]	AAM81400.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOI68473.1	QOI68473.1 site-specific integrase [Salmonella phage VSe13]	QOI68473.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BAF80738.1	BAF80738.1 integrase [Salmonella phage P22]	BAF80738.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAF75002.1	AAF75002.1 integrase [Salmonella phage P22]	AAF75002.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAA27685.1	CAA27685.1 unnamed protein product [Salmonella phage P22]	CAA27685.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BAG12621.1	BAG12621.1 integrase [Salmonella phage P22]	BAG12621.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WBC28716.1	WBC28716.1 Int [Salmonella phage P22virB-3]	WBC28716.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB4327898.1	CAB4327898.1 Integrase [Bacteriophage APSE-7]	CAB4327898.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3623596.1	CAB3623596.1 Integrase [Bacteriophage APSE-7]	CAB3623596.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WPF54699.1	WPF54699.1 integrase [Shigella phage VIT_AJPSC]	WPF54699.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGY37079.1	AGY37079.1 integrase [Shigella phage SfIV]	AGY37079.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADW81959.1	ADW81959.1 integrase [Enterobacteria phage UAB_Phi20]	ADW81959.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADM32336.1	ADM32336.1 Int [Enterobacteria phage Phi75]	ADM32336.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNO00923.1	QNO00923.1 tyrosine integrase [Serratia phage vB_SspM_BZS1]	QNO00923.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3635639.1	CAB3635639.1 Integrase [Hamiltonella phage APSE-8]	CAB3635639.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAB72135.1	AAB72135.1 integrase [Enterobacteria phage SfV]	AAB72135.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALF02443.1	ALF02443.1 integrase [Salmonella phage SEN22]	ALF02443.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UWV16693.1	UWV16693.1 integrase [Salmonella phage BIS08P22]	UWV16693.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACF16647.1	ACF16647.1 Tyrosine integrase [Salmonella phage epsilon34]	ACF16647.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADO67713.1	ADO67713.1 integrase [Escherichia phage HK639]	ADO67713.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHZ95168.1	AHZ95168.1 integrase [Shigella phage POCJ13]	AHZ95168.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHB80183.2	AHB80183.2 integrase [Shigella phage 75/02 Stx]	AHB80183.2	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYP69185.1	AYP69185.1 integrase [Edwardsiella phage Edno5]	AYP69185.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BAP28905.1	BAP28905.1 putative integrase [Edwardsiella phage GF-2]	BAP28905.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACJ10160.1	ACJ10160.1 integrase, partial [Bacteriophage APSE-3]	ACJ10160.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBQ71473.1	QBQ71473.1 integrase [Klebsiella phage ST512-KPC3phi13.1]	QBQ71473.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBQ71407.1	QBQ71407.1 integrase [Klebsiella phage ST11-VIM1phi8.1]	QBQ71407.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACJ10161.1	ACJ10161.1 integrase, partial [Bacteriophage APSE-5]	ACJ10161.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP28345.1	QBP28345.1 integrase [Klebsiella phage ST101-KPC2phi6.1]	QBP28345.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP28265.1	QBP28265.1 site-specific integrase [Klebsiella phage ST15-VIM1phi2.1]	QBP28265.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP08159.1	QBP08159.1 site-specific integrase [Klebsiella phage ST405-OXA48phi1.2]	QBP08159.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARB15590.1	ARB15590.1 integrase [Klebsiella phage 2b LV-2017]	ARB15590.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEA09476.1	QEA09476.1 integrase [Klebsiella phage ST13-OXA48phi12.5]	QEA09476.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACJ10162.1	ACJ10162.1 integrase, partial [Bacteriophage APSE-4]	ACJ10162.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXH43543.1	AXH43543.1 integrase [Erwinia phage vB_EhrS_59]	AXH43543.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	SIU02682.1	SIU02682.1 Integrase [Lederbergvirus BTP1]	SIU02682.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNT47734.1	WNT47734.1 integrase [Salmonella phage SPLA1b]	WNT47734.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QQO89492.1	QQO89492.1 tyrosine recombinase [Salmonella phage vB_SenP_ER25]	QQO89492.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3775454.1	CAB3775454.1 Integrase [Bacteriophage APSE-2]	CAB3775454.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UEP18735.1	UEP18735.1 site-specific integrase [Shewanella phage vB_Sb_QDWS]	UEP18735.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYA57398.1	QYA57398.1 putative site-specific integrase [Hafnia phage vB_HpaM_Meifeng]	QYA57398.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAC39270.1	AAC39270.1 integrase, partial [Shigella phage SfII]	AAC39270.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARM67888.1	ARM67888.1 integrase [Morganella phage IME1369_01]	ARM67888.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74361.1	AKJ74361.1 integrase [Salmonella phage 22]	AKJ74361.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74223.1	AKJ74223.1 DNA integration/recombination/inversion protein [Salmonella phage 34]	AKJ74223.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74299.1	AKJ74299.1 integrase [Salmonella phage 25]	AKJ74299.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXM43042.1	AXM43042.1 integrase, partial [Salmonella phage vB_SalP_PM27]	AXM43042.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXM43039.1	AXM43039.1 integrase, partial [Salmonella phage vB_SalP_PM12]	AXM43039.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXM43038.1	AXM43038.1 integrase, partial [Salmonella phage vB_SalP_PM43]	AXM43038.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXM43040.1	AXM43040.1 integrase, partial [Salmonella phage vB_SalP_PM19]	AXM43040.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXM43041.1	AXM43041.1 integrase, partial [Salmonella phage vB_SalP_PM26]	AXM43041.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QVW29150.1	QVW29150.1 integrase [Pseudomonas phage Medea1]	QVW29150.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UPT53242.1	UPT53242.1 integrase [Synechococcus phage Yong-L1-251]	UPT53242.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAF04808.1	AAF04808.1 integrase [Pseudomonas phage D3]	AAF04808.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEX55906.1	AEX55906.1 integrase [Pseudomonas phage PMG1]	AEX55906.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALP47856.1	ALP47856.1 hypothetical protein BPPAER656_00350 [Pseudomonas phage YMC11/02/R656]	ALP47856.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WWQ71811.1	WWQ71811.1 integrase [Pseudomonas phage Haboob]	WWQ71811.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ULG00228.1	ULG00228.1 integrase [Pseudomonas phage PP9W2]	ULG00228.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QUE30215.1	QUE30215.1 integrase [Pseudomonas phage BUCT566]	QUE30215.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WXA36778.1	WXA36778.1 integrase [Pseudomonas phage Marin]	WXA36778.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI81028.1	QBI81028.1 integrase [Pseudomonas phage vB_Pae_BR141b]	QBI81028.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI80793.1	QBI80793.1 integrase [Pseudomonas phage vB_Pae_BR153a]	QBI80793.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UVD41418.1	UVD41418.1 integrase [Pseudomonas phage vB_Pae_LC3I3]	UVD41418.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QVJ07677.1	QVJ07677.1 telomere resolvase [Sphingopyxis phage VSN-002]	QVJ07677.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	APU00288.1	APU00288.1 shufflon-specific DNA recombinase [Ralstonia phage RS-PII-1]	APU00288.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UOF82081.1	UOF82081.1 integrase [Caudoviricetes sp.]	UOF82081.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QIG75024.1	QIG75024.1 integrase protein [Rhizobium phage RHph_I3_18]	QIG75024.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QMV32530.1	QMV32530.1 tyrosine recombinase [Ralstonia phage Anchaing]	QMV32530.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UAW53885.1	UAW53885.1 integrase [Pseudomonas phage psageK9]	UAW53885.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QXV71595.1	QXV71595.1 putative integrase [Pseudomonas phage psageB2]	QXV71595.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHZ95039.1	AHZ95039.1 integrase [Pseudomonas phage phiPSA1]	AHZ95039.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74360.1	AKJ74360.1 integrase [Salmonella phage 22]	AKJ74360.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74222.1	AKJ74222.1 hypothetical protein SP34_68 [Salmonella phage 34]	AKJ74222.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ74298.1	AKJ74298.1 integrase [Salmonella phage 25]	AKJ74298.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNO49131.1	WNO49131.1 integrase family protein [Achromobacter phage CF418P1]	WNO49131.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UIU47043.1	UIU47043.1 site-specific integrase [Microcystis phage MinS1]	UIU47043.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CDL65243.1	CDL65243.1 putative integrase recombinase protein [Burkholderia phage Bp-AMP4]	CDL65243.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ULF50168.1	ULF50168.1 integrase [Prochlorococcus phage P-SCSP2]	ULF50168.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CDL65162.1	CDL65162.1 putative integrase/recombinase protein [Burkholderia phage Bp-AMP2]	CDL65162.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QEP52874.1	QEP52874.1 putative integrase/recombinase protein [Burkholderia phage AMP1]	QEP52874.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CDK30075.1	CDK30075.1 putative integrase/recombinase protein [Burkholderia phage Bp-AMP1]	CDK30075.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WEM05503.1	WEM05503.1 integrase [Ralstonia phage BOESR1]	WEM05503.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WLW40582.1	WLW40582.1 integrase [Ralstonia phage BOESR1]	WLW40582.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WMM95823.1	WMM95823.1 integrase [Roseobacter phage CRP-113]	WMM95823.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ATN93283.1	ATN93283.1 shufflon-specific DNA recombinase [Marinobacter phage PS6]	ATN93283.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UPT53072.1	UPT53072.1 integrase [Synechococcus phage Yong-M3-232]	UPT53072.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDB70994.1	QDB70994.1 tyrosine integrase [Bordetella phage vB_BbrP_BB8]	QDB70994.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYW02349.1	QYW02349.1 tyrosine integrase [Burkholderia phage Paku]	QYW02349.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AQT27764.1	AQT27764.1 shufflon-specific DNA recombinase [Ralstonia phage RS-PI-1]	AQT27764.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WMM95310.1	WMM95310.1 integrase [Roseobacter phage CRP-125]	WMM95310.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXH71576.1	AXH71576.1 integrase [Pelagibacter phage HTVC200P]	AXH71576.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAK37784.1	AAK37784.1 integrase [Haemophilus phage HP2]	AAK37784.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP27640.1	QBP27640.1 integrase [Klebsiella phage ST13-OXA48phi12.1]	QBP27640.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WBY65450.1	WBY65450.1 integrase [Pasteurella phage vB_PmuM_CFP3]	WBY65450.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAZ93639.1	AAZ93639.1 Int [Pasteurella phage F108]	AAZ93639.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WMM95045.1	WMM95045.1 integrase [Roseobacter phage CRP-171]	WMM95045.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASW27630.1	ASW27630.1 hypothetical protein KPNN133_011 [Klebsiella phage YMC16/01/N133_KPN_BP]	ASW27630.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAB09182.1	AAB09182.1 integrase [Haemophilus phage HP1]	AAB09182.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ATS93362.1	ATS93362.1 putative integrase [Ralstonia phage DU_RP_I]	ATS93362.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AUO78179.1	AUO78179.1 hypothetical protein RSEGYP2_18 [Ralstonia phage RsoP1EGY]	AUO78179.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UHX60253.1	UHX60253.1 integrase [Ralstonia phage vRsoP-WF2]	UHX60253.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UHX60305.1	UHX60305.1 integrase [Ralstonia phage vRsoP-WM2]	UHX60305.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UHX60357.1	UHX60357.1 integrase [Ralstonia phage vRsoP-WR2]	UHX60357.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UGC97312.1	UGC97312.1 integrase [Aeromonas phage vB_AsaM_LPM4]	UGC97312.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UKL54188.1	UKL54188.1 integrase [Yersinia phage vB_YenM_324]	UKL54188.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UAJ16927.1	UAJ16927.1 integrase [Desulfovibrio phage ProddE]	UAJ16927.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXH71359.1	AXH71359.1 integrase [Pelagibacter phage HTVC119P]	AXH71359.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBQ71978.1	QBQ71978.1 integrase [Klebsiella phage ST15-OXA48phi14.1]	QBQ71978.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP08063.1	QBP08063.1 site-specific integrase [Klebsiella phage ST437-OXA245phi4.1]	QBP08063.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP27791.1	QBP27791.1 integrase [Klebsiella phage ST512-KPC3phi13.6]	QBP27791.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP27946.1	QBP27946.1 integrase [Klebsiella phage ST258-KPC3phi16.1]	QBP27946.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QQM14890.1	QQM14890.1 recombinase/integrase [Kosakonia phage Kc166BP]	QQM14890.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAA96221.1	CAA96221.1 integrase [Haemophilus phage S2]	CAA96221.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNA05845.1	UNA05845.1 integrase [Yersinia phage vB_YenM_06.16-2]	UNA05845.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADX32415.1	ADX32415.1 phage integrase family protein [Erwinia phage ENT90]	ADX32415.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANT40746.1	ANT40746.1 tyrosine family integrase [Acinetobacter phage vB_AbaS_TRS1]	ANT40746.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AQT27312.1	AQT27312.1 integrase [Salmonella phage SEN8]	AQT27312.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALO79832.1	ALO79832.1 site-specific recombinase [Bacillus phage phi4J1]	ALO79832.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QIG56961.1	QIG56961.1 integrase [Pseudomonas phage vB_Pae-SS2019XI]	QIG56961.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UPT53114.1	UPT53114.1 integrase [Synechococcus phage Yong-M4-251]	UPT53114.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UKL54229.1	UKL54229.1 integrase [Yersinia phage vB_YenM_31.17]	UKL54229.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QLF84179.1	QLF84179.1 tyrosine integrase [Gordonia Phage Jablanski]	QLF84179.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYL88067.1	UYL88067.1 tyrosine integrase [Gordonia phage Pytheas]	UYL88067.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADQ92377.1	ADQ92377.1 integrase [Salmonella phage RE2010]	ADQ92377.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAH1234742.1	CAH1234742.1 Integrase [Escherichia phage Cartapus]	CAH1234742.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXF42072.1	AXF42072.1 integrase [Synechococcus T7-like phage S-TIP37]	AXF42072.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNA05944.1	UNA05944.1 integrase [Yersinia phage vB_YenM_201.16]	UNA05944.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAC34175.1	AAC34175.1 Int [Escherichia phage 186]	AAC34175.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WXX18214.1	WXX18214.1 integrase [Yersinia phage GCS667]	WXX18214.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UXY92547.1	UXY92547.1 site-specific tyrosine integrase [Pseudomonas phage LUZ100]	UXY92547.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WYC18467.1	WYC18467.1 integrase [Yersinia phage vB_YpM_MHG38]	WYC18467.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WYC18359.1	WYC18359.1 integrase [Yersinia phage vB_YpM_MDG94-186]	WYC18359.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WYC18425.1	WYC18425.1 integrase [Yersinia phage vB_YpM_MDG45]	WYC18425.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASD51156.1	ASD51156.1 integrase [Erwinia phage EtG]	ASD51156.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYJ74799.1	AYJ74799.1 hypothetical protein phiMa_16 [Thermus phage phiMa]	AYJ74799.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AUS03438.1	AUS03438.1 integrase [Paenibacillus phage Dragolir]	AUS03438.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALF01608.1	ALF01608.1 integrase [Bacillus phage vB_BtS_BMBtp16]	ALF01608.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UUG69894.1	UUG69894.1 tyrosine integrase [Gordonia phage Morkie]	UUG69894.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYL87792.1	UYL87792.1 tyrosine integrase [Gordonia phage OneDirection]	UYL87792.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QXN74950.1	QXN74950.1 tyrosine integrase [Gordonia phage Posh]	QXN74950.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AZF98778.1	AZF98778.1 integrase [Gordonia phage Maridalia]	AZF98778.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UTC25924.1	UTC25924.1 integrase [Salmonella phage vB_Sal_PHB48]	UTC25924.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYC52685.1	QYC52685.1 tyrosine recombinase [Salmonella phage BIS20]	QYC52685.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGZ15341.1	QGZ15341.1 integrase [Pseudomonas phage pf8_ST274-AUS411]	QGZ15341.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UOW93706.1	UOW93706.1 tyrosine integrase [Gordonia phage Wrigley]	UOW93706.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIK68482.1	AIK68482.1 putative integrase [Mesorhizobium phage vB_MloP_Lo5R7ANS]	AIK68482.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKJ72127.1	AKJ72127.1 putative integrase [Gordonia phage GMA1]	AKJ72127.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UJD21056.1	UJD21056.1 tyrosine integrase [Gordonia phage Pickett]	UJD21056.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMS03198.1	AMS03198.1 integrase [Gordonia phage Nymphadora]	AMS03198.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDP43320.1	QDP43320.1 integrase [Gordonia phage Eviarto]	QDP43320.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDP43401.1	QDP43401.1 integrase [Gordonia phage TimTam]	QDP43401.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QZD97556.1	QZD97556.1 tyrosine integrase [Gordonia phage LonelyBoi]	QZD97556.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAQ94690.1	AAQ94690.1 PA0728 [Primolicivirus Pf1]	AAQ94690.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BCD83183.1	BCD83183.1 phage integrase [Nitratiruptor phage NrS-4]	BCD83183.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	BCD83242.1	BCD83242.1 phage integrase [Nitratiruptor phage NrS-5]	BCD83242.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDP43662.1	QDP43662.1 tyrosine integrase [Gordonia phage PhorbesPhlower]	QDP43662.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WVW75630.1	WVW75630.1 tyrosine-type recombinase/integrase [Pseudomonas phage PfAC13]	WVW75630.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDF16520.1	QDF16520.1 integrase [Gordonia phage Zameen]	QDF16520.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMS02435.1	AMS02435.1 integrase [Gordonia phage SoilAssassin]	AMS02435.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QUE26324.1	QUE26324.1 tyrosine integrase [Gordonia phage Neobush]	QUE26324.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UXE04843.1	UXE04843.1 tyrosine integrase [Gordonia phage Eudoria]	UXE04843.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYL86411.1	UYL86411.1 tyrosine integrase [Gordonia phage Manasvini]	UYL86411.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYQ99179.1	AYQ99179.1 integrase [Gordonia phage Bialota]	AYQ99179.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDB74464.1	QDB74464.1 integrase [Gordonia phage Polly]	QDB74464.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDH48865.1	QDH48865.1 tyrosine integrase [Gordonia phage Suscepit]	QDH48865.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QCG77458.1	QCG77458.1 integrase [Gordonia phage Antonio]	QCG77458.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMS02509.1	AMS02509.1 integrase [Gordonia phage Attis]	AMS02509.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QUE26146.1	QUE26146.1 tyrosine integrase [Gordonia phage Trumpet]	QUE26146.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QCW22442.1	QCW22442.1 integrase [Gordonia phage Tayonia]	QCW22442.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDF18355.1	QDF18355.1 integrase [Gordonia phage LordFarquaad]	QDF18355.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AOE45036.1	AOE45036.1 integrase [Gordonia phage Zirinka]	AOE45036.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QWY84543.1	QWY84543.1 tyrosine integrase [Gordonia phage Yeet412]	QWY84543.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOP67340.1	QOP67340.1 tyrosine integrase [Gordonia phage Herod]	QOP67340.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AOE43929.1	AOE43929.1 integrase [Gordonia phage BatStarr]	AOE43929.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARB15672.1	ARB15672.1 integrase [Klebsiella phage 4LV2017]	ARB15672.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYJ74300.1	AYJ74300.1 hypothetical protein phiE131_034 [Burkholderia phage phiE131]	AYJ74300.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYJ74370.1	AYJ74370.1 hypothetical protein phiE058_034 [Burkholderia phage phiE058]	AYJ74370.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOI66869.1	QOI66869.1 tyrosine integrase [Gordonia phage Bosnia]	QOI66869.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMS03353.1	AMS03353.1 integrase [Gordonia phage Kita]	AMS03353.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AVO21646.1	AVO21646.1 integrase [Mycobacterium phage MooMoo]	AVO21646.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXQ62870.1	AXQ62870.1 tyrosine integrase [Gordonia phage Angelique]	AXQ62870.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNJ58089.1	QNJ58089.1 tyrosine integrase [Gordonia phage Bunnybear]	QNJ58089.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYE91943.1	UYE91943.1 putative integrase [Aeromonas phage A051]	UYE91943.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ABG73202.1	ABG73202.1 putative integrase [Aeromonas phage phiO18P]	ABG73202.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALA12684.1	ALA12684.1 integrase [Paenibacillus phage Vegas]	ALA12684.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALA12940.1	ALA12940.1 integrase [Paenibacillus phage Diane]	ALA12940.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALA12767.1	ALA12767.1 integrase [Paenibacillus phage Hayley]	ALA12767.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALA12854.1	ALA12854.1 integrase [Paenibacillus phage Vadim]	ALA12854.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYW01065.1	QYW01065.1 tyrosine integrase [Gordonia phage AlumE]	QYW01065.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QWY79500.1	QWY79500.1 tyrosine integrase [Gordonia phage BoyNamedSue]	QWY79500.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNA05890.1	UNA05890.1 integrase [Yersinia phage vB_YenM_56.17]	UNA05890.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QCW22223.1	QCW22223.1 integrase [Gordonia phage WelcomeAyanna]	QCW22223.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QPX62268.1	QPX62268.1 tyrosine integrase [Gordonia phage Lamberg]	QPX62268.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QPL13602.1	QPL13602.1 tyrosine integrase [Gordonia phage Mocha12]	QPL13602.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UUG69822.1	UUG69822.1 tyrosine integrase [Gordonia phage Clap]	UUG69822.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOC59160.1	QOC59160.1 tyrosine integrase [Gordonia phage GemG]	QOC59160.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWY04707.1	AWY04707.1 integrase [Gordonia phage Ebert]	AWY04707.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QCW22519.1	QCW22519.1 integrase [Gordonia phage Haley23]	QCW22519.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QWT30244.1	QWT30244.1 tyrosine integrase [Gordonia phage TuertoX]	QWT30244.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AZS12855.1	AZS12855.1 integrase [Gordonia phage Savage]	AZS12855.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOC55960.1	QOC55960.1 tyrosine integrase [Gordonia phage Matteo]	QOC55960.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AZS12782.1	AZS12782.1 integrase [Gordonia phage Sproutie]	AZS12782.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UXE04699.1	UXE04699.1 tyrosine integrase [Gordonia phage Nettuno]	UXE04699.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QRI45370.1	QRI45370.1 tyrosine integrase [Gordonia Phage Whiteclaw]	QRI45370.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXF40327.1	AXF40327.1 site-specific integrase [Paenibacillus phage LincolnB]	AXF40327.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXF39444.1	AXF39444.1 site-specific integrase [Paenibacillus phage Wanderer]	AXF39444.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QFP93753.1	QFP93753.1 integrase [Ralstonia phage P-PSG-11-1]	QFP93753.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QFP93705.1	QFP93705.1 integrase [Ralstonia phage P-PSG-11]	QFP93705.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ96660.1	QGJ96660.1 tyrosine integrase [Gordonia phage Cynthia]	QGJ96660.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADX32374.1	ADX32374.1 phage integrase [Cronobacter phage ESSI-2]	ADX32374.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UAJ15629.1	UAJ15629.1 tyrosine integrase [Gordonia phage Gizermo]	UAJ15629.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEV51892.1	AEV51892.1 phage integrase [Rhodococcus phage REQ2]	AEV51892.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ATW60730.1	ATW60730.1 integrase [Gordonia phage Bjanes7]	ATW60730.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYW00764.1	QYW00764.1 tyrosine integrase [Gordonia phage Sahara]	QYW00764.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYC54596.1	QYC54596.1 tyrosine integrase [Gordonia phage Agueybana]	QYC54596.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDF17799.1	QDF17799.1 integrase [Gordonia phage ThankyouJordi]	QDF17799.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QJT69881.1	QJT69881.1 integrase [Acinetobacter phage fEg-Aba01]	QJT69881.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QJT69935.1	QJT69935.1 integrase [Acinetobacter phage fLi-Aba02]	QJT69935.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QJT69989.1	QJT69989.1 integrase [Acinetobacter phage fLi-Aba03]	QJT69989.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYQ99558.1	AYQ99558.1 integrase [Mycobacterium phage IrishSherpFalk]	AYQ99558.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AOQ28495.1	AOQ28495.1 integrase [Mycobacterium phage WillSterrel]	AOQ28495.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QIQ63726.1	QIQ63726.1 tyrosine integrase [Mycobacterium phage Phanphagia]	QIQ63726.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UYL91830.1	UYL91830.1 integrase [Paenibacillus phage Bob]	UYL91830.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	CAB3775455.1	CAB3775455.1 Integrase [Bacteriophage APSE-2]	CAB3775455.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WAK79734.1	WAK79734.1 integrase [Flavonifractor phage Castelnaud]	WAK79734.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UVK63030.1	UVK63030.1 tyrosine integrase [Mycobacterium phage Beakin]	UVK63030.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYP29004.1	AYP29004.1 integrase [Marinobacter phage AS1]	AYP29004.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UOF81798.1	UOF81798.1 integrase [Caudoviricetes sp.]	UOF81798.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYB69277.1	AYB69277.1 integrase [Mycobacterium phage Galactic]	AYB69277.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNM74026.1	WNM74026.1 tyrosine integrase [Mycobacterium Phage LunaBlu]	WNM74026.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXQ60740.1	AXQ60740.1 integrase [Mycobacterium phage EleanorGeorge]	AXQ60740.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASZ74418.1	ASZ74418.1 integrase [Mycobacterium phage Wachhund]	ASZ74418.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACI12354.1	ACI12354.1 integrase [Mycobacterium phage Fruitloop]	ACI12354.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNM65612.1	WNM65612.1 tyrosine integrase [Mycobacterium phage Rialto]	WNM65612.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAD03774.1	AAD03774.1 integrase [Mycobacterium phage Ms6]	AAD03774.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGG54594.1	AGG54594.1 integrase [Prochlorococcus phage P-SSP3]	AGG54594.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYQ99392.1	AYQ99392.1 integrase [Mycobacterium phage Filuzino]	AYQ99392.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAO46045.1	AAO46045.1 integrase [Micromonospora phage pMLP1]	AAO46045.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11658.1	QBX11658.1 integrase/recombinase [Streptococcus satellite phage Javan598]	QBX11658.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UOF80914.1	UOF80914.1 integrase [Caudoviricetes sp.]	UOF80914.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11045.1	QBX11045.1 integrase/recombinase [Streptococcus satellite phage Javan538]	QBX11045.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QFR56878.1	QFR56878.1 tyrosine integrase [Mycobacterium phage Juice456]	QFR56878.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QHB47332.1	QHB47332.1 tyrosine integrase [Mycobacterium phage Hegedechwinu]	QHB47332.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QZD98520.1	QZD98520.1 tyrosine integrase [Mycobacterium phage Sarma624]	QZD98520.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIK67440.1	AIK67440.1 integrase [Mycobacterium phage Cerasum]	AIK67440.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARM70632.1	ARM70632.1 integrase [Mycobacterium phage Kingsley]	ARM70632.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AKQ06943.1	AKQ06943.1 integrase [Mycobacterium phage Ovechkin]	AKQ06943.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QKO03036.1	QKO03036.1 tyrosine integrase [Mycobacterium phage LastJedi]	QKO03036.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASJ79637.1	ASJ79637.1 integrase [Mycobacterium phage Pippy]	ASJ79637.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMS01743.1	AMS01743.1 integrase [Mycobacterium phage Brocalys]	AMS01743.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AVR76431.1	AVR76431.1 integrase [Mycobacterium phage BigPhil]	AVR76431.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGT12244.1	AGT12244.1 integrase [Mycobacterium phage Velveteen]	AGT12244.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXC35579.1	AXC35579.1 integrase [Mycobacterium phage Clifton]	AXC35579.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QOP65478.1	QOP65478.1 tyrosine integrase [Mycobacterium phage Coco12]	QOP65478.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALA48789.1	ALA48789.1 integrase [Mycobacterium phage XFactor]	ALA48789.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WKW86428.1	WKW86428.1 integrase [Mycobacterium phage ShroomBoi]	WKW86428.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QJD53162.1	QJD53162.1 tyrosine integrase [Mycobacterium phage DRBy19]	QJD53162.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWN05373.1	AWN05373.1 integrase [Mycobacterium phage Mattes]	AWN05373.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	USH45138.1	USH45138.1 tyrosine integrase [Mycobacterium phage Whatsapiecost]	USH45138.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXH70328.1	AXH70328.1 integrase [Mycobacterium phage Gorge]	AXH70328.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP30705.1	QBP30705.1 integrase [Mycobacterium phage SwagPigglett]	QBP30705.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWN04859.1	AWN04859.1 integrase [Mycobacterium phage BobaPhett]	AWN04859.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WVX89179.1	WVX89179.1 tyrosine integrase [Mycobacterium phage Philus]	WVX89179.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI98897.1	QBI98897.1 integrase [Mycobacterium phage James]	QBI98897.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHI61336.1	AHI61336.1 integrase [Mycobacterium phage Saal]	AHI61336.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYC54829.1	QYC54829.1 tyrosine integrase [Mycobacterium phage Zizzle]	QYC54829.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFA45049.1	AFA45049.1 integrase [Mycobacterium phage Spartacus]	AFA45049.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGH79177.1	QGH79177.1 tyrosine integrase [Mycobacterium phage Flathead]	QGH79177.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ89545.1	QGJ89545.1 tyrosine integrase [Mycobacterium phage Enby]	QGJ89545.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYD86867.1	AYD86867.1 integrase [Mycobacterium phage MilleniumForce]	AYD86867.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AER49450.1	AER49450.1 integrase [Mycobacterium phage SG4]	AER49450.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ91229.1	QGJ91229.1 tyrosine integrase [Mycobacterium phage Lorde]	QGJ91229.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASZ72925.1	ASZ72925.1 integrase [Mycobacterium phage Emma]	ASZ72925.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNN98723.1	QNN98723.1 tyrosine integrase [Mycobacterium phage Moonbeam]	QNN98723.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WDW20015.1	WDW20015.1 integrase [Mycobacterium phage LOCARD]	WDW20015.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACY39918.1	ACY39918.1 gp36 [Mycobacterium phage Ardmore]	ACY39918.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEK09665.1	AEK09665.1 integrase [Mycobacterium phage Mozy]	AEK09665.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGH77862.1	QGH77862.1 tyrosine integrase [Mycobacterium phage Kenuha5]	QGH77862.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWH14095.1	AWH14095.1 integrase [Mycobacterium phage Melissauren88]	AWH14095.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ88214.1	QGJ88214.1 tyrosine integrase [Mycobacterium phage StAnnes]	QGJ88214.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNN99596.1	QNN99596.1 tyrosine integrase [Mycobacterium phage Hlubikazi]	QNN99596.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNN99043.1	QNN99043.1 tyrosine integrase [Mycobacterium phage Mandlovu]	QNN99043.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ91126.1	QGJ91126.1 tyrosine integrase [Mycobacterium phage Strokeseat]	QGJ91126.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEJ93126.1	AEJ93126.1 integrase [Mycobacterium phage Mutaforma13]	AEJ93126.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WRQ08543.1	WRQ08543.1 integrase [Mycobacterium phage mcgavigan]	WRQ08543.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WGL39656.1	WGL39656.1 integrase [Aeromonas phage P05B]	WGL39656.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEK08585.1	AEK08585.1 integrase [Mycobacterium phage DLane]	AEK08585.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UXE03929.1	UXE03929.1 tyrosine integrase [Mycobacterium phage Phalconet]	UXE03929.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWN04964.1	AWN04964.1 integrase [Mycobacterium phage Byougenkin]	AWN04964.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07694.1	QBX07694.1 integrase/recombinase [Streptococcus satellite phage Javan167]	QBX07694.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIW02433.1	AIW02433.1 integrase [Mycobacterium phage CaptainTrips]	AIW02433.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGH78828.1	QGH78828.1 tyrosine integrase [Mycobacterium phage MinionDave]	QGH78828.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07526.1	QBX07526.1 integrase/recombinase [Streptococcus satellite phage Javan153]	QBX07526.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIT13077.1	AIT13077.1 integrase [Mycobacterium phage Bipolar]	AIT13077.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QUE26223.1	QUE26223.1 tyrosine integrase [Mycobacterium phage Akhila]	QUE26223.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UAJ16639.1	UAJ16639.1 tyrosine integrase [Mycobacterium phage MilanaBonita]	UAJ16639.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	APC43537.1	APC43537.1 integrase [Mycobacterium phage SuperGrey]	APC43537.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGS82238.1	AGS82238.1 integrase [Mycobacterium phage Bobi]	AGS82238.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMW64461.1	AMW64461.1 integrase (endogenous virus) [Pseudomonas phage phiAH14a]	AMW64461.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UNI73751.1	UNI73751.1 integrase [Klebsiella phage KP12]	UNI73751.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	URC10494.1	URC10494.1 integrase [Escherichia phage vB_EcoM-813R9]	URC10494.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QLF84266.1	QLF84266.1 integrase [Mycobacterium phage Soul22]	QLF84266.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGH79615.1	QGH79615.1 tyrosine integrase [Mycobacterium phage Minnie]	QGH79615.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QNN98878.1	QNN98878.1 tyrosine integrase [Mycobacterium phage Mova]	QNN98878.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNO25781.1	WNO25781.1 tyrosine integrase [Gordonia phage Goib]	WNO25781.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANA85584.1	ANA85584.1 tyrosine integrase [Gordonia phage Vendetta]	ANA85584.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ANA85663.1	ANA85663.1 tyrosine integrase [Gordonia phage Splinter]	ANA85663.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXN54075.1	AXN54075.1 integrase [Pelagibacter phage HTVC109P]	AXN54075.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ90829.1	QGJ90829.1 tyrosine integrase [Mycobacterium phage Donkeykong]	QGJ90829.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WAA20354.1	WAA20354.1 tyrosine integrase [Mycobacterium phage VRedHorse]	WAA20354.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AVO24495.1	AVO24495.1 integrase [Mycobacterium phage Alexphander]	AVO24495.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AVP41699.1	AVP41699.1 integrase [Mycobacterium phage Batiatus]	AVP41699.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QKO02959.1	QKO02959.1 tyrosine integrase [Gordonia phage TZGordon]	QKO02959.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AQY55722.1	AQY55722.1 tyrosine integrase [Gordonia phage DinoDaryn]	AQY55722.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AQY55640.1	AQY55640.1 tyrosine integrase [Gordonia phage Huffy]	AQY55640.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNA14203.1	WNA14203.1 tyrosine-type recombinase [Bacillus phage phi18-2]	WNA14203.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGK88223.1	AGK88223.1 putative intergrase [Mycobacterium phage WIVsmall]	AGK88223.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXQ64100.1	AXQ64100.1 integrase [Mycobacterium phage KristaRAM]	AXQ64100.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWH14444.1	AWH14444.1 integrase [Mycobacterium phage TChen]	AWH14444.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UCR74419.1	UCR74419.1 putative integrase [Mycobacterium phage Saroj]	UCR74419.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UZV39571.1	UZV39571.1 integrase [Mycobacterium phage Ritam007]	UZV39571.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UVG34667.1	UVG34667.1 tyrosine integrase [Mycobacterium phage Rita]	UVG34667.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AQT25855.1	AQT25855.1 putative integrase [Mycobacterium phage SimranZ1]	AQT25855.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AIK69150.1	AIK69150.1 integrase [Mycobacterium phage Hades]	AIK69150.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AEJ93015.1	AEJ93015.1 integrase [Mycobacterium phage Shauna1]	AEJ93015.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX12021.1	QBX12021.1 integrase/recombinase [Streptococcus satellite phage Javan625]	QBX12021.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11920.1	QBX11920.1 integrase/recombinase [Streptococcus satellite phage Javan619]	QBX11920.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX12041.1	QBX12041.1 integrase/recombinase [Streptococcus satellite phage Javan627]	QBX12041.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI77581.1	QBI77581.1 putative transposase [Pseudomonas phage vB_Pae_CF67a]	QBI77581.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI78979.1	QBI78979.1 putative transposase [Pseudomonas phage vB_Pae_BR201a]	QBI78979.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI77451.1	QBI77451.1 putative transposase [Pseudomonas phage vB_Pae_CF55b]	QBI77451.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI77614.1	QBI77614.1 putative transposase [Pseudomonas phage vB_Pae_CF79a]	QBI77614.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI78798.1	QBI78798.1 putative transposase [Pseudomonas phage vB_Pae_BR133a]	QBI78798.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBI77503.1	QBI77503.1 putative transposase [Pseudomonas phage vB_Pae_CF60a]	QBI77503.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBP31523.1	QBP31523.1 integrase [Mycobacterium phage Cornucopia]	QBP31523.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AJA73104.1	AJA73104.1 integrase [Mannheimia phage vB_MhM_1127AP1]	AJA73104.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AMQ66696.1	AMQ66696.1 tyrosine recombinase XerD-like protein [Bacillus phage Mgbh1]	AMQ66696.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARM70493.1	ARM70493.1 hypothetical protein jbd68_31 [Pseudomonas phage JBD68]	ARM70493.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11893.1	QBX11893.1 integrase/recombinase [Streptococcus satellite phage Javan615]	QBX11893.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ABD90651.1	ABD90651.1 integrase [Mannheimia phage phiMhaA1-BAA410]	ABD90651.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ABD90601.1	ABD90601.1 integrase [Mannheimia phage PHL101]	ABD90601.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AJA73156.1	AJA73156.1 integrase [Mannheimia phage vB_MhM_2256AP1]	AJA73156.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AJA72924.1	AJA72924.1 integrase [Mannheimia phage vB_MhM_535AP1]	AJA72924.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AJA72975.1	AJA72975.1 integrase [Mannheimia phage vB_MhM_587AP1]	AJA72975.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AFL46500.1	AFL46500.1 integrase [Mannheimia phage vB_MhM_1152AP]	AFL46500.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WWE31743.1	WWE31743.1 integrase [Pseudomonas phage 62-2]	WWE31743.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGK86518.1	AGK86518.1 integrase [Synechococcus phage S-CBP1]	AGK86518.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWY03268.1	AWY03268.1 integrase [Pasteurella phage Pm86]	AWY03268.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WWY66217.1	WWY66217.1 putative integrase [Burkholderia phage vB_HM795]	WWY66217.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11876.1	QBX11876.1 integrase/recombinase [Streptococcus satellite phage Javan614]	QBX11876.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX12234.1	QBX12234.1 integrase/recombinase [Streptococcus satellite phage Javan651]	QBX12234.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX12262.1	QBX12262.1 integrase/recombinase [Streptococcus satellite phage Javan653]	QBX12262.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11683.1	QBX11683.1 integrase/recombinase [Streptococcus satellite phage Javan600]	QBX11683.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UVD41333.1	UVD41333.1 site-specific integrase [Pseudomonas phage vB_Pae_HB2107-3I]	UVD41333.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AAX44192.1	AAX44192.1 phage-related integrase [Prochlorococcus phage P-SSP7]	AAX44192.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ACY76217.1	ACY76217.1 conserved hypothetical protein [Tiamatvirus PSSP7]	ACY76217.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11443.1	QBX11443.1 integrase/recombinase [Streptococcus satellite phage Javan574]	QBX11443.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARB15663.1	ARB15663.1 integrase [Klebsiella phage 3LV2017]	ARB15663.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QTZ82856.1	QTZ82856.1 integrase [Clostridium phage phiCp-B]	QTZ82856.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX08266.1	QBX08266.1 integrase/recombinase [Streptococcus satellite phage Javan24]	QBX08266.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07150.1	QBX07150.1 integrase/recombinase [Streptococcus satellite phage Javan12]	QBX07150.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX10324.1	QBX10324.1 integrase/recombinase [Streptococcus satellite phage Javan43]	QBX10324.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX13557.1	QBX13557.1 integrase/recombinase [Streptococcus satellite phage Javan9]	QBX13557.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07281.1	QBX07281.1 integrase/recombinase [Streptococcus satellite phage Javan13]	QBX07281.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX08112.1	QBX08112.1 integrase/recombinase [Streptococcus satellite phage Javan22]	QBX08112.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX08503.1	QBX08503.1 integrase/recombinase [Streptococcus satellite phage Javan27]	QBX08503.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11992.1	QBX11992.1 integrase/recombinase [Streptococcus satellite phage Javan622]	QBX11992.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QPD06429.1	QPD06429.1 integrase [Synechococcus phage S-SRP01]	QPD06429.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASR86783.1	ASR86783.1 tyrosine integrase [Mycobacterium phage Findley]	ASR86783.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AJA43716.1	AJA43716.1 tyrosine integrase [Mycobacterium phage Milly]	AJA43716.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASR86587.1	ASR86587.1 tyrosine integrase [Mycobacterium phage DismalFunk]	ASR86587.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHY26867.1	AHY26867.1 tyrosine integrase [Mycobacterium phage ZoeJ]	AHY26867.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AOZ64382.1	AOZ64382.1 tyrosine integrase [Mycobacterium phage Marcoliusprime]	AOZ64382.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYB68998.1	AYB68998.1 tyrosine integrase [Mycobacterium phage DismalStressor]	AYB68998.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AYN57217.1	AYN57217.1 tyrosine integrase [Mycobacterium phage BoostSeason]	AYN57217.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALF00478.1	ALF00478.1 tyrosine integrase [Mycobacterium phage Mufasa]	ALF00478.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	VUF53859.1	VUF53859.1 Phage integrase [Escherichia phage ESSI2_ev129]	VUF53859.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	VUF53809.1	VUF53809.1 Phage integrase [Escherichia phage ESSI2_ev040]	VUF53809.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WAX24374.1	WAX24374.1 site-specific integrase [Bradyrhizobium phage ppBeUSDA76-2]	WAX24374.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	VUF53771.1	VUF53771.1 Phage integrase, site-specific tyrosine recombinase [Escherichia phage ESSI2_ev015]	VUF53771.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WVW37919.1	WVW37919.1 tyrosine-type recombinase/integrase [Pseudomonas phage PfAC20]	WVW37919.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AII27753.1	AII27753.1 integrase (endogenous virus) [Sinorhizobium phage phiLM21]	AII27753.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WKV23985.1	WKV23985.1 integrase [Pseudomonas phage PaBSM-2607-JFK]	WKV23985.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07485.1	QBX07485.1 integrase/recombinase [Streptococcus satellite phage Javan15]	QBX07485.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNA15521.1	WNA15521.1 hypothetical protein [Acinetobacter phage HFM1]	WNA15521.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX10875.1	QBX10875.1 integrase/recombinase [Streptococcus satellite phage Javan50]	QBX10875.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGK86584.1	AGK86584.1 integrase [Synechococcus phage S-CBP3]	AGK86584.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07802.1	QBX07802.1 integrase/recombinase [Streptococcus satellite phage Javan19]	QBX07802.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX07761.1	QBX07761.1 integrase/recombinase [Streptococcus satellite phage Javan175]	QBX07761.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGR47573.2	AGR47573.2 integrase [Brevibacillus phage Davies]	AGR47573.2	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGR47480.2	AGR47480.2 integrase [Brevibacillus phage Abouo]	AGR47480.2	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11044.1	QBX11044.1 integrase/recombinase [Streptococcus satellite phage Javan537]	QBX11044.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WOZ57214.1	WOZ57214.1 DUF3596 domain-containing protein [Citrobacter phage phiNP]	WOZ57214.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AHB79575.1	AHB79575.1 tyrosine integrase [Mycobacterium phage Validus]	AHB79575.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WVW75614.1	WVW75614.1 tyrosine-type recombinase/integrase [Pseudomonas phage PfAC11]	WVW75614.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WWE31771.1	WWE31771.1 integrase [Pseudomonas phage 99-2]	WWE31771.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WQZ01470.1	WQZ01470.1 tyrosine-type recombinase/integrase [Pseudomonas phage PfAC02a]	WQZ01470.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WOZ55637.1	WOZ55637.1 integrase [Roseobacter phage CRP-118]	WOZ55637.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX11511.1	QBX11511.1 integrase [Streptococcus satellite phage Javan586]	QBX11511.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QDB74387.1	QDB74387.1 tyrosine integrase [Gordonia phage EnalisNailo]	QDB74387.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QAY17563.1	QAY17563.1 tyrosine integrase [Gordonia phage Bradissa]	QAY17563.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AZV00689.1	AZV00689.1 tyrosine integrase [Gordonia phage Lilas]	AZV00689.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AXQ51873.1	AXQ51873.1 integrase [Gordonia phage Catfish]	AXQ51873.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WNO27524.1	WNO27524.1 tyrosine integrase [Mycobacterium phage Ageofdapage]	WNO27524.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ARV77533.1	ARV77533.1 integrase [Sinorhizobium phage phiM5]	ARV77533.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ALY08246.1	ALY08246.1 site-specific recombinase [Pseudomonas phage phi3]	ALY08246.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX08984.1	QBX08984.1 integrase/recombinase [Streptococcus satellite phage Javan305]	QBX08984.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QGJ87762.1	QGJ87762.1 tyrosine integrase [Mycobacterium phage Leogania]	QGJ87762.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX13493.1	QBX13493.1 integrase [Streptococcus satellite phage Javan86]	QBX13493.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ADL71130.1	ADL71130.1 tyrosine integrase [Mycobacterium phage Angelica]	ADL71130.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX08717.1	QBX08717.1 integrase/recombinase [Streptococcus satellite phage Javan289]	QBX08717.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AWD90798.1	AWD90798.1 integrase [Burkholderia phage vB_BmuP_KL4]	AWD90798.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UQT01963.1	UQT01963.1 tyrosine integrase [Mycobacterium phage Ganymede]	UQT01963.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ASZ72671.1	ASZ72671.1 tyrosine integrase [Mycobacterium phage Apocalypse]	ASZ72671.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QYW07689.1	QYW07689.1 tyrosine integrase [Mycobacterium phage QuincyRose]	QYW07689.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	ATS92789.1	ATS92789.1 tyrosine integrase [Mycobacterium phage Sulley]	ATS92789.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QFP95518.1	QFP95518.1 tyrosine integrase [Mycobacterium phage GaugeLDP]	QFP95518.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QIG67283.1	QIG67283.1 integrase protein [Rhizobium phage RHph_TM3_3_3]	QIG67283.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	QBX12074.1	QBX12074.1 integrase/recombinase [Streptococcus satellite phage Javan631]	QBX12074.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	WEW73689.1	WEW73689.1 integrase [Mycobacterium phage Nanz197]	WEW73689.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	UVD40899.1	UVD40899.1 tyrosine integrase [Mycobacterium phage Kashi_VT1]	UVD40899.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AII28189.1	AII28189.1 integrase [Mycobacterium phage Sparky]	AII28189.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AOY11806.1	AOY11806.1 integrase [Salinivibrio phage SMHB1]	AOY11806.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGK86066.1	AGK86066.1 integrase [Mycobacterium phage Chy5]	AGK86066.1	0
+affe482c-fc09-4c0c-916a-36e5494c3258	AGK85993.1	AGK85993.1 integrase [Mycobacterium phage Chy4]	AGK85993.1	0
+f4fdd0f1-1be2-443d-a00c-dac23834b595	UNY41764.1	UNY41764.1 hypothetical protein CPT_Milagro_045 [Burkholderia phage Milagro]	UNY41764.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UNY41765.1	UNY41765.1 hypothetical protein CPT_Milagro_046 [Burkholderia phage Milagro]	UNY41765.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QCW22218.1	QCW22218.1 metalloprotease [Gordonia phage WelcomeAyanna]	QCW22218.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QDF17794.1	QDF17794.1 metalloprotease [Gordonia phage ThankyouJordi]	QDF17794.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	WMT83755.1	WMT83755.1 antirepressor [Pseudoalteromonas phage proACA1-A]	WMT83755.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	WMT83703.1	WMT83703.1 antirepressor [Pseudoalteromonas phage ACA2]	WMT83703.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	WMT83651.1	WMT83651.1 antirepressor [Pseudoalteromonas phage ACA1]	WMT83651.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QDF16513.1	QDF16513.1 metalloprotease [Gordonia phage Zameen]	QDF16513.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QUE26317.1	QUE26317.1 metalloprotease [Gordonia phage Neobush]	QUE26317.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UYL86404.1	UYL86404.1 IrrE-like protein [Gordonia phage Manasvini]	UYL86404.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QDB74457.1	QDB74457.1 metalloprotease [Gordonia phage Polly]	QDB74457.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QDH48858.1	QDH48858.1 metalloprotease [Gordonia phage Suscepit]	QDH48858.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QUE26139.1	QUE26139.1 metalloprotease [Gordonia phage Trumpet]	QUE26139.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	AZF98771.1	AZF98771.1 metalloprotease [Gordonia phage Maridalia]	AZF98771.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QCW22436.1	QCW22436.1 metalloprotease [Gordonia phage Tayonia]	QCW22436.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UXE04836.1	UXE04836.1 metalloprotease [Gordonia phage Eudoria]	UXE04836.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QCG77451.1	QCG77451.1 metalloprotease [Gordonia phage Antonio]	QCG77451.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	AMS03345.1	AMS03345.1 hypothetical protein SEA_KITA_32 [Gordonia phage Kita]	AMS03345.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	WFG40938.1	WFG40938.1 hypothetical protein KANBJGNJ_00003 [Salmonella phage MET_P1_103_31]	WFG40938.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	USM11602.1	USM11602.1 ImmA/IrrE family metallo-endopeptidase [Burkholderia phage Carl1]	USM11602.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	CAG9593845.1	CAG9593845.1 hypothetical protein P2DC1_00041 [Peduovirus P2]	CAG9593845.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	BAE47822.1	BAE47822.1 conserved hypothetical phage-related protein [Clostridium phage c-st]	BAE47822.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	URC10639.1	URC10639.1 ImmA/IrrE family metallo-endopeptidase [Escherichia phage vB_EcoM-705R4]	URC10639.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QJT71661.1	QJT71661.1 ImmA/IrrE family metallo-endopeptidase [Psychrobacillus phage Spoks]	QJT71661.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	AAN12593.1	AAN12593.1 hypothetical protein PBI_CHE9C_32 [Mycobacterium phage Che9c]	AAN12593.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	ABE99503.1	ABE99503.1 DUF955 [Clostridioides phage phiC2]	ABE99503.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	ANT45104.1	ANT45104.1 hypothetical protein CDHM9_36 [Clostridium phage CDKM9]	ANT45104.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	CDW17225.1	CDW17225.1 conserved hypothetical protein [Clostridium phage phiCDHM19]	CDW17225.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	ACH91329.1	ACH91329.1 hypothetical protein [Clostridioides phage phiCD27]	ACH91329.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QLF84843.1	QLF84843.1 helix-turn-helix DNA binding domain protein [Gordonia phage BBQValindra]	QLF84843.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	AZF93610.1	AZF93610.1 LamD-like [Gordonia phage Eyes]	AZF93610.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UAJ16284.1	UAJ16284.1 helix-turn-helix DNA binding domain protein [Gordonia phage Hortense]	UAJ16284.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	ALY07668.1	ALY07668.1 helix-turn-helix DNA binding protein [Gordonia phage Howe]	ALY07668.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QDF16814.1	QDF16814.1 helix-turn-helix DNA binding protein [Gordonia phage Twinkle]	QDF16814.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QYC54434.1	QYC54434.1 helix-turn-helix DNA binding domain protein [Gordonia phage Shlim410]	QYC54434.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QST89216.1	QST89216.1 MerR-like helix-turn-helix DNA binding protein [Mycobacterium phage prophiGD44-1]	QST89216.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QVW56777.1	QVW56777.1 putative cI-like repressor protein [Clostridioides phage phiCD418]	QVW56777.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UYL93292.1	UYL93292.1 helix-turn-helix domain protein [Paenibacillus phage Dash]	UYL93292.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	UYL93216.1	UYL93216.1 helix-turn-helix domain protein [Paenibacillus phage Callan]	UYL93216.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	QBX16370.1	QBX16370.1 hypothetical protein Javan249_0004 [Streptococcus phage Javan249]	QBX16370.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	ACH91363.1	ACH91363.1 putative phage DNA-binding protein [Clostridioides phage phiCD27]	ACH91363.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	WEU68051.1	WEU68051.1 XRE family transcriptional regulator [Acinetobacter phage vB_AbaM_ABMM1]	WEU68051.1	0
+20f72738-5faa-4f55-b287-bf7512b5fc2e	CAH1234852.1	CAH1234852.1 ImmA/IrrE metallo-endopeptidase [Escherichia phage Tritos]	CAH1234852.1	0
+4ea2cd7e-d116-46d6-8ac5-498c60d3255a	UNY41766.1	UNY41766.1 endonuclease [Burkholderia phage Milagro]	UNY41766.1	0
+4ea2cd7e-d116-46d6-8ac5-498c60d3255a	AEY69542.1	AEY69542.1 Vsr endonuclease [Burkholderia phage vB_BceS_AH2]	AEY69542.1	0
+4ea2cd7e-d116-46d6-8ac5-498c60d3255a	ADP02339.1	ADP02339.1 gp46 [Burkholderia phage KL3]	ADP02339.1	0
+4ea2cd7e-d116-46d6-8ac5-498c60d3255a	UNY41825.1	UNY41825.1 DNA mismatch endonuclease [Burkholderia phage Menos]	UNY41825.1	0
+4ea2cd7e-d116-46d6-8ac5-498c60d3255a	AHB80354.1	AHB80354.1 Very-short-patch mismatch repair endonuclease [Oenococcus phage phiS11]	AHB80354.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UNY41767.1	UNY41767.1 DNA methylase [Burkholderia phage Milagro]	UNY41767.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX25475.1	WAX25475.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage YS162]	WAX25475.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AND75555.1	AND75555.1 DNA-cytosine methyltransferase [Nostoc phage N1]	AND75555.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAA56493.1	CAA56493.1 type II DNA-methyltransferase [Bacillus phage phi3T]	CAA56493.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNN96733.1	QNN96733.1 DNA-cytosine methyltransferase [Bacillus phage phi3Ts]	QNN96733.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNR51637.1	QNR51637.1 DNA-cytosine methyltransferase [Bacillus phage Hyb1phi3Ts-SPbeta]	QNR51637.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNN96918.1	QNN96918.1 DNA-cytosine methyltransferase [Bacillus phage Hyb2phi3Ts-SPbeta]	QNN96918.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNN97104.1	QNN97104.1 DNA-cytosine methyltransferase [Bacillus phage Hyb3phi3Ts-SPbeta]	QNN97104.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD21292.1	APD21292.1 site-specific DNA methylase [Bacillus phage phi3T]	APD21292.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ABU96847.1	ABU96847.1 C5 cytosine-specific DNA methylase [Thermus phage P23-45]	ABU96847.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ABU96964.1	ABU96964.1 C5 cytosine-specific DNA methylase [Thermus phage P74-26]	ABU96964.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYB98460.1	UYB98460.1 hypothetical protein [Thermus phage P23-45]	UYB98460.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AFU62910.1	AFU62910.1 site specific DNA modification methylase Dcm [Acidithiobacillus phage AcaML1]	AFU62910.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AND75652.1	AND75652.1 DNA-cytosine methyltransferase [Nostoc phage A1]	AND75652.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAT72355.1	AAT72355.1 C-5 cytosine-specific DNA methylase [Streptococcus phage phi1207.3]	AAT72355.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJD49536.1	QJD49536.1 type II restriction-modification system modification protein [Streptococcus phage phi29961]	QJD49536.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QKN61630.1	QKN61630.1 type II restriction-modification system modification protein [Streptococcus phage phi29862]	QKN61630.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJD49473.1	QJD49473.1 type II restriction-modification system modification protein [Streptococcus phage phi29854]	QJD49473.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85233.1	QGJ85233.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SgaBSJ27_rum]	QGJ85233.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85344.1	QGJ85344.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SgaBSJ31_rum]	QGJ85344.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QLF85055.1	QLF85055.1 cytosine-specific methyltransferase [Nostoc phage YongM]	QLF85055.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNA14251.1	WNA14251.1 DNA cytosine methyltransferase [Bacillus phage phi18-2]	WNA14251.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ATW59271.1	ATW59271.1 C-5 cytosine-specific DNA methyltransferase [Aphanizomenon phage vB_AphaS-CL131]	ATW59271.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WVW37905.1	WVW37905.1 cytosine-specific methyltransferase [Pseudomonas phage PfAC20]	WVW37905.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDJ98430.1	QDJ98430.1 hypothetical protein LLFFHNDI_00003 [Escherichia phage vB_EcoM-12474II]	QDJ98430.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDJ98562.1	QDJ98562.1 hypothetical protein OMJLAAIH_00003 [Escherichia phage vB_EcoM-12474V]	QDJ98562.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDJ98518.1	QDJ98518.1 hypothetical protein PBINGOGM_00003 [Escherichia phage vB_EcoM-12474IV]	QDJ98518.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDJ98477.1	QDJ98477.1 hypothetical protein BBAMJIOM_00006 [Escherichia phage vB_EcoM-12474III]	QDJ98477.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAG9593764.1	CAG9593764.1 Modification methylase BspRI [Peduovirus P2]	CAG9593764.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAN28260.1	AAN28260.1 Mth [Escherichia phage Wphi]	AAN28260.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX25277.1	QBX25277.1 DNA-cytosine methyltransferase [Streptococcus phage Javan246]	QBX25277.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QRI43997.1	QRI43997.1 DNA-cytosine methyltransferase [Mycoplasma phage sp.]	QRI43997.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV97269.1	QVV97269.1 hypothetical protein 1992IndM4_0485 [Vibrio phage ICP1]	QVV97269.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYJ73871.1	AYJ73871.1 putative cytosine-specific methyltransferase [Thermus phage phiLo]	AYJ73871.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYJ73871.1	AYJ73871.1 putative cytosine-specific methyltransferase [Thermus phage phiLo]	AYJ73871.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXN53393.1	AXN53393.1 hypothetical protein Drs3_00012 [Methanobacterium virus Drs3]	AXN53393.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UIB81217.1	UIB81217.1 C-5 cytosine-specific DNA methylase [Flyfo myovirus Tbat2_7]	UIB81217.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGM11533.1	AGM11533.1 AdoMet-MTase [Halogranum tailed virus 1]	AGM11533.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UBF23032.1	UBF23032.1 C5-cytosine methyltransferase [Haloarcula virus HCTV-16]	UBF23032.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WCS66361.1	WCS66361.1 DNA (cytosine-5-)-methyltransferase [Riemerella phage vB_RanS_CRP5]	WCS66361.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WOZ56218.1	WOZ56218.1 cytosine specific methyltransferase [Brochothrix phage BtpYZU03]	WOZ56218.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QPL14152.1	QPL14152.1 methyltransferase [Streptomyces phage TurkishDelight]	QPL14152.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBU87817.1	WBU87817.1 DNA-cytosine methyltransferase [Brochothrix phage BtpYZU01]	WBU87817.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKI27362.1	AKI27362.1 hypothetical protein [Moraxella phage Mcat8]	AKI27362.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUR91445.1	AUR91445.1 C-5 cytosine-specific DNA methylase [Vibrio phage 1.161.O._10N.261.48.C5]	AUR91445.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QWT28879.1	QWT28879.1 DNA methyltransferase [Microbacterium phage vB_MoxS-R1]	QWT28879.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AMQ66558.1	AMQ66558.1 DNA-cytosine methyltransferase-like protein [Bacillus phage Shbh1]	AMQ66558.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WGL32758.1	WGL32758.1 DNA cytosine methyltransferase [Streptococcus phage phiKSM96]	WGL32758.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX17307.1	QBX17307.1 DNA-cytosine methyltransferase [Streptococcus phage Javan349]	QBX17307.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27011.1	QBX27011.1 DNA-cytosine methyltransferase [Streptococcus phage Javan362]	QBX27011.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD24220.1	APD24220.1 type II DNA modification methyltransferase [Streptococcus phage IPP62]	APD24220.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD23914.1	APD23914.1 type II DNA modification methyltransferase [Streptococcus phage IPP55]	APD23914.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD22681.1	APD22681.1 type II DNA modification methyltransferase [Streptococcus phage IPP29]	APD22681.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD22737.1	APD22737.1 type II DNA modification methyltransferase [Streptococcus phage IPP30]	APD22737.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD22100.1	APD22100.1 type II DNA modification methyltransferase [Streptococcus phage IPP18]	APD22100.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27231.1	QBX27231.1 DNA-cytosine methyltransferase [Streptococcus phage Javan374]	QBX27231.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UZO33359.1	UZO33359.1 hypothetical protein KEKKGBKC_00089 [Klebsiella phage pR7_1]	UZO33359.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UUG67250.1	UUG67250.1 methyltransferase [Klebsiella phage PSKm4DII]	UUG67250.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD24335.1	APD24335.1 DNA methylase [Streptococcus phage IPP64]	APD24335.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX31470.1	QBX31470.1 DNA-cytosine methyltransferase [Streptococcus phage Javan64]	QBX31470.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CBW39159.1	CBW39159.1 Cytosine-specific DNA methyltransferase [Streptococcus phage 11865]	CBW39159.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDB71453.1	QDB71453.1 DNA (cytosine-5)-methyltransferase [Microcystis phage Mic1]	QDB71453.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD21781.1	APD21781.1 type II DNA modification methyltransferase [Streptococcus phage IPP11]	APD21781.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAA7537748.1	CAA7537748.1 cytosine-specific methyltransferase [Klebsiella phage vB_KpnM_05F]	CAA7537748.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA46831.1	ALA46831.1 DNA_methylase domain protein [Streptococcus phage phiARI0923]	ALA46831.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ACR45907.1	ACR45907.1 putative DNA methylase [Streptococcus phage 5093]	ACR45907.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URQ04375.1	URQ04375.1 DNA methyltransferase [Klebsiella phage BL02]	URQ04375.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UJP30811.1	UJP30811.1 hypothetical protein phKl35c1_184 [Klebsiella phage Kpn35c1]	UJP30811.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WWS23460.1	WWS23460.1 hypothetical protein IJMDGFEA_00071 [Klebsiella phage KP5]	WWS23460.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ20809.1	WPJ20809.1 hypothetical protein OOGAAMIP_00051 [Klebsiella phage Kp11_Ajakkala-2023]	WPJ20809.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ47437.1	WPJ47437.1 hypothetical protein RCIP0002_00189 [Klebsiella phage RCIP0002]	WPJ47437.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ47906.1	WPJ47906.1 hypothetical protein RCIP0006_00189 [Klebsiella phage RCIP0006]	WPJ47906.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA45229.1	ALA45229.1 cytosine-specific methyltransferase [Enterobacter phage phiEap-3]	ALA45229.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UXD79452.1	UXD79452.1 IS1595 family transposase [Klebsiella phage 150040]	UXD79452.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKU44427.1	AKU44427.1 DNA methyltransferase [Klebsiella phage Matisse]	AKU44427.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QWY13835.1	QWY13835.1 cytosine-specific DNA methyltransferase [Klebsiella phage vB_KpnM_VAC13]	QWY13835.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WKC55720.1	WKC55720.1 hypothetical protein R41_273 [Klebsiella phage R4_1]	WKC55720.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WDQ26399.1	WDQ26399.1 hypothetical protein phiKPNS3_00133 [Klebsiella phage phi_KPN_S3]	WDQ26399.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WKC55018.1	WKC55018.1 hypothetical protein R61_127 [Klebsiella phage R6_1]	WKC55018.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QIW86220.1	QIW86220.1 DNA methyltransferase [Klebsiella phage P-KP2]	QIW86220.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD22204.1	APD22204.1 type II DNA modification methyltransferase [Streptococcus phage IPP20]	APD22204.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UJH95028.1	UJH95028.1 IS1595 family transposase [Streptococcus phage MismyG]	UJH95028.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD23861.1	APD23861.1 type II DNA modification methyltransferase [Streptococcus phage IPP54]	APD23861.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARQ94572.1	ARQ94572.1 DNA (cytosine-5-)-methyltransferase [Weissella phage PWc]	ARQ94572.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BCG66335.1	BCG66335.1 DNA (cytosine-5-)-methyltransferase [Staphylococcus phage vB_SsapH-Golestan101-M]	BCG66335.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QRG24192.1	QRG24192.1 DNA cytosine methyltransferase [Haloferax virus Halfgib1]	QRG24192.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QRG24192.1	QRG24192.1 DNA cytosine methyltransferase [Haloferax virus Halfgib1]	QRG24192.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ49890.1	WPJ49890.1 hypothetical protein RCIP0021_00191 [Klebsiella phage RCIP0021]	WPJ49890.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ49618.1	WPJ49618.1 hypothetical protein RCIP0020_00191 [Klebsiella phage RCIP0020]	WPJ49618.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX17096.1	QBX17096.1 DNA-cytosine methyltransferase [Streptococcus phage Javan33]	QBX17096.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX31077.1	QBX31077.1 DNA-cytosine methyltransferase [Streptococcus phage Javan6]	QBX31077.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX25127.1	QBX25127.1 DNA-cytosine methyltransferase [Streptococcus phage Javan240]	QBX25127.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD23752.1	APD23752.1 type II DNA modification methyltransferase [Streptococcus phage IPP52]	APD23752.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH85071.1	BEH85071.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_9]	BEH85071.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH83895.1	BEH83895.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_3]	BEH83895.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH86496.1	BEH86496.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_15]	BEH86496.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH84293.1	BEH84293.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_5]	BEH84293.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH88847.1	BEH88847.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_23]	BEH88847.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QEG10625.1	QEG10625.1 cytosine-specific methyltransferase [Klebsiella phage KMI9]	QEG10625.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH87074.1	BEH87074.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_17]	BEH87074.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH86800.1	BEH86800.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_16]	BEH86800.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH84712.1	BEH84712.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_8]	BEH84712.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH87348.1	BEH87348.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_18]	BEH87348.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ48536.1	WPJ48536.1 hypothetical protein RCIP0009_00193 [Klebsiella phage RCIP0009]	WPJ48536.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH89294.1	BEH89294.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_26]	BEH89294.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH85517.1	BEH85517.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_11]	BEH85517.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	SCO64701.1	SCO64701.1 DNA-cytosine methyltransferase [Klebsiella phage PMBT1]	SCO64701.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AEX26604.1	AEX26604.1 cytosine-specific methyltransferase [Klebsiella phage KP27]	AEX26604.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ48259.1	WPJ48259.1 hypothetical protein RCIP0008_00192 [Klebsiella phage RCIP0008]	WPJ48259.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH86052.1	BEH86052.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_13]	BEH86052.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH83500.1	BEH83500.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_1]	BEH83500.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPJ52712.1	WPJ52712.1 hypothetical protein RCIP0052_00194 [Klebsiella phage RCIP0052]	WPJ52712.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH84016.1	BEH84016.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_4]	BEH84016.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WVX87251.1	WVX87251.1 DNA methyltransferase [Klebsiella phage KP1LMA]	WVX87251.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UUG66979.1	UUG66979.1 methyltransferase [Klebsiella phage PSKm2DI]	UUG66979.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UJP30547.1	UJP30547.1 cytosine-specific methyltransferase [Raoultella phage Rpl1]	UJP30547.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH85867.1	BEH85867.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_12]	BEH85867.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH87774.1	BEH87774.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_20]	BEH87774.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEH87592.1	BEH87592.1 DNA cytosine methyltransferase [Klebsiella phage phiKp_19]	BEH87592.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21218.1	QBX21218.1 DNA-cytosine methyltransferase [Streptococcus phage Javan565]	QBX21218.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA47620.1	ALA47620.1 DNA_methylase domain protein [Streptococcus phage phiARI0639b]	ALA47620.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AOQ27413.1	AOQ27413.1 C5 cytosine methyltransferase [Streptococcus phage SpGS-1]	AOQ27413.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD21879.1	APD21879.1 type II DNA modification methyltransferase [Streptococcus phage IPP14]	APD21879.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALH47370.1	ALH47370.1 DNA_methylase domain protein [Streptococcus phage phiARI0378]	ALH47370.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA47218.1	ALA47218.1 DNA_methylase domain protein [Streptococcus phage phiARI0285-3]	ALA47218.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QTJ24291.1	QTJ24291.1 putative DNA-methyltransferase [Enterobacter phage PF-CE2]	QTJ24291.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD22259.1	APD22259.1 type II DNA modification methyltransferase [Streptococcus phage IPP21]	APD22259.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGS82053.1	AGS82053.1 DNA cytosine methylase [Pseudomonas phage PaBG]	AGS82053.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WOL25277.1	WOL25277.1 DNA methyltransferase [Klebsiella phage iPHaGe-KPN-12i]	WOL25277.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AFC22226.1	AFC22226.1 putative DNA-methyltransferase, type II restriction-modification system [Cronobacter phage vB_CsaM_GAP161]	AFC22226.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URP86416.1	URP86416.1 DNA-cytosine methyltransferase [Enterobacter phage EC-F2]	URP86416.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD23591.1	APD23591.1 type II DNA modification methyltransferase [Streptococcus phage IPP48]	APD23591.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APD23806.1	APD23806.1 type II DNA modification methyltransferase [Streptococcus phage IPP53]	APD23806.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAM88754.1	AAM88754.1 putative C5-cytosine methyltransferase [Natrialba phage PhiCh1]	AAM88754.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBJ01257.1	QBJ01257.1 putative C5-cytosine methyltransferase [Natrialba phage PhiCh1]	QBJ01257.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URP86143.1	URP86143.1 DNA-cytosine methyltransferase [Enterobacter phage EC-F1]	URP86143.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAZ82425.1	AAZ82425.1 C5 methyltransferase alpha subunit [Streptococcus phage MM1 1998]	AAZ82425.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAC48079.1	CAC48079.1 putative DNA methylase [Streptococcus phage MM1]	CAC48079.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26196.1	QBX26196.1 DNA-cytosine methyltransferase [Streptococcus phage Javan308]	QBX26196.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WYM31174.1	WYM31174.1 cytosine-specific methyltransferase [Citrobacter phage Citrof4]	WYM31174.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UPW35544.1	UPW35544.1 DNA-cytosine methyltransferase [Cronobacter phage Dev_CS701]	UPW35544.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WOL25437.1	WOL25437.1 DNA methyltransferase [Klebsiella phage iPHaGe-KPN-11i]	WOL25437.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URP85593.1	URP85593.1 DNA-cytosine methyltransferase [Enterobacter phage EC-W1]	URP85593.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WFD55515.1	WFD55515.1 DNA-cytosine methyltransferase [Enterobacter phage phi5]	WFD55515.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJI53170.1	QJI53170.1 DNA-cytosine methyltransferase [Enterobacter phage EBPL]	QJI53170.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WWO62836.1	WWO62836.1 DNA-cytosine methyltransferase [Enterobacter phage HK6]	WWO62836.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX31826.1	QBX31826.1 DNA-cytosine methyltransferase [Streptococcus phage Javan78]	QBX31826.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX22460.1	QBX22460.1 DNA-cytosine methyltransferase [Streptococcus phage Javan83]	QBX22460.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA46871.1	ALA46871.1 DNA_methylase domain protein [Streptococcus phage phiARI0746]	ALA46871.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANM47459.1	ANM47459.1 DNA-cytosine methyltransferase [Streptococcus phage phiJH1301-1]	ANM47459.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AIX12947.1	AIX12947.1 C-5 cytosine-specific DNA methylase [Streptococcus phage SpSL1]	AIX12947.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CCK73975.1	CCK73975.1 protein of unknown function [Pseudotevenvirus RB43]	CCK73975.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAX78649.1	AAX78649.1 hypothetical protein RB43ORF127c [Escherichia phage RB43]	AAX78649.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CCL97592.1	CCL97592.1 protein of unknown function [Pseudotevenvirus RB43]	CCL97592.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAW44673.1	WAW44673.1 DNA-cytosine methyltransferase [Klebsiella phage Kp_GWPR59]	WAW44673.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QUL77053.1	QUL77053.1 cytosine-specific methyltransferase [Escherichia phage UPEC03]	QUL77053.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AOG16254.1	AOG16254.1 DNA-methyltransferase type II restriction modification system [Cronobacter phage vB_CsaM_leB]	AOG16254.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX12728.1	WAX12728.1 methyltransferase [Enterococcus phage EC99P2]	WAX12728.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BCM29446.1	BCM29446.1 cytosine-specific methyltransferase [Enterobacter phage vB_EkoM5VN]	BCM29446.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYJ72988.1	AYJ72988.1 modification methylase [Citrobacter phage Maroon]	AYJ72988.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALF01817.1	ALF01817.1 cytosine methyltransferase [Citrobacter phage Margaery]	ALF01817.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	USL89300.1	USL89300.1 DNA (cytosine-5-)-methyltransferase [Bacillus phage vB_BceH_LY2]	USL89300.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86093.1	QGJ86093.1 modification methylase, partial [Streptococcus phage phi-SsuHCJ3_rum]	QGJ86093.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85285.1	QGJ85285.1 modification methylase [Streptococcus phage phi-SgaBSJ27_rum]	QGJ85285.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85396.1	QGJ85396.1 modification methylase [Streptococcus phage phi-SgaBSJ31_rum]	QGJ85396.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UGO54586.1	UGO54586.1 putative DNA-methyltransferase [Cronobacter phage vB_CsaD_Banach]	UGO54586.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21501.1	QBX21501.1 DNA-cytosine methyltransferase [Streptococcus phage Javan577]	QBX21501.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26617.1	QBX26617.1 DNA-cytosine methyltransferase [Streptococcus phage Javan336]	QBX26617.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ADP02340.1	ADP02340.1 gp47 [Burkholderia phage KL3]	ADP02340.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URP85875.1	URP85875.1 DNA-cytosine methyltransferase [Enterobacter phage EC-W2]	URP85875.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX30952.1	QBX30952.1 DNA-cytosine methyltransferase [Streptococcus phage Javan584]	QBX30952.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJI10743.1	QJI10743.1 putative cytosine-specific methyltransferase [Buttiauxella phage vB_ButM_GuL6]	QJI10743.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVQ57093.1	QVQ57093.1 methyltransferase [Anabaena phage Elbi]	QVQ57093.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAA32604.1	AAA32604.1 DNA methyltransferase [Bacillus phage SPR]	AAA32604.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UNY48682.1	UNY48682.1 DNA-cytosine methyltransferase [Bacillus phage SPR]	UNY48682.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WIT27736.1	WIT27736.1 hypothetical protein [Bacillus phage SPbetaL5]	WIT27736.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WIT28105.1	WIT28105.1 hypothetical protein [Bacillus phage SPbetaL7]	WIT28105.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WIT27922.1	WIT27922.1 hypothetical protein [Bacillus phage SPbetaL6]	WIT27922.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARU13199.1	ARU13199.1 DNA methyltransferase [Streptococcus phage P0095]	ARU13199.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ADJ55423.1	ADJ55423.1 putative DNA-methyltransferase, type II restriction-modification system [Escherichia phage RB16]	ADJ55423.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARU13145.1	ARU13145.1 DNA methyltransferase [Streptococcus phage P0094]	ARU13145.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AZS06237.1	AZS06237.1 DNA-cytosine methyltransferase [Streptococcus phage CHPC1282]	AZS06237.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AZF92031.1	AZF92031.1 DNA-cytosine methyltransferase [Streptococcus phage CHPC1148]	AZF92031.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF53561.1	AXF53561.1 DNA cytosine methyltransferase [Streptococcus phage 94]	AXF53561.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF53786.1	AXF53786.1 DNA cytosine methyltransferase [Streptococcus phage pST]	AXF53786.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARU12997.1	ARU12997.1 DNA methyltransferase [Streptococcus phage P0091]	ARU12997.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARU13098.1	ARU13098.1 DNA methyltransferase [Streptococcus phage P0093]	ARU13098.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ARU13046.1	ARU13046.1 DNA methyltransferase [Streptococcus phage P0092]	ARU13046.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APC45910.1	APC45910.1 DNA-cytosine methyltransferase [Streptococcus phage CHPC1151]	APC45910.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AOG16535.1	AOG16535.1 putative DNA-methyltransferase [Cronobacter phage vB_CsaM_leN]	AOG16535.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX17057.1	QBX17057.1 DNA-cytosine methyltransferase [Streptococcus phage Javan311]	QBX17057.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAM83053.1	AAM83053.1 putative methylase [Lactococcus phage 4268]	AAM83053.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QIW90024.1	QIW90024.1 DNA (cytosine-5-)-methyltransferase [Yersinia phage P37]	QIW90024.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANS05975.1	ANS05975.1 methyltransferase [Citrobacter phage vB_CfrM_CfP1]	ANS05975.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AIK68065.1	AIK68065.1 methyltransferase [Citrobacter phage Miller]	AIK68065.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WIT27176.1	WIT27176.1 hypothetical protein [Bacillus phage SPbetaL2]	WIT27176.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WIT27362.1	WIT27362.1 hypothetical protein [Bacillus phage SPbetaL3]	WIT27362.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AHB80353.1	AHB80353.1 DNA-cytosine methyltransferase [Oenococcus phage phiS11]	AHB80353.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKR15922.1	AKR15922.1 DNA-cytosine methyltransferase [Citrobacter phage IME-CF2]	AKR15922.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAA28869.1	CAA28869.1 unnamed protein product [Bacillus phage rho11s]	CAA28869.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKU44707.1	AKU44707.1 cytosine-specific methyltransferase [Klebsiella phage Miro]	AKU44707.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AZF95169.1	AZF95169.1 methyltransferase [Mycobacterium phage Zerg]	AZF95169.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNO12388.1	QNO12388.1 DNA methylase [Mycobacterium phage Royals2015]	QNO12388.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AVR77239.1	AVR77239.1 hypothetical protein SEA_OWLST2W_71 [Mycobacterium phage OwlsT2W]	AVR77239.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNM65672.1	WNM65672.1 DNA methyltransferase [Mycobacterium phage Rialto]	WNM65672.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QPX73015.1	QPX73015.1 putative DNA methylase [Citrobacter phage vB_Cfr_Xman]	QPX73015.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26355.1	QBX26355.1 DNA-cytosine methyltransferase [Streptococcus phage Javan318]	QBX26355.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AIK69176.1	AIK69176.1 DNA methylase [Mycobacterium phage Hades]	AIK69176.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW22935.1	QCW22935.1 DNA-cytosine methyltransferase [Synechococcus phage S-B05]	QCW22935.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QDH50620.1	QDH50620.1 DNA-cytosine methyltransferase [Synechococcus phage S-B43]	QDH50620.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AON97137.1	AON97137.1 putative DNA-methyltransferase [Cronobacter phage vB_CsaM_leE]	AON97137.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WKC55374.1	WKC55374.1 hypothetical protein R21_208 [Klebsiella phage R2_1]	WKC55374.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QQO91523.1	QQO91523.1 cytosine-specific methyltransferase [Klebsiella phage vB_KpnM_M1]	QQO91523.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNA09083.1	WNA09083.1 IS1595 family transposase [Klebsiella phage P61_1]	WNA09083.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAK6606476.1	CAK6606476.1 DNA methyltransferase [Klebsiella phage vB_Ko_K41P2]	CAK6606476.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UJB55249.1	UJB55249.1 DNA-cytosine methyltransferase [Enterobacter phage vB_EcRAM-01]	UJB55249.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBJ04075.1	QBJ04075.1 DNA cytosine methyltransferase [Fusobacterium phage Fnu1]	QBJ04075.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WGH50354.1	WGH50354.1 putative DNA cytosine methyltransferase [Fusobacterium phage vB_FnuS_FNU3]	WGH50354.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WGH50206.1	WGH50206.1 putative DNA cytosine methyltransferase [Fusobacterium phage vB_FnuS_FNU2]	WGH50206.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QYC51253.1	QYC51253.1 cytosine-specific methyltransferase [Klebsiella phage vB_KpnM-VAC66]	QYC51253.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL05617.1	UYL05617.1 transposase [Klebsiella phage KP13MC5-1]	UYL05617.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANN86382.1	ANN86382.1 DNA-cytosine methyltransferase [Escherichia phage phT4A]	ANN86382.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGO48544.1	AGO48544.1 DNA methylase [Cellulophaga phage phi18:3]	AGO48544.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGF89780.1	AGF89780.1 C-5 cytosine-specific DNA methylase [Streptococcus phage phiD12]	AGF89780.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGF89780.1	AGF89780.1 C-5 cytosine-specific DNA methylase [Streptococcus phage phiD12]	AGF89780.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGT52890.1	QGT52890.1 DNA-cytosine methyltransferase [Lactococcus phage CHPC148]	QGT52890.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAA69959.1	AAA69959.1 5C-DNA methyltransferase [Bacillus phage H2]	AAA69959.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGT52598.1	QGT52598.1 DNA-cytosine methyltransferase [Lactococcus phage CHPC1175]	QGT52598.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUM58908.1	AUM58908.1 transcription regulation protein [Bacillus phage BCP01]	AUM58908.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANY29371.1	ANY29371.1 putative DNA methylase [Bacillus phage PK16]	ANY29371.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QAY06188.1	QAY06188.1 DNA methylase [Mycobacterium phage Cueylyss]	QAY06188.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGJ71531.1	AGJ71531.1 putative DNA-methyltransferase, type II restriction-modification system [Escherichia phage Lw1]	AGJ71531.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAR04663.1	AAR04663.1 putative methylase [Lactobacillus phage Lc-Nu]	AAR04663.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WPH65912.1	WPH65912.1 DNA-cytosine methyltransferase [Lactococcus phage D6867]	WPH65912.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNV47010.1	WNV47010.1 DNA-cytosine methyltransferase [Lactococcus phage D7138]	WNV47010.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNV47077.1	WNV47077.1 DNA-cytosine methyltransferase [Lactococcus phage D7893]	WNV47077.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AEJ93254.1	AEJ93254.1 DNA methylase [Mycobacterium phage ShiLan]	AEJ93254.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UVG34697.1	UVG34697.1 DNA methylase [Mycobacterium phage Rita]	UVG34697.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJI52435.1	QJI52435.1 site-specific DNA-cytosine methylase [Psychrobacillus phage Perkons]	QJI52435.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AHN66609.1	AHN66609.1 C-5 cytosine-specific DNA methylase II [Bacillus phage Bcp1]	AHN66609.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXQ67800.1	AXQ67800.1 DNA cytosine methyltransferase [Bacillus phage Kioshi]	AXQ67800.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AEC53094.1	AEC53094.1 DNA-cytosine methyltransferase [Synechococcus phage S-CRM01]	AEC53094.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19465.1	QVV19465.1 deoxycytosine methyltransferase [Paenibacillus phage Bert]	QVV19465.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19866.1	QVV19866.1 deoxycytosine methyltransferase [Paenibacillus phage Mock2]	QVV19866.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QHB41062.1	QHB41062.1 DNA methyltransferase [Flavobacterium phage vB_FspS_tooticki9-1]	QHB41062.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QHB40997.1	QHB40997.1 DNA methyltransferase [Flavobacterium phage vB_FspS_tooticki6-1]	QHB40997.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBF77087.1	WBF77087.1 hypothetical protein [Lacticaseibacillus phage R9.2]	WBF77087.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV20255.1	QVV20255.1 deoxycytosine methyltransferase [Paenibacillus phage Riker]	QVV20255.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV20051.1	QVV20051.1 deoxycytosine methyltransferase [Paenibacillus phage Norbert]	QVV20051.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19734.1	QVV19734.1 deoxycytosine methyltransferase [Paenibacillus phage Hobie]	QVV19734.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03949.2	AUS03949.2 DNA cytosine methyltransferase [Paenibacillus phage Likha]	AUS03949.2	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV20189.1	QVV20189.1 deoxycytosine methyltransferase [Paenibacillus phage Picard]	QVV20189.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXH45382.1	AXH45382.1 DNA cytosine methyltransferase [Paenibacillus phage DevRi]	AXH45382.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF42295.1	AXF42295.1 DNA cytosine methyltransferase [Paenibacillus phage Gryphonian]	AXF42295.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF40069.1	AXF40069.1 DNA cytosine methyltransferase [Paenibacillus phage Bloom]	AXF40069.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF40428.1	AXF40428.1 DNA cytosine methyltransferase [Paenibacillus phage Genki]	AXF40428.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXH45316.1	AXH45316.1 DNA cytosine methyltransferase [Paenibacillus phage Arcticfreeze]	AXH45316.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF40201.1	AXF40201.1 DNA cytosine methyltransferase [Paenibacillus phage Jacopo]	AXF40201.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVW27413.1	QVW27413.1 methyltransferase [Cronobacter phage JC03]	QVW27413.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ADD81179.1	ADD81179.1 gp74 [Rhodococcus phage ReqiPine5]	ADD81179.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYD83945.1	AYD83945.1 DNA methylase [Gordonia phage Getalong]	AYD83945.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UAW08327.1	UAW08327.1 DNA methylase [Gordonia phage Whitney]	UAW08327.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBF77253.1	WBF77253.1 hypothetical protein [Lacticaseibacillus phage R23.9]	WBF77253.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UVK58536.1	UVK58536.1 DNA methyltransferase [Mycobacterium phage Jarcob]	UVK58536.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93474.1	UYL93474.1 DNA cytosine methyltransferase [Paenibacillus phage vB_PlaS-1/A]	UYL93474.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03878.1	AUS03878.1 DNA-cytosine methyltransferase [Paenibacillus phage Leyra]	AUS03878.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93546.1	UYL93546.1 DNA cytosine methyltransferase [Paenibacillus phage vB_PlaS-2/A]	UYL93546.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93688.1	UYL93688.1 DNA cytosine methyltransferase [Paenibacillus phage vB_PlaS-5/A]	UYL93688.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA12543.1	ALA12543.1 DNA-cytosine methyltransferase [Paenibacillus phage Xenia]	ALA12543.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93617.1	UYL93617.1 DNA cytosine methyltransferase [Paenibacillus phage vB_PlaS-3/A]	UYL93617.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19984.1	QVV19984.1 deoxycytosine methyltransferase [Paenibacillus phage Newport]	QVV19984.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19669.1	QVV19669.1 deoxycytosine methyltransferase [Paenibacillus phage Gohan]	QVV19669.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19601.1	QVV19601.1 deoxycytosine methyltransferase [Paenibacillus phage Fitz]	QVV19601.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK27975.1	AJK27975.1 DNA-cytosine methyltransferase [Paenibacillus phage Shelly]	AJK27975.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVW56770.1	QVW56770.1 DNA cytosine-5-methyltransferase [Clostridioides phage phiCD418]	QVW56770.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CEK40690.1	CEK40690.1 putative phage DNA modification methylase [Clostridium phage phiCD505]	CEK40690.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UGV22945.1	UGV22945.1 DNA-methyltransferase [Cronobacter phage vB_CsaM_Invicta]	UGV22945.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QPX76476.1	QPX76476.1 putative DNA-methyltransferase, type II restriction-modification system [Cronobacter phage vB_CsaM_SemperBestia]	QPX76476.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WVX88630.1	WVX88630.1 DNA methyltransferase [Gordonia phage CheeseTouch]	WVX88630.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBM89939.1	WBM89939.1 hypothetical protein [Lacticaseibacillus phage R9.1]	WBM89939.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANT45134.1	ANT45134.1 DNA-cytosine methyltransferase [Clostridium phage CDKM9]	ANT45134.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03611.1	AUS03611.1 DNA-cytosine methyltransferase [Paenibacillus phage BN12]	AUS03611.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03744.1	AUS03744.1 DNA-cytosine methyltransferase [Paenibacillus phage Pagassa]	AUS03744.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03673.1	AUS03673.1 DNA-cytosine methyltransferase [Paenibacillus phage Kiel007]	AUS03673.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK27848.1	AJK27848.1 DNA-cytosine methyltransferase [Paenibacillus phage Rani]	AJK27848.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF40558.1	AXF40558.1 DNA-cytosine methyltransferase [Paenibacillus phage Toothless]	AXF40558.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXF39614.1	AXF39614.1 DNA-cytosine methyltransferase [Paenibacillus phage Honeybear]	AXF39614.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUS03809.1	AUS03809.1 DNA-cytosine methyltransferase [Paenibacillus phage Tadhana]	AUS03809.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV20119.1	QVV20119.1 deoxycytosine methyltransferase [Paenibacillus phage Pahemo]	QVV20119.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK28047.1	AJK28047.1 DNA-cytosine methyltransferase [Paenibacillus phage Sitara]	AJK28047.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJD83058.1	AJD83058.1 putative BsuMI modification methylase subunit YdiP [Paenibacillus phage HB10c2]	AJD83058.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19392.1	QVV19392.1 deoxycytosine methyltransferase [Paenibacillus phage AlexiD]	QVV19392.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QVV19793.1	QVV19793.1 deoxycytosine methyltransferase [Paenibacillus phage JackPlaque]	QVV19793.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK27909.1	AJK27909.1 DNA-cytosine methyltransferase [Bacteriophage Redbud]	AJK27909.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX16870.1	WAX16870.1 hypothetical protein PD491P1_00043 [Parabacteroides phage PD491P1]	WAX16870.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBC28442.1	WBC28442.1 DNA methyltransferase [Rhodobacteraceae phage LS06-2018-MD05]	WBC28442.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WQZ49450.1	WQZ49450.1 putative C-5 cytosine-specific DNA methylase I [Bacillus phage Z3]	WQZ49450.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AID17851.1	AID17851.1 putative C-5 cytosine-specific DNA methylase I [Bacillus phage JBP901]	AID17851.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAT72376.1	AAT72376.1 C-5 cytosine-specific DNA methylase [Streptococcus phage phi1207.3]	AAT72376.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK27713.1	AJK27713.1 DNA-cytosine methyltransferase [Paenibacillus phage Diva]	AJK27713.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	BEU14603.1	BEU14603.1 DNA methyltransferase [Bacillus phage CM1]	BEU14603.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJD49556.1	QJD49556.1 DNA-cytosine methyltransferase [Streptococcus phage phi29961]	QJD49556.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX16246.1	QBX16246.1 DNA-cytosine methyltransferase [Streptococcus phage Javan239]	QBX16246.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX14867.1	QBX14867.1 DNA-cytosine methyltransferase [Streptococcus phage Javan159]	QBX14867.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX19781.1	QBX19781.1 DNA-cytosine methyltransferase [Streptococcus phage Javan499]	QBX19781.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QJD49495.1	QJD49495.1 DNA-cytosine methyltransferase [Streptococcus phage phi29854]	QJD49495.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QKN61652.1	QKN61652.1 DNA-cytosine methyltransferase [Streptococcus phage phi29862]	QKN61652.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANT45211.1	ANT45211.1 DNA-cytosine methyltransferase [Clostridium phage CDKM15]	ANT45211.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AFO72127.1	AFO72127.1 DNA-cytosine methyltransferase [Clostridium phage phiMMP02]	AFO72127.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CEK40913.1	CEK40913.1 putative phage DNA modification methylase [Clostridium phage phiMMP03]	CEK40913.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANM47668.1	ANM47668.1 DNA-cytosine methyltransferase [Streptococcus phage phiJH1301-2]	ANM47668.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86531.1	QGJ86531.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuYTJ2_rum]	QGJ86531.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CDI66691.1	CDI66691.1 putative DNA methylase protein [Clostridium phage CDMH1]	CDI66691.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QYI86511.1	QYI86511.1 DNA-cytosine methyltransferase [Enterococcus phage VEsP-1]	QYI86511.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QZI94738.1	QZI94738.1 modification methylase [Methylophilales phage Melnitz EXVC044M]	QZI94738.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QZI94959.1	QZI94959.1 modification methylase [Methylophilales phage Melnitz-3 EXVC039M]	QZI94959.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QZI94292.1	QZI94292.1 modification methylase [Methylophilales phage Melnitz-1 EXVC043M]	QZI94292.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QZI94516.1	QZI94516.1 modification methylase [Methylophilales phage Melnitz-2 EXVC040M]	QZI94516.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CDW17254.1	CDW17254.1 putative DNA methylase protein [Clostridium phage phiCDHM19]	CDW17254.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX15536.1	QBX15536.1 DNA-cytosine methyltransferase [Streptococcus phage Javan191]	QBX15536.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX25230.1	QBX25230.1 DNA-cytosine methyltransferase [Streptococcus phage Javan244]	QBX25230.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGH71165.1	QGH71165.1 putative DNA (cytosine-5-)-methyltransferase [Methanobacterium virus PhiF1]	QGH71165.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	URG13520.1	URG13520.1 DNA-cytosine methyltransferase [Staphylococcus phage CUB-EPI_14]	URG13520.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QLF84033.1	QLF84033.1 DNA methylase [Gordonia phage Upyo]	QLF84033.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX23295.1	QBX23295.1 DNA-cytosine methyltransferase [Streptococcus phage Javan124]	QBX23295.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ACH91353.1	ACH91353.1 putative DNA methylase [Clostridioides phage phiCD27]	ACH91353.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ADE34937.1	ADE34937.1 hypothetical protein KP15_105 [Klebsiella phage KP15]	ADE34937.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX17616.1	QBX17616.1 DNA-cytosine methyltransferase [Streptococcus phage Javan369]	QBX17616.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WKN59634.1	WKN59634.1 hypothetical protein ayl_00051 [Klebsiella phage AYL]	WKN59634.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WMX18120.1	WMX18120.1 cytosine-specific methyltransferase [Klebsiella phage KpF2]	WMX18120.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WRN93184.1	WRN93184.1 DNA-cytosine methyltransferase [Streptococcus phage PhiSdyV1524-fexAoptrA]	WRN93184.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86409.1	QGJ86409.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuSSJ27_rum]	QGJ86409.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UQJ95205.1	UQJ95205.1 cytosine-specific methyltransferase [Klebsiella phage CPRSA]	UQJ95205.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALO79550.1	ALO79550.1 cytosine-C5 specific DNA methylase [Bacillus phage BM15]	ALO79550.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXQ66901.1	AXQ66901.1 DNA cytosine methyltransferase [Bacillus phage Hobo]	AXQ66901.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAR95400.1	CAR95400.1 hypothetical protein [Streptococcus phage phi-m46.1]	CAR95400.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJK27786.1	AJK27786.1 DNA-cytosine methyltransferase [Bacteriophage Lily]	AJK27786.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WJJ55959.1	WJJ55959.1 DNA methylase [Mycobacterium phage prophiT49-1]	WJJ55959.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX31174.1	QBX31174.1 DNA-cytosine methyltransferase [Streptococcus phage Javan618]	QBX31174.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AZF93982.1	AZF93982.1 DNA methylase [Mycobacterium phage Rhynn]	AZF93982.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBJ03955.1	QBJ03955.1 methyltransferase [Lactobacillus phage SAC12B]	QBJ03955.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNJ57978.1	QNJ57978.1 DNA methylase [Gordonia phage JKSyngboy]	QNJ57978.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UOF79580.1	UOF79580.1 cytosine specific methyltransferase [Caudoviricetes sp.]	UOF79580.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX23936.1	WAX23936.1 methyltransferase [Latilactobacillus phage TMW 1.46 P1]	WAX23936.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AEK08609.1	AEK08609.1 methylase [Mycobacterium phage DLane]	AEK08609.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UAJ15672.1	UAJ15672.1 DNA methylase [Gordonia phage Baddon]	UAJ15672.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ACE79832.1	ACE79832.1 hypothetical protein KBG_84 [Mycobacterium phage KBG]	ACE79832.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	APU89226.1	APU89226.1 methyltransferase-like protein [Virus Rctr41k]	APU89226.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UZV40675.1	UZV40675.1 hypothetical protein [Lacticaseibacillus phage C3.1]	UZV40675.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBM89644.1	WBM89644.1 hypothetical protein [Lacticaseibacillus phage C4.1]	WBM89644.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86696.1	QGJ86696.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuZKB4_rum]	QGJ86696.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86298.1	QGJ86298.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuSC05017_rum]	QGJ86298.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA07095.1	ALA07095.1 DNA-cytosine methyltransferase [Streptococcus phage phiSC070807]	ALA07095.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WJJ56217.1	WJJ56217.1 DNA methylase [Mycobacterium phage prophiT46-2]	WJJ56217.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QSM02759.1	QSM02759.1 DNA methylase [Mycobacterium phage prophi88-1]	QSM02759.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QSM03307.1	QSM03307.1 DNA methylase [Mycobacterium phage prophi_GD43-6]	QSM03307.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40693.1	ANB40693.1 hypothetical protein [Flavobacterium phage Fpv8]	ANB40693.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20591.1	QCW20591.1 site-specific DNA methylase [Flavobacterium phage FPSV-S20]	QCW20591.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20419.1	QCW20419.1 site-specific DNA methylase [Flavobacterium phage FPSV-S2]	QCW20419.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40635.1	ANB40635.1 hypothetical protein [Flavobacterium phage Fpv7]	ANB40635.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40577.1	ANB40577.1 hypothetical protein [Flavobacterium phage Fpv6]	ANB40577.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20543.1	QCW20543.1 site-specific DNA methylase [Flavobacterium phage FPSV-S18]	QCW20543.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW19968.1	QCW19968.1 site-specific DNA methylase [Flavobacterium phage FPSV-D2]	QCW19968.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20077.1	QCW20077.1 site-specific DNA methylase [Flavobacterium phage FPSV-D19]	QCW20077.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20454.1	QCW20454.1 site-specific DNA methylase [Flavobacterium phage FPSV-S3]	QCW20454.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALN97226.1	ALN97226.1 hypothetical protein [Flavobacterium phage FpV9]	ALN97226.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40751.1	ANB40751.1 hypothetical protein [Flavobacterium phage Fpv10]	ANB40751.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40519.1	ANB40519.1 hypothetical protein [Flavobacterium phage Fpv5]	ANB40519.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QCW20160.1	QCW20160.1 site-specific DNA methylase [Flavobacterium phage FPSV-D22]	QCW20160.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANB40809.1	ANB40809.1 hypothetical protein [Flavobacterium phage Fpv11]	ANB40809.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85251.1	QGJ85251.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SgaBSJ27_rum]	QGJ85251.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85362.1	QGJ85362.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SgaBSJ31_rum]	QGJ85362.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86473.1	QGJ86473.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuSSJ28_rum]	QGJ86473.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21869.1	QBX21869.1 DNA-cytosine methyltransferase [Streptococcus phage Javan599]	QBX21869.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UDF60320.1	UDF60320.1 putative C-5 cytosine methyltransferase [Pseudomonas phage Kopi]	UDF60320.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX25495.1	WAX25495.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage YS162]	WAX25495.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WMI33015.1	WMI33015.1 DNA methyltransferase [Gordonia Phage SchottB]	WMI33015.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WJE88153.1	WJE88153.1 DNA methyltransferase [Phage C75C1]	WJE88153.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBI97409.1	QBI97409.1 DNA methylase [Mycobacterium phage Fancypants]	QBI97409.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGF89759.1	AGF89759.1 putative C-5 cytosine-specific DNA methylase [Streptococcus phage phiD12]	AGF89759.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86000.1	QGJ86000.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuHCJ31_comEC]	QGJ86000.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX30607.1	QBX30607.1 DNA-cytosine methyltransferase [Streptococcus phage Javan558]	QBX30607.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGF87640.1	AGF87640.1 putative C-5 cytosine-specific DNA methylase [Streptococcus phage phiD12]	AGF87640.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX25044.1	WAX25044.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage YS771]	WAX25044.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86114.1	QGJ86114.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuJS7_SSU0237]	QGJ86114.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKQ06971.1	AKQ06971.1 DNA methylase [Mycobacterium phage Ovechkin]	AKQ06971.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX25557.1	WAX25557.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage YS43]	WAX25557.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86055.1	QGJ86055.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuHCJ3_rum]	QGJ86055.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85732.1	QGJ85732.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuFJSM7_rum]	QGJ85732.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85680.1	QGJ85680.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuFJSM5_rum]	QGJ85680.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX25123.1	WAX25123.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage YS387]	WAX25123.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WBL53604.1	WBL53604.1 DNA modification methylase [Bacillus phage yong1]	WBL53604.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QEM40845.1	QEM40845.1 cytosine-C-5 specific DNA methylase [Streptococcus phage phi-SC181]	QEM40845.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21471.1	QBX21471.1 DNA-cytosine methyltransferase [Streptococcus phage Javan575]	QBX21471.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CBR26899.1	CBR26899.1 hypothetical protein [Streptococcus phage phi-SsUD.1]	CBR26899.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX14137.1	QBX14137.1 DNA-cytosine methyltransferase [Streptococcus phage Javan123]	QBX14137.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85905.1	QGJ85905.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuFJZZ39_rum]	QGJ85905.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ85826.1	QGJ85826.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuFJZZ32_rum]	QGJ85826.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGJ86361.1	QGJ86361.1 DNA-cytosine methyltransferase [Streptococcus phage phi-SsuSH0918_comEC]	QGJ86361.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QXN74445.1	QXN74445.1 DNA methylase [Gordonia phage Float294]	QXN74445.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AZF88223.1	AZF88223.1 methyltransferase [Rothia phage Spartoi]	AZF88223.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAJ1313410.1	CAJ1313410.1 DNA methyltransferase [Bacteroides phage LoVEphage]	CAJ1313410.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAJ1888702.1	CAJ1888702.1 DNA methyltransferase [Bacteroides phage LoVEphage]	CAJ1888702.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGH77885.1	QGH77885.1 DNA methylase [Mycobacterium phage Kenuha5]	QGH77885.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYN59132.1	AYN59132.1 DNA methylase [Arthrobacter phage Yang]	AYN59132.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AJT61531.1	AJT61531.1 DNA methylase [Staphylococcus phage IME-SA4]	AJT61531.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXC37244.1	AXC37244.1 DNA methylase [Mycobacterium phage ByChance]	AXC37244.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QHB37286.1	QHB37286.1 DNA methylase [Gordonia phage Gudmit]	QHB37286.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AIM40465.1	AIM40465.1 DNA methyltransferase [Mycobacterium phage Estave1]	AIM40465.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYQ99586.1	AYQ99586.1 DNA methylase [Mycobacterium phage IrishSherpFalk]	AYQ99586.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AOQ28524.1	AOQ28524.1 DNA methylase [Mycobacterium phage WillSterrel]	AOQ28524.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYQ99414.1	AYQ99414.1 DNA methylase domain protein [Mycobacterium phage Filuzino]	AYQ99414.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX23262.1	QBX23262.1 DNA-cytosine methyltransferase [Streptococcus phage Javan122]	QBX23262.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAB10350.1	WAB10350.1 DNA methyltransferase [Mycobacterium phage RedBird]	WAB10350.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAK78980.1	WAK78980.1 DNA methyltransferase [Akkermansia phage Chambord]	WAK78980.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WWV91865.1	WWV91865.1 DNA methyltransferase [Microbacterium phage phiMiGM15]	WWV91865.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX32065.1	QBX32065.1 DNA-cytosine methyltransferase [Streptococcus phage Javan92]	QBX32065.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX22682.1	QBX22682.1 DNA-cytosine methyltransferase [Streptococcus phage Javan93]	QBX22682.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKU45050.1	AKU45050.1 DNA methylase [Mycobacterium phage Florinda]	AKU45050.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKU45660.1	AKU45660.1 DNA methylase [Mycobacterium phage Quico]	AKU45660.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKU45164.1	AKU45164.1 DNA methylase [Mycobacterium phage Girafales]	AKU45164.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNM68488.1	WNM68488.1 DNA methyltransferase [Mycobacterium phage Starcevich]	WNM68488.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QNN98662.1	QNN98662.1 methyltransferase [Mycobacterium phage Moonbeam]	QNN98662.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AFQ97461.1	AFQ97461.1 DNA methylase [Mycobacterium phage Dorothy]	AFQ97461.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26450.1	QBX26450.1 DNA-cytosine methyltransferase [Streptococcus phage Javan320]	QBX26450.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ATN91243.1	ATN91243.1 DNA methylase [Mycobacterium phage Phasih]	ATN91243.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QWY82562.1	QWY82562.1 DNA methylase [Mycobacterium phage Sassafras]	QWY82562.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AIK67683.1	AIK67683.1 DNA methylase [Mycobacterium phage Inventum]	AIK67683.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WCZ54843.1	WCZ54843.1 Cytosine-specific methyltransferase [Latilactobacillus phage TMW 1.706 P1]	WCZ54843.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QIQ63754.1	QIQ63754.1 DNA methylase [Mycobacterium phage Phanphagia]	QIQ63754.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ACI12681.1	ACI12681.1 hypothetical protein RAMSEY_69 [Mycobacterium phage Ramsey]	ACI12681.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGT12477.1	AGT12477.1 cytosine methyl transferase [Mycobacterium phage Hamulus]	AGT12477.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UTN93662.1	UTN93662.1 DNA methyltransferase [Mycobacterium phage Yorick]	UTN93662.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WNM66531.1	WNM66531.1 DNA methyltransferase [Mycobacterium phage Martik]	WNM66531.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QST89279.1	QST89279.1 DNA methylase [Mycobacterium phage prophi104-2]	QST89279.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93332.1	UYL93332.1 DNA cytosine methyltransferase [Paenibacillus phage Dash]	UYL93332.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA12632.1	ALA12632.1 DNA-cytosine methyltransferase [Paenibacillus phage Paisley]	ALA12632.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93405.1	UYL93405.1 DNA cytosine methyltransferase [Paenibacillus phage Lilo]	UYL93405.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UYL93255.1	UYL93255.1 DNA cytosine methyltransferase [Paenibacillus phage Callan]	UYL93255.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA12471.1	ALA12471.1 DNA-cytosine methyltransferase [Paenibacillus phage Harrison]	ALA12471.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AEJ93041.1	AEJ93041.1 DNA methylase [Mycobacterium phage Shauna1]	AEJ93041.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX20154.1	QBX20154.1 DNA-cytosine methyltransferase [Streptococcus phage Javan51]	QBX20154.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX31854.1	QBX31854.1 DNA-cytosine methyltransferase [Streptococcus phage Javan8]	QBX31854.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX13914.1	QBX13914.1 DNA-cytosine methyltransferase [Streptococcus phage Javan113]	QBX13914.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UAW59177.1	UAW59177.1 DNA (cytosine-5)-methyltransferase [Roseobacter phage CRP-603]	UAW59177.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA48711.1	ALA48711.1 DNA methylase [Mycobacterium phage Seagreen]	ALA48711.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QST90157.1	QST90157.1 DNA methylase [Mycobacterium phage prophi91-1]	QST90157.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKC02866.1	AKC02866.1 DNA methylase [Gordonia phage Gmala1]	AKC02866.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ASZ74443.1	ASZ74443.1 DNA methylase [Mycobacterium phage Wachhund]	ASZ74443.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX16657.1	QBX16657.1 DNA-cytosine methyltransferase [Streptococcus phage Javan269]	QBX16657.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QSM03884.1	QSM03884.1 DNA cytosine methyltransferase [Mycobacterium phage prophiGD91-2]	QSM03884.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ADZ31517.1	ADZ31517.1 site-specific DNA methylase [Planktothrix phage PaV-LD]	ADZ31517.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UJE15618.1	UJE15618.1 DNA methylase [Mycobacterium phage Madiba]	UJE15618.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX19580.1	QBX19580.1 DNA-cytosine methyltransferase [Streptococcus phage Javan49]	QBX19580.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX16954.1	QBX16954.1 DNA-cytosine methyltransferase [Streptococcus phage Javan3]	QBX16954.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27576.1	QBX27576.1 DNA-cytosine methyltransferase [Streptococcus phage Javan40]	QBX27576.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21365.1	QBX21365.1 DNA-cytosine methyltransferase [Streptococcus phage Javan57]	QBX21365.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX24666.1	QBX24666.1 DNA-cytosine methyltransferase [Streptococcus phage Javan20]	QBX24666.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX21012.1	QBX21012.1 DNA-cytosine methyltransferase [Streptococcus phage Javan55]	QBX21012.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QGT53593.1	QGT53593.1 DNA-cytosine methyltransferase [Lactococcus phage CHPC974]	QGT53593.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AYR02475.1	AYR02475.1 DNA methylase [Gordonia phage Ailee]	AYR02475.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKC02768.1	AKC02768.1 methyltransferase [Gordonia phage GordTnk2]	AKC02768.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AER48432.1	AER48432.1 DNA methylase [Mycobacterium phage Babsiella]	AER48432.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX22724.1	QBX22724.1 DNA-cytosine methyltransferase [Streptococcus phage Javan95]	QBX22724.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAX23749.1	WAX23749.1 putative methyltransferase [Latilactobacillus phage TMW 1.1386 P1]	WAX23749.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBZ73348.1	QBZ73348.1 DNA methylase [Streptomyces phage RemusLoopin]	QBZ73348.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX16443.1	QBX16443.1 DNA-cytosine methyltransferase [Streptococcus phage Javan25]	QBX16443.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26410.1	QBX26410.1 DNA-cytosine methyltransferase [Streptococcus phage Javan32]	QBX26410.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX22272.1	QBX22272.1 DNA-cytosine methyltransferase [Streptococcus phage Javan65]	QBX22272.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WVW37683.1	WVW37683.1 DNA (cytosine-5-)-methyltransferase [Streptococcus phage phiStag1_20280_6_181]	WVW37683.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27274.1	QBX27274.1 DNA-cytosine methyltransferase [Streptococcus phage Javan38]	QBX27274.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AGT12377.1	AGT12377.1 methylase [Mycobacterium phage Daenerys]	AGT12377.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXQ61806.1	AXQ61806.1 DNA methylase [Mycobacterium phage PHappiness]	AXQ61806.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AUV60570.1	AUV60570.1 methylase [Mycobacterium phage OldBen]	AUV60570.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AAX53484.1	AAX53484.1 hypothetical protein [Clostridium phage phi CD119]	AAX53484.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX26790.1	QBX26790.1 DNA-cytosine methyltransferase [Streptococcus phage Javan346]	QBX26790.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXQ51418.1	AXQ51418.1 DNA methylase [Mycobacterium phage Aggie]	AXQ51418.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ATW60114.1	ATW60114.1 DNA methylase [Mycobacterium phage Philonius]	ATW60114.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QAX95022.1	QAX95022.1 DNA methylase [Streptomyces phage Sebastisaurus]	QAX95022.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AXQ61205.1	AXQ61205.1 DNA methylase [Mycobacterium phage JoeyJr]	AXQ61205.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ASZ73844.1	ASZ73844.1 DNA methylase [Mycobacterium phage RitaG]	ASZ73844.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QFG10450.1	QFG10450.1 DNA methylase [Mycobacterium phage Anthony]	QFG10450.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBZ73405.1	QBZ73405.1 DNA methylase [Streptomyces phage Heather]	QBZ73405.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALA48177.1	ALA48177.1 hypothetical protein [Mycobacterium phage Phlei]	ALA48177.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WEU68080.1	WEU68080.1 DNA methyltransferase [Acinetobacter phage vB_AbaM_ABMM1]	WEU68080.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	WAA20379.1	WAA20379.1 DNA methyltransferase [Mycobacterium phage VRedHorse]	WAA20379.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBP31548.1	QBP31548.1 DNA methylase [Mycobacterium phage Cornucopia]	QBP31548.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ALY06928.1	ALY06928.1 putative DNA methylase [Lactobacillus phage SA-C12]	ALY06928.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	UQT02021.1	UQT02021.1 DNA methyltransferase [Gordonia phage ChadMasterC]	UQT02021.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX13820.1	QBX13820.1 DNA-cytosine methyltransferase [Streptococcus phage Javan107]	QBX13820.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX22934.1	QBX22934.1 DNA-cytosine methyltransferase [Streptococcus phage Javan104]	QBX22934.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX13716.1	QBX13716.1 DNA-cytosine methyltransferase [Streptococcus phage Javan101]	QBX13716.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	USH45035.1	USH45035.1 DNA methyltransferase [Gordonia phage Camerico]	USH45035.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AKC02956.1	AKC02956.1 DNA methylase [Gordonia phage GordDuk1]	AKC02956.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QAX94732.1	QAX94732.1 DNA methylase [Streptomyces phage Lilbooboo]	QAX94732.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27933.1	QBX27933.1 DNA-cytosine methyltransferase [Streptococcus phage Javan424]	QBX27933.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAJ1878299.1	CAJ1878299.1 DNA methyltransferase [Bacteroides phage LoVEphage]	CAJ1878299.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	CAD80133.1	CAD80133.1 gp9.1 [Lomovskayavirus BT1]	CAD80133.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	ANT40007.1	ANT40007.1 DNA-cytosine methyltransferase [Bacillus phage vB_BtS_BMBtp14]	ANT40007.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QAX93288.1	QAX93288.1 DNA methylase [Streptomyces phage Vash]	QAX93288.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QBX27888.1	QBX27888.1 DNA-cytosine methyltransferase [Streptococcus phage Javan422]	QBX27888.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	AWH13768.1	AWH13768.1 methyltransferase [Mycobacterium phage DillTech15]	AWH13768.1	0
+a11c4b17-d0de-4a9f-a4b4-6af9418cf226	QYC52389.1	QYC52389.1 putative cytosine specific methyltransferase [Solobacterium phage SMO_1P]	QYC52389.1	0
+3616a2b7-c5e4-466c-9391-8102e19a8ba2	UNY41768.1	UNY41768.1 endonuclease [Burkholderia phage Milagro]	UNY41768.1	0
+3616a2b7-c5e4-466c-9391-8102e19a8ba2	UBF21666.1	UBF21666.1 Eco29kI restriction endonuclease [Haloarcula virus HJTV-2]	UBF21666.1	0
+0914bac7-1f6e-4015-a0bd-bd34fee6f260	UNY41772.1	UNY41772.1 hypothetical protein CPT_Milagro_053 [Burkholderia phage Milagro]	UNY41772.1	0
+0914bac7-1f6e-4015-a0bd-bd34fee6f260	UNY41879.1	UNY41879.1 hypothetical protein CPT_Momento_049 [Burkholderia phage Momento]	UNY41879.1	0
+0914bac7-1f6e-4015-a0bd-bd34fee6f260	UNY41715.1	UNY41715.1 hypothetical protein CPT_Musica_056 [Burkholderia phage Musica]	UNY41715.1	0
+0914bac7-1f6e-4015-a0bd-bd34fee6f260	UNY41714.1	UNY41714.1 hypothetical protein CPT_Musica_055 [Burkholderia phage Musica]	UNY41714.1	0
+0d729222-7dd5-4d3f-bd0b-793e5c0f17d6	UNY41773.1	UNY41773.1 hypothetical protein CPT_Milagro_054 [Burkholderia phage Milagro]	UNY41773.1	0
+0d729222-7dd5-4d3f-bd0b-793e5c0f17d6	UNY41716.1	UNY41716.1 hypothetical protein CPT_Musica_057 [Burkholderia phage Musica]	UNY41716.1	0
+0d729222-7dd5-4d3f-bd0b-793e5c0f17d6	UNY41883.1	UNY41883.1 hypothetical protein CPT_Momento_053 [Burkholderia phage Momento]	UNY41883.1	0
+0d729222-7dd5-4d3f-bd0b-793e5c0f17d6	UNY41876.1	UNY41876.1 hypothetical protein CPT_Momento_046 [Burkholderia phage Momento]	UNY41876.1	0
+0d729222-7dd5-4d3f-bd0b-793e5c0f17d6	UNY41880.1	UNY41880.1 hypothetical protein CPT_Momento_050 [Burkholderia phage Momento]	UNY41880.1	0
+3d83c446-26f4-42fd-8cb1-6137e8552370	UNY41774.1	UNY41774.1 hypothetical protein CPT_Milagro_055 [Burkholderia phage Milagro]	UNY41774.1	0
+3d83c446-26f4-42fd-8cb1-6137e8552370	UNY41717.1	UNY41717.1 hypothetical protein CPT_Musica_058 [Burkholderia phage Musica]	UNY41717.1	0
+7d744dd6-401c-45bb-a1ed-3529acdf7f2b	UNY41775.1	UNY41775.1 hypothetical protein CPT_Milagro_056 [Burkholderia phage Milagro]	UNY41775.1	0
+7d744dd6-401c-45bb-a1ed-3529acdf7f2b	UNY41718.1	UNY41718.1 hypothetical protein CPT_Musica_059 [Burkholderia phage Musica]	UNY41718.1	0
+7d744dd6-401c-45bb-a1ed-3529acdf7f2b	UNY41829.1	UNY41829.1 hypothetical protein CPT_Menos_055 [Burkholderia phage Menos]	UNY41829.1	0
+7d744dd6-401c-45bb-a1ed-3529acdf7f2b	UNY41885.1	UNY41885.1 hypothetical protein CPT_Momento_055 [Burkholderia phage Momento]	UNY41885.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNY41720.1	UNY41720.1 portal protein [Burkholderia phage Milagro]	UNY41720.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNY41660.1	UNY41660.1 portal vertex protein [Burkholderia phage Musica]	UNY41660.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNY41831.1	UNY41831.1 portal vertex protein [Burkholderia phage Momento]	UNY41831.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNY41776.1	UNY41776.1 portal vertex protein [Burkholderia phage Menos]	UNY41776.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADP02335.1	ADP02335.1 gp42 [Burkholderia phage KL3]	ADP02335.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UKM53763.1	UKM53763.1 portal vertex protein [Burkholderia phage PhiBP82.2]	UKM53763.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QWY84946.1	QWY84946.1 portal vertex protein [Burkholderia phage PK23]	QWY84946.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ABO60724.1	ABO60724.1 gp5, phage portal protein, pbsx family [Burkholderia phage phiE202]	ABO60724.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAZ72647.1	AAZ72647.1 pbsx family phage portal protein [Burkholderia phage phiE52237]	AAZ72647.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AFV51395.1	AFV51395.1 Q portal vertex protein [Burkholderia phage phiX216]	AFV51395.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UPI15555.1	UPI15555.1 portal vertex protein [Burkholderia phage PhiBP82.3]	UPI15555.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AIP84274.1	AIP84274.1 phage portal protein, PBSX family [Burkholderia phage BEK]	AIP84274.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ABO60792.1	ABO60792.1 gp5, phage portal protein, pbsx family [Burkholderia phage phiE12-2]	ABO60792.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WWY66143.1	WWY66143.1 portal protein [Burkholderia phage vB_HM387]	WWY66143.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QPI18541.1	QPI18541.1 portal vertex protein [Burkholderia phage phiE094]	QPI18541.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BCB23215.1	BCB23215.1 portal vertex protein (Q) [Burkholderia phage FLC5]	BCB23215.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADP02381.1	ADP02381.1 gp36 [Burkholderia phage KS14]	ADP02381.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BDD79916.1	BDD79916.1 hypothetical protein [Burkholderia phage FLC10]	BDD79916.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BAP28107.1	BAP28107.1 hypothetical protein [Ralstonia phage RSY1]	BAP28107.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BAF52382.1	BAF52382.1 bacteriophage gpQ [Ralstonia phage RSA1]	BAF52382.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AVP39999.1	AVP39999.1 portal protein [Ralstonia phage RsoM1USA]	AVP39999.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNA05861.1	UNA05861.1 portal vertex protein [Yersinia phage vB_YenM_06.16-2]	UNA05861.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNA05907.1	UNA05907.1 portal vertex protein [Yersinia phage vB_YenM_56.17]	UNA05907.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNA05962.1	UNA05962.1 portal vertex protein [Yersinia phage vB_YenM_201.16]	UNA05962.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UKL54244.1	UKL54244.1 portal vertex protein [Yersinia phage vB_YenM_31.17]	UKL54244.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNA05736.1	UNA05736.1 portal vertex protein [Yersinia phage vB_YenM_42.18]	UNA05736.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27624.1	QBP27624.1 portal protein [Klebsiella phage ST13-OXA48phi12.1]	QBP27624.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AQT27279.1	AQT27279.1 portal protein [Salmonella phage SEN8]	AQT27279.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	CAH1234679.1	CAH1234679.1 Portal [Escherichia phage Cartapus]	CAH1234679.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UNI73734.1	UNI73734.1 capsid packaging protein [Klebsiella phage KP12]	UNI73734.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBQ71994.1	QBQ71994.1 portal protein [Klebsiella phage ST15-OXA48phi14.1]	QBQ71994.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADQ92390.1	ADQ92390.1 capsid packaging protein [Salmonella phage RE2010]	ADQ92390.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP08046.1	QBP08046.1 portal protein [Klebsiella phage ST437-OXA245phi4.1]	QBP08046.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27774.1	QBP27774.1 portal protein [Klebsiella phage ST512-KPC3phi13.6]	QBP27774.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27928.1	QBP27928.1 portal protein [Klebsiella phage ST258-KPC3phi16.1]	QBP27928.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC10480.1	URC10480.1 portal vertex protein [Escherichia phage vB_EcoM-813R9]	URC10480.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ARB15683.1	ARB15683.1 capsid packaging protein [Klebsiella phage 4LV2017]	ARB15683.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADX32414.1	ADX32414.1 phage portal protein [Erwinia phage ENT90]	ADX32414.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27415.1	QBP27415.1 portal protein [Klebsiella phage ST512-KPC3phi13.2]	QBP27415.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP07826.1	QBP07826.1 portal protein [Klebsiella phage ST11-VIM1phi8.4]	QBP07826.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27884.1	QBP27884.1 portal protein [Klebsiella phage ST11-OXA48phi15.3]	QBP27884.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP08082.1	QBP08082.1 portal protein [Klebsiella phage ST11-OXA245phi3.1]	QBP08082.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27654.1	QBP27654.1 portal protein [Klebsiella phage ST340-VIM1phi10.2]	QBP27654.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP27982.1	QBP27982.1 portal protein [Klebsiella phage ST258-KPC3phi16.2]	QBP27982.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBQ71733.1	QBQ71733.1 portal protein [Klebsiella phage ST437-OXA245phi4.2]	QBQ71733.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AKA61127.1	AKA61127.1 putative portal vertex protein [Burkholderia phage AP3]	AKA61127.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	USM11608.1	USM11608.1 portal protein [Burkholderia phage Carl1]	USM11608.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADP02290.1	ADP02290.1 gp43 [Burkholderia phage KS5]	ADP02290.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WWQ72084.1	WWQ72084.1 portal protein [Pseudomonas phage Sirocco]	WWQ72084.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QPB09396.1	QPB09396.1 portal protein [Burkholderia phage Mana]	QPB09396.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UZV40206.1	UZV40206.1 portal vertex protein [Acidovorax phage Acica]	UZV40206.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AZF87843.1	AZF87843.1 portal protein [Pseudomonas phage Dobby]	AZF87843.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BAA36227.1	BAA36227.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36227.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QYC52698.1	QYC52698.1 portal protein, PBSX family [Salmonella phage BIS20]	QYC52698.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBI84110.1	QBI84110.1 capsid packaging protein [Pseudomonas phage vB_Pae_BR319a]	QBI84110.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URE76623.1	URE76623.1 portal vertex protein [Escherichia phage vB_EcoM-613R3]	URE76623.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WYC18440.1	WYC18440.1 portal vertex protein [Yersinia phage vB_YpM_MHG38]	WYC18440.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WYC18372.1	WYC18372.1 capsid packaging protein [Yersinia phage vB_YpM_MDG94-186]	WYC18372.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WYC18398.1	WYC18398.1 portal vertex protein [Yersinia phage vB_YpM_MDG45]	WYC18398.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WXX18199.1	WXX18199.1 capsid packaging protein [Yersinia phage GCS667]	WXX18199.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AUV47163.1	AUV47163.1 capsid portal protein [Erwinia phage EtG]	AUV47163.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ALF02240.1	ALF02240.1 portal protein [Salmonella phage SEN1]	ALF02240.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAN08363.1	AAN08363.1 gp1 [Salmonella phage PSP3]	AAN08363.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QEI25340.1	QEI25340.1 portal protein [Salmonella phage SI22]	QEI25340.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QEI25385.1	QEI25385.1 portal protein [Salmonella phage SW9]	QEI25385.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAC34146.1	AAC34146.1 capsid portal protein [Escherichia phage 186]	AAC34146.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UFI07940.1	UFI07940.1 major coat protein, partial [Escherichia phage sp.]	UFI07940.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WPJ53075.1	WPJ53075.1 putative portal protein [Klebsiella phage RCIP0057]	WPJ53075.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AGF88414.1	AGF88414.1 portal vertex protein [Salmonella phage FSLSP004]	AGF88414.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC09854.1	URC09854.1 portal vertex protein [Escherichia phage vB_EcoM-720R8]	URC09854.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QKE55625.1	QKE55625.1 hypothetical protein vBYpM50_00004 [Yersinia phage vB_YpM_50]	QKE55625.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	CAG9593805.1	CAG9593805.1 hypothetical protein P2DC1_00001 [Peduovirus P2]	CAG9593805.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AGX84565.1	AGX84565.1 capsid portal protein [Enterobacteria phage fiAA91-ss]	AGX84565.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WPJ21685.1	WPJ21685.1 portal protein [Bacillus phage vB_BpuM-ZY1]	WPJ21685.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QXF95267.1	QXF95267.1 portal vertex protein [Yersinia phage HQ103]	QXF95267.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URP83662.1	URP83662.1 portal protein [Escherichia phage S164]	URP83662.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WOZ55989.1	WOZ55989.1 hypothetical protein B115_00001 [Yersinia phage vB_YpM_115]	WOZ55989.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WOZ56035.1	WOZ56035.1 hypothetical protein B117_00001 [Yersinia phage vB_YpM_117]	WOZ56035.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ULG00980.1	ULG00980.1 portal vertex protein [Escherichia phage 9W]	ULG00980.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD37919.1	VUD37919.1 Phage-related capsid packaging protein [Peduovirus P22H4]	VUD37919.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WFG40977.1	WFG40977.1 portal protein [Salmonella phage MET_P1_103_31]	WFG40977.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDP43495.1	QDP43495.1 portal vertex protein [Bacteriophage R18C]	QDP43495.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	API82936.1	API82936.1 Phage portal protein [Salmonella phage STYP1]	API82936.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDJ98471.1	QDJ98471.1 putative portal protein [Escherichia phage vB_EcoM-12474II]	QDJ98471.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AKH49373.1	AKH49373.1 capsid packaging protein [Escherichia phage pro483]	AKH49373.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDJ98603.1	QDJ98603.1 putative portal protein [Escherichia phage vB_EcoM-12474V]	QDJ98603.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDJ98559.1	QDJ98559.1 putative portal protein [Escherichia phage vB_EcoM-12474IV]	QDJ98559.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD37962.1	VUD37962.1 Portal vertex protein [Peduovirus P22H1]	VUD37962.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDJ98474.1	QDJ98474.1 putative portal protein [Escherichia phage vB_EcoM-12474III]	QDJ98474.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD38006.1	VUD38006.1 Phage portal protein [Peduovirus P24B2]	VUD38006.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ULG01137.1	ULG01137.1 portal vertex protein [Escherichia phage 10W]	ULG01137.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ULG00864.1	ULG00864.1 portal vertex protein [Escherichia phage 11W]	ULG00864.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD39476.1	VUD39476.1 Phage-related capsid packaging protein [Peduovirus P24C9]	VUD39476.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	CAH0786527.1	CAH0786527.1 hypothetical protein P2AC1_00042 [Escherichia phage P2_AC1]	CAH0786527.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AGG36516.1	AGG36516.1 phage-related capsid packaging protein [Escherichia phage P2]	AGG36516.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAD03268.1	AAD03268.1 gpQ [Bacteriophage P2]	AAD03268.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAP04438.1	AAP04438.1 gpQ [Yersinia phage L-413C]	AAP04438.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	CAG9593804.1	CAG9593804.1 hypothetical protein P2SIAC10_00043 [Peduovirus P2]	CAG9593804.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UPI11499.1	UPI11499.1 hypothetical protein BFNKNBEH_00009 [Yersinia phage VB-YPM-18]	UPI11499.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WOZ56081.1	WOZ56081.1 hypothetical protein B476A_00001 [Yersinia phage vB_YpM_476A]	WOZ56081.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ULG00678.1	ULG00678.1 portal vertex protein [Escherichia phage D8]	ULG00678.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD38854.1	VUD38854.1 Portal vertex protein [Peduovirus P24E6b]	VUD38854.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QKE55489.1	QKE55489.1 hypothetical protein vBYpM22_00004 [Yersinia phage vB_YpM_22]	QKE55489.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WOZ56121.1	WOZ56121.1 hypothetical protein B476B_00001 [Yersinia phage vB_YpM_476B]	WOZ56121.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ULG01138.1	ULG01138.1 portal vertex protein [Escherichia phage 12W]	ULG01138.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AKH49345.1	AKH49345.1 capsid packaging protein [Escherichia phage pro147]	AKH49345.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD39017.1	VUD39017.1 Portal vertex protein [Peduovirus P24A7b]	VUD39017.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QIW90064.1	QIW90064.1 PBSX family portal protein [Yersinia phage P37]	QIW90064.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAN28219.1	AAN28219.1 gpQ [Escherichia phage Wphi]	AAN28219.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UPI11449.1	UPI11449.1 hypothetical protein COILCCMC_00001 [Yersinia phage VB-YPM-4]	UPI11449.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QKE55581.1	QKE55581.1 hypothetical protein vBYpM46_00001 [Yersinia phage vB_YpM_46]	QKE55581.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBQ71545.1	QBQ71545.1 portal protein [Klebsiella phage ST147-VIM1phi7.1]	QBQ71545.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UYL85504.1	UYL85504.1 portal vertex protein [Acidovorax phage Alfacinha1]	UYL85504.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ABD90602.1	ABD90602.1 capsid portal protein Q [Mannheimia phage phiMhaA1-BAA410]	ABD90602.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ABD90553.1	ABD90553.1 capsid portal protein Q [Mannheimia phage PHL101]	ABD90553.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AJA73105.1	AJA73105.1 capsid portal protein Q [Mannheimia phage vB_MhM_2256AP1]	AJA73105.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AJA72874.1	AJA72874.1 capsid portal protein Q [Mannheimia phage vB_MhM_535AP1]	AJA72874.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AFL46449.1	AFL46449.1 capsid portal protein Q [Mannheimia phage vB_MhM_1152AP]	AFL46449.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC10090.1	URC10090.1 portal vertex protein [Escherichia phage vB_EcoM-640R3]	URC10090.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UYL85403.1	UYL85403.1 portal vertex protein [Acidovorax phage Alfacinha3]	UYL85403.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AJA72925.1	AJA72925.1 capsid portal protein Q [Mannheimia phage vB_MhM_587AP1]	AJA72925.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AJA73053.1	AJA73053.1 capsid portal protein Q [Mannheimia phage vB_MhM_1127AP1]	AJA73053.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC09611.1	URC09611.1 portal vertex protein [Escherichia phage vB_EcoM-569R9]	URC09611.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QYW06326.1	QYW06326.1 portal protein [Shewanella phage vB_SspM_M16-3]	QYW06326.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UGC97288.1	UGC97288.1 portal vertex protein [Aeromonas phage vB_AsaM_LPM4]	UGC97288.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC10017.1	URC10017.1 portal vertex protein [Escherichia phage vB_EcoM-473R3]	URC10017.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ALF02290.1	ALF02290.1 portal vertex protein [Salmonella phage SEN4]	ALF02290.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ALF02339.1	ALF02339.1 portal vertex protein [Salmonella phage SEN5]	ALF02339.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AFJ75476.1	AFJ75476.1 phage portal vertex protein [Stenotrophomonas phage Smp131]	AFJ75476.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP07918.1	QBP07918.1 portal protein [Klebsiella phage ST101-KPC2phi6.2]	QBP07918.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AYD79788.1	AYD79788.1 hypothetical protein OGLPLLMI_00022 [Enterobacter phage phiT5282H]	AYD79788.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URE76764.1	URE76764.1 portal vertex protein [Escherichia phage vB_EcoM-705R2]	URE76764.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URC09566.1	URC09566.1 portal vertex protein [Escherichia phage vB_EcoM-569R5]	URC09566.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AIZ95131.1	AIZ95131.1 PBSX family portal protein [Escherichia phage P88]	AIZ95131.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WOZ57143.1	WOZ57143.1 portal protein [Citrobacter phage Shae_phiSM]	WOZ57143.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUD40163.1	VUD40163.1 Presumed portal vertex protein [Xuanwuvirus P884B11]	VUD40163.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP07936.1	QBP07936.1 portal protein [Klebsiella phage ST16-OXA48phi5.4]	QBP07936.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ARB15637.1	ARB15637.1 putative portal vertex protein [Klebsiella phage 3LV2017]	ARB15637.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AGK86776.1	AGK86776.1 phage portal vertex protein [Burkholderia phage ST79]	AGK86776.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WKV24002.1	WKV24002.1 portal vertex protein [Pseudomonas phage PaBSM-2607-JFK]	WKV24002.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UYE91962.1	UYE91962.1 portal protein [Aeromonas phage A051]	UYE91962.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ABG73172.1	ABG73172.1 putative portal protein [Aeromonas phage phiO18P]	ABG73172.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WGL39673.1	WGL39673.1 portal protein [Aeromonas phage P05B]	WGL39673.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AOY11831.1	AOY11831.1 portal vortex protein [Salinivibrio phage SMHB1]	AOY11831.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WMT83779.1	WMT83779.1 portal [Pseudoalteromonas phage proACA1-A]	WMT83779.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WMT83727.1	WMT83727.1 portal [Pseudoalteromonas phage ACA2]	WMT83727.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WMT83675.1	WMT83675.1 portal [Pseudoalteromonas phage ACA1]	WMT83675.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ADX32372.1	ADX32372.1 phage portal protein [Cronobacter phage ESSI-2]	ADX32372.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QEI25521.1	QEI25521.1 portal protein [Salmonella phage SW3]	QEI25521.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QEI25483.1	QEI25483.1 portal protein [Salmonella phage SW5]	QEI25483.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AUR95197.1	AUR95197.1 portal protein [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95197.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UKL54199.1	UKL54199.1 portal vertex protein [Yersinia phage vB_YenM_324]	UKL54199.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGF21294.1	QGF21294.1 portal protein [Vibrio phage vB_ValM-yong1]	QGF21294.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QMP23900.1	QMP23900.1 portal protein [Vibrio phage ValB1MD-2]	QMP23900.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WPJ21746.1	WPJ21746.1 portal protein [Vibrio phage L9-1]	WPJ21746.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUF53522.1	VUF53522.1 Portal vertex protein [Escherichia phage ESSI2_ev040]	VUF53522.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUF53487.1	VUF53487.1 Portal vertex protein [Escherichia phage ESSI2_ev015]	VUF53487.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAB09200.1	AAB09200.1 hypothetical protein [Haemophilus phage HP1]	AAB09200.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUF53559.1	VUF53559.1 Portal vertex protein [Escherichia phage ESSI2_ev129]	VUF53559.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ALY08256.1	ALY08256.1 portal protein [Pseudomonas phage phi3]	ALY08256.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAK37797.1	AAK37797.1 orf15 [Haemophilus phage HP2]	AAK37797.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AGW43559.1	AGW43559.1 putative capsid portal protein [Vibrio phage VPUSM 8]	AGW43559.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ANA87653.1	ANA87653.1 portal vertex protein [Vibrio phage VcP032]	ANA87653.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAL47514.1	AAL47514.1 orf15 [Bacteriophage K139]	AAL47514.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	BAF98814.1	BAF98814.1 hypothetical pbsx family phage portal protein [Vibrio phage Kappa]	BAF98814.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	VUF53465.1	VUF53465.1 phage portal protein [Escherichia phage ESSI2_ev239]	VUF53465.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WBY65433.1	WBY65433.1 hypothetical protein FP3_000002 [Pasteurella phage vB_PmuM_CFP3]	WBY65433.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	APM00234.1	APM00234.1 portal protein [Pseudoalteromonas phage C5a]	APM00234.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAZ93653.1	AAZ93653.1 unknown [Pasteurella phage F108]	AAZ93653.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP08113.1	QBP08113.1 putative portal protein [Klebsiella phage ST405-OXA48phi1.3]	QBP08113.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	CAG9593847.1	CAG9593847.1 hypothetical protein P2SIDE7_00001 [Peduovirus P2]	CAG9593847.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QEI25468.1	QEI25468.1 capsid packaging protein [Salmonella phage SI7]	QEI25468.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UTC25954.1	UTC25954.1 portal vertex protein [Salmonella phage vB_Sal_PHB48]	UTC25954.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AAG50262.1	AAG50262.1 probable portal protein, partial [Phage GMSE-1]	AAG50262.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AFM54726.1	AFM54726.1 phage portal protein [Nonlabens phage P12024L]	AFM54726.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AFM54667.1	AFM54667.1 phage portal protein [Nonlabens phage P12024S]	AFM54667.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WDY79056.1	WDY79056.1 portal protein [Halorubrum tailed virus]	WDY79056.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WDY79144.1	WDY79144.1 hypothetical protein ORFS47 [Halorubrum tailed virus]	WDY79144.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH69574.1	AXH69574.1 portal protein [Streptomyces phage LukeCage]	AXH69574.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UMO76240.1	UMO76240.1 portal protein [Streptomyces phage Tomas]	UMO76240.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH66797.1	AXH66797.1 portal protein [Streptomyces phage StarPlatinum]	AXH66797.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH76356.1	QGH76356.1 portal protein [Streptomyces phage Daubenski]	QGH76356.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QOI67425.1	QOI67425.1 portal protein [Streptomyces phage Beuffert]	QOI67425.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDH93915.1	QDH93915.1 portal protein [Streptomyces phage Evy]	QDH93915.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UEM46836.1	UEM46836.1 portal protein [Streptomyces phage Targaryen]	UEM46836.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH49170.1	AXH49170.1 portal protein [Streptomyces phage Blueeyedbeauty]	AXH49170.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AIW02550.1	AIW02550.1 portal protein [Streptomyces phage Jay2Jay]	AIW02550.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASN73125.1	ASN73125.1 portal protein [Streptomyces phage Warpy]	ASN73125.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXG66145.1	AXG66145.1 portal protein [Streptomyces phage Annadreamy]	AXG66145.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH79357.1	QGH79357.1 portal protein [Streptomyces phage Limpid]	QGH79357.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH69914.1	AXH69914.1 portal protein [Streptomyces phage Karimac]	AXH69914.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH67244.1	AXH67244.1 portal protein [Streptomyces phage Wollford]	AXH67244.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QFP97362.1	QFP97362.1 portal protein [Streptomyces phage IchabodCrane]	QFP97362.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UVK59950.1	UVK59950.1 portal protein [Streptomyces phage Spilled]	UVK59950.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UVK61141.1	UVK61141.1 portal protein [Streptomyces phage Angela]	UVK61141.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QNO12468.1	QNO12468.1 portal protein [Streptomyces phage MulchMansion]	QNO12468.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QNN98294.1	QNN98294.1 portal protein [Streptomyces phage LilMartin]	QNN98294.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QNN99127.1	QNN99127.1 portal protein [Streptomyces phage Faust]	QNN99127.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QJD50794.1	QJD50794.1 portal protein [Streptomyces phage Bmoc]	QJD50794.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WXW92537.1	WXW92537.1 portal protein [Streptomyces phage Enygma]	WXW92537.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AST15278.1	AST15278.1 portal protein [Streptomyces phage Samisti12]	AST15278.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WDS51843.1	WDS51843.1 portal protein [Streptomyces phage Pepperwood]	WDS51843.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QAX95783.1	QAX95783.1 portal protein [Streptomyces phage Teutsch]	QAX95783.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASR77752.1	ASR77752.1 portal protein [Streptomyces phage Peebs]	ASR77752.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNN95408.1	WNN95408.1 portal protein [Streptomyces phage Watermoore]	WNN95408.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WZB39539.1	WZB39539.1 portal protein [Streptomyces phage Cursive]	WZB39539.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH78237.1	QGH78237.1 portal protein [Streptomyces phage Tribute]	QGH78237.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBP30844.1	QBP30844.1 portal protein [Streptomyces phage EGole]	QBP30844.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QRI46042.1	QRI46042.1 portal protein [Streptomyces phage Cross]	QRI46042.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASR76479.1	ASR76479.1 portal protein [Streptomyces phage Sushi23]	ASR76479.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGZ14587.1	QGZ14587.1 putative portal protein [Methanobacterium virus PhiF3]	QGZ14587.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNM73310.1	WNM73310.1 portal protein [Streptomyces phage Liandry]	WNM73310.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASR77533.1	ASR77533.1 portal protein [Streptomyces phage Paradiddles]	ASR77533.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UGL63045.1	UGL63045.1 portal protein [Streptomyces phage Bartholomune]	UGL63045.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDK02903.1	QDK02903.1 portal protein [Streptomyces phage Braelyn]	QDK02903.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNM72925.1	WNM72925.1 portal protein [Streptomyces phage Persimmon]	WNM72925.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASR77312.1	ASR77312.1 portal protein [Streptomyces phage NootNoot]	ASR77312.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UOW93478.1	UOW93478.1 portal protein [Streptomyces phage Squillium]	UOW93478.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH74293.1	QGH74293.1 portal protein [Streptomyces phage Wipeout]	QGH74293.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WGH19836.1	WGH19836.1 portal protein [Streptomyces phage PumpkinSpice]	WGH19836.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QPL13687.1	QPL13687.1 portal protein [Streptomyces phage MindFlayer]	QPL13687.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNM74708.1	WNM74708.1 portal protein [Streptomyces phage PinkiePie]	WNM74708.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	ASR75452.1	ASR75452.1 portal protein [Streptomyces phage Mildred21]	ASR75452.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WMI33658.1	WMI33658.1 portal protein [Streptomyces phage Patelgo]	WMI33658.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QIQ62910.1	QIQ62910.1 portal protein [Streptomyces phage Moab]	QIQ62910.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QAY12700.1	QAY12700.1 portal protein [Streptomyces phage BoomerJR]	QAY12700.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QAY08710.1	QAY08710.1 portal protein [Streptomyces phage Genie2]	QAY08710.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNM73637.1	WNM73637.1 portal protein [Streptomyces phage Sollertia]	WNM73637.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UVD39896.1	UVD39896.1 portal protein [Streptomyces phage Stanimal]	UVD39896.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AYB70887.1	AYB70887.1 portal protein [Streptomyces phage Yaboi]	AYB70887.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH79819.1	QGH79819.1 portal protein [Streptomyces phage Bordeaux]	QGH79819.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URM86623.1	URM86623.1 portal protein [Streptomyces phage SaltySpitoon]	URM86623.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QRI45735.1	QRI45735.1 portal protein [Streptomyces phage Battuta]	QRI45735.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UVK60895.1	UVK60895.1 portal protein [Streptomyces phage JimJam]	UVK60895.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WPH58375.1	WPH58375.1 portal protein [Streptomyces phage Spelly]	WPH58375.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WXW92939.1	WXW92939.1 portal protein [Streptomyces phage Amabiko]	WXW92939.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AXH66556.1	AXH66556.1 portal protein [Streptomyces phage Starbow]	AXH66556.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URM87576.1	URM87576.1 portal protein [Streptomyces phage Quaran19]	URM87576.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QGH78934.1	QGH78934.1 portal protein [Streptomyces phage TomSawyer]	QGH78934.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QWT29916.1	QWT29916.1 portal protein [Streptomyces phage TunaTartare]	QWT29916.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	UUG69358.1	UUG69358.1 portal protein [Streptomyces phage Sham]	UUG69358.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QDF17222.1	QDF17222.1 portal protein [Streptomyces phage Birchlyn]	QDF17222.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QZE11392.1	QZE11392.1 portal protein [Streptomyces phage Jada]	QZE11392.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	URQ04642.1	URQ04642.1 portal protein [Streptomyces phage Emma1919]	URQ04642.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QQV92395.1	QQV92395.1 portal protein [Streptomyces phage MeganTheeKilla]	QQV92395.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QZE11165.1	QZE11165.1 portal protein [Streptomyces phage Forrest]	QZE11165.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AZU97106.1	AZU97106.1 portal protein [Streptomyces phage Gilson]	AZU97106.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	AVD99222.1	AVD99222.1 portal protein [Streptomyces phage BillNye]	AVD99222.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QBZ72306.1	QBZ72306.1 portal protein [Streptomyces phage Circinus]	QBZ72306.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QIN94577.1	QIN94577.1 portal protein [Streptomyces phage Muntaha]	QIN94577.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WDY79190.1	WDY79190.1 hypothetical protein ORF_00005 [Halorubrum tailed virus]	WDY79190.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QMP84179.1	QMP84179.1 portal protein [Streptomyces phage Coruscant]	QMP84179.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	QIN94013.1	QIN94013.1 portal protein [Streptomyces phage Wakanda]	QIN94013.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WNN94614.1	WNN94614.1 portal protein [Streptomyces phage Phredrick]	WNN94614.1	0
+ecf4ebb5-bd4d-4352-9c92-691de052b34d	WMI33422.1	WMI33422.1 portal protein [Streptomyces phage Kenrey]	WMI33422.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNY41721.1	UNY41721.1 terminase large subunit [Burkholderia phage Milagro]	UNY41721.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNY41832.1	UNY41832.1 terminase large subunit [Burkholderia phage Momento]	UNY41832.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNY41777.1	UNY41777.1 terminase large subunit [Burkholderia phage Menos]	UNY41777.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNY41661.1	UNY41661.1 terminase large subunit [Burkholderia phage Musica]	UNY41661.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADP02334.1	ADP02334.1 gp41 [Burkholderia phage KL3]	ADP02334.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABO60770.1	ABO60770.1 gp4, phage terminase, ATPase subunit [Burkholderia phage phiE12-2]	ABO60770.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAZ72646.1	AAZ72646.1 phage terminase ATPase subunit [Burkholderia phage phiE52237]	AAZ72646.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AFV51396.1	AFV51396.1 P terminase ATPase subunit [Burkholderia phage phiX216]	AFV51396.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QPI18542.1	QPI18542.1 terminase large subunit [Burkholderia phage phiE094]	QPI18542.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UPI15556.1	UPI15556.1 terminase, ATPase subunit [Burkholderia phage PhiBP82.3]	UPI15556.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AIP84290.1	AIP84290.1 ATPase subunit of terminase family protein [Burkholderia phage BEK]	AIP84290.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QWY84947.1	QWY84947.1 terminase, ATPase subunit [Burkholderia phage PK23]	QWY84947.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WWY66144.1	WWY66144.1 terminase large subunit [Burkholderia phage vB_HM387]	WWY66144.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UKM53764.1	UKM53764.1 terminase, ATPase subunit [Burkholderia phage PhiBP82.2]	UKM53764.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABO60745.1	ABO60745.1 gp4, phage terminase, ATPase subunit [Burkholderia phage phiE202]	ABO60745.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BCB23214.1	BCB23214.1 terminase ATPase subunit (P) [Burkholderia phage FLC5]	BCB23214.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADP02380.1	ADP02380.1 gp35 [Burkholderia phage KS14]	ADP02380.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BDD79917.1	BDD79917.1 hypothetical protein [Burkholderia phage FLC10]	BDD79917.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AZF87844.1	AZF87844.1 terminase large subunit [Pseudomonas phage Dobby]	AZF87844.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBI84111.1	QBI84111.1 terminase, ATPase subunit [Pseudomonas phage vB_Pae_BR319a]	QBI84111.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BAA36228.1	BAA36228.1 unnamed protein product [Pseudomonas phage phiCTX]	BAA36228.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WWQ72085.1	WWQ72085.1 terminase large subunit [Pseudomonas phage Sirocco]	WWQ72085.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BAP28108.1	BAP28108.1 hypothetical protein [Ralstonia phage RSY1]	BAP28108.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AVP40000.1	AVP40000.1 oxidoreductase [Ralstonia phage RsoM1USA]	AVP40000.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BAF52383.1	BAF52383.1 terminase [Ralstonia phage RSA1]	BAF52383.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QYW06325.1	QYW06325.1 terminase, ATPase subunit [Shewanella phage vB_SspM_M16-3]	QYW06325.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UZV40207.1	UZV40207.1 terminase, ATPase subunit [Acidovorax phage Acica]	UZV40207.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADP02289.1	ADP02289.1 gp42 [Burkholderia phage KS5]	ADP02289.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	USM11609.1	USM11609.1 terminase large subunit [Burkholderia phage Carl1]	USM11609.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UGC97287.1	UGC97287.1 terminase, ATPase subunit [Aeromonas phage vB_AsaM_LPM4]	UGC97287.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UYL85505.1	UYL85505.1 terminase, ATPase subunit [Acidovorax phage Alfacinha1]	UYL85505.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UYL85404.1	UYL85404.1 terminase, ATPase subunit [Acidovorax phage Alfacinha3]	UYL85404.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AFJ75477.1	AFJ75477.1 phage terminase ATPase subunit [Stenotrophomonas phage Smp131]	AFJ75477.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADX32410.1	ADX32410.1 terminase ATPase subunit [Erwinia phage ENT90]	ADX32410.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05909.1	UNA05909.1 terminase, ATPase subunit [Yersinia phage vB_YenM_56.17]	UNA05909.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADQ92391.1	ADQ92391.1 terminase ATPase subunit [Salmonella phage RE2010]	ADQ92391.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05964.1	UNA05964.1 terminase, ATPase subunit [Yersinia phage vB_YenM_201.16]	UNA05964.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UKL54245.1	UKL54245.1 terminase, ATPase subunit [Yersinia phage vB_YenM_31.17]	UKL54245.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AKA61128.1	AKA61128.1 putative terminase ATPase subunit [Burkholderia phage AP3]	AKA61128.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05862.1	UNA05862.1 terminase, ATPase subunit [Yersinia phage vB_YenM_06.16-2]	UNA05862.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBQ71995.1	QBQ71995.1 terminase/oxidoreductase [Klebsiella phage ST15-OXA48phi14.1]	QBQ71995.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WPJ21686.1	WPJ21686.1 large terminase subunit [Bacillus phage vB_BpuM-ZY1]	WPJ21686.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	CAH1234680.1	CAH1234680.1 Large Terminase ATPase subunit TermL [Escherichia phage Cartapus]	CAH1234680.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AQT27280.1	AQT27280.1 terminase ATPase subunit [Salmonella phage SEN8]	AQT27280.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNI73733.1	UNI73733.1 terminase [Klebsiella phage KP12]	UNI73733.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27416.1	QBP27416.1 terminase, oxidoreductase [Klebsiella phage ST512-KPC3phi13.2]	QBP27416.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP07825.1	QBP07825.1 oxidoreductase [Klebsiella phage ST11-VIM1phi8.4]	QBP07825.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27883.1	QBP27883.1 terminase/oxidoreductase [Klebsiella phage ST11-OXA48phi15.3]	QBP27883.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP08083.1	QBP08083.1 oxidoreductase [Klebsiella phage ST11-OXA245phi3.1]	QBP08083.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27655.1	QBP27655.1 oxidoreductase [Klebsiella phage ST340-VIM1phi10.2]	QBP27655.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27981.1	QBP27981.1 terminase [Klebsiella phage ST258-KPC3phi16.2]	QBP27981.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC10479.1	URC10479.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-813R9]	URC10479.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBQ71732.1	QBQ71732.1 oxidoreductase [Klebsiella phage ST437-OXA245phi4.2]	QBQ71732.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27623.1	QBP27623.1 terminase, oxidoreductase [Klebsiella phage ST13-OXA48phi12.1]	QBP27623.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QPB09397.1	QPB09397.1 terminase large subunit [Burkholderia phage Mana]	QPB09397.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ARB15684.1	ARB15684.1 terminase, ATPase subunit [Klebsiella phage 4LV2017]	ARB15684.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP08045.1	QBP08045.1 terminase [Klebsiella phage ST437-OXA245phi4.1]	QBP08045.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27773.1	QBP27773.1 terminase [Klebsiella phage ST512-KPC3phi13.6]	QBP27773.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP27927.1	QBP27927.1 terminase [Klebsiella phage ST258-KPC3phi16.1]	QBP27927.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UTC25950.1	UTC25950.1 terminase ATPase subunit [Salmonella phage vB_Sal_PHB48]	UTC25950.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC09612.1	URC09612.1 terminase [Escherichia phage vB_EcoM-569R9]	URC09612.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WPJ53074.1	WPJ53074.1 hypothetical protein RCIP0057_00001 [Klebsiella phage RCIP0057]	WPJ53074.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	CAG9593803.1	CAG9593803.1 hypothetical protein P2SIAC10_00042 [Peduovirus P2]	CAG9593803.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	CAG9593885.1	CAG9593885.1 hypothetical protein P2SIDE7_00039 [Peduovirus P2]	CAG9593885.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QYC52661.1	QYC52661.1 terminase ATPase subunit [Salmonella phage BIS20]	QYC52661.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URE76622.1	URE76622.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-613R3]	URE76622.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ALF02241.1	ALF02241.1 terminase ATPase subunit [Salmonella phage SEN1]	ALF02241.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QIW90063.1	QIW90063.1 putative terminase, ATPase subunit [Yersinia phage P37]	QIW90063.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	API82937.1	API82937.1 Terminase-like family protein [Salmonella phage STYP1]	API82937.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAD03269.1	AAD03269.1 gpP [Bacteriophage P2]	AAD03269.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD38007.1	VUD38007.1 Phage TermL, terminase large subunit [Peduovirus P24B2]	VUD38007.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WXX18240.1	WXX18240.1 terminase [Yersinia phage GCS667]	WXX18240.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ULG00679.1	ULG00679.1 terminase, ATPase subunit [Escherichia phage D8]	ULG00679.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	CAH0786526.1	CAH0786526.1 hypothetical protein P2AC1_00041 [Escherichia phage P2_AC1]	CAH0786526.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD38856.1	VUD38856.1 Phage terminase, ATPase subunit [Peduovirus P24E6b]	VUD38856.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QXF95268.1	QXF95268.1 terminase, ATPase subunit [Yersinia phage HQ103]	QXF95268.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ULG01139.1	ULG01139.1 terminase, ATPase subunit [Escherichia phage 12W]	ULG01139.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URP83663.1	URP83663.1 terminase ATPase subunit family protein [Escherichia phage S164]	URP83663.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QKE55626.1	QKE55626.1 hypothetical protein vBYpM50_00005 [Yersinia phage vB_YpM_50]	QKE55626.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAC34148.1	AAC34148.1 terminase subunit [Escherichia phage 186]	AAC34148.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WYC18441.1	WYC18441.1 terminase [Yersinia phage vB_YpM_MHG38]	WYC18441.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WYC18373.1	WYC18373.1 terminase [Yersinia phage vB_YpM_MDG94-186]	WYC18373.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AKH49374.1	AKH49374.1 terminase [Escherichia phage pro483]	AKH49374.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WOZ55990.1	WOZ55990.1 hypothetical protein B115_00002 [Yersinia phage vB_YpM_115]	WOZ55990.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WOZ56036.1	WOZ56036.1 hypothetical protein B117_00002 [Yersinia phage vB_YpM_117]	WOZ56036.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WYC18399.1	WYC18399.1 terminase [Yersinia phage vB_YpM_MDG45]	WYC18399.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QDJ98470.1	QDJ98470.1 hypothetical protein LLFFHNDI_00043 [Escherichia phage vB_EcoM-12474II]	QDJ98470.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ULG00981.1	ULG00981.1 terminase, ATPase subunit [Escherichia phage 9W]	ULG00981.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD37920.1	VUD37920.1 Phage terminase, ATPase subunit [Peduovirus P22H4]	VUD37920.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QDJ98602.1	QDJ98602.1 hypothetical protein OMJLAAIH_00043 [Escherichia phage vB_EcoM-12474V]	QDJ98602.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD39018.1	VUD39018.1 Phage terminase, ATPase subunit [Peduovirus P24A7b]	VUD39018.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QDJ98558.1	QDJ98558.1 hypothetical protein PBINGOGM_00043 [Escherichia phage vB_EcoM-12474IV]	QDJ98558.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QDJ98473.1	QDJ98473.1 hypothetical protein BBAMJIOM_00002 [Escherichia phage vB_EcoM-12474III]	QDJ98473.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QDP43496.1	QDP43496.1 terminase, ATPase subunit [Bacteriophage R18C]	QDP43496.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AKH49344.1	AKH49344.1 terminase [Escherichia phage pro147]	AKH49344.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC09853.1	URC09853.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-720R8]	URC09853.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAP04439.1	AAP04439.1 gpP [Yersinia phage L-413C]	AAP04439.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UPI11450.1	UPI11450.1 hypothetical protein COILCCMC_00002 [Yersinia phage VB-YPM-4]	UPI11450.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAN28220.1	AAN28220.1 gpP [Escherichia phage Wphi]	AAN28220.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGF88415.1	AGF88415.1 terminase ATPase subunit [Salmonella phage FSLSP004]	AGF88415.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QKE55582.1	QKE55582.1 hypothetical protein vBYpM46_00002 [Yersinia phage vB_YpM_46]	QKE55582.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	CAG9593806.1	CAG9593806.1 hypothetical protein P2DC1_00002 [Peduovirus P2]	CAG9593806.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ULG01136.1	ULG01136.1 terminase, ATPase subunit [Escherichia phage 10W]	ULG01136.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC10091.1	URC10091.1 large terminase subunit [Escherichia phage vB_EcoM-640R3]	URC10091.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ULG00865.1	ULG00865.1 terminase, ATPase subunit [Escherichia phage 11W]	ULG00865.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGX84573.1	AGX84573.1 large terminase subunit [Enterobacteria phage fiAA91-ss]	AGX84573.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD39478.1	VUD39478.1 Phage terminase, ATPase subunit [Peduovirus P24C9]	VUD39478.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAN08365.1	AAN08365.1 gp3 [Salmonella phage PSP3]	AAN08365.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WFG40976.1	WFG40976.1 hypothetical protein KANBJGNJ_00041 [Salmonella phage MET_P1_103_31]	WFG40976.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25342.1	QEI25342.1 terminase, ATPase subunit [Salmonella phage SI22]	QEI25342.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25387.1	QEI25387.1 terminase, ATPase subunit [Salmonella phage SW9]	QEI25387.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UPI11500.1	UPI11500.1 hypothetical protein BFNKNBEH_00010 [Yersinia phage VB-YPM-18]	UPI11500.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WOZ56082.1	WOZ56082.1 hypothetical protein B476A_00002 [Yersinia phage vB_YpM_476A]	WOZ56082.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WOZ56122.1	WOZ56122.1 hypothetical protein B476B_00002 [Yersinia phage vB_YpM_476B]	WOZ56122.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD37963.1	VUD37963.1 Phage terminase, ATPase subunit [Peduovirus P22H1]	VUD37963.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ASD51185.1	ASD51185.1 terminase, ATPase subunit [Erwinia phage EtG]	ASD51185.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QKE55490.1	QKE55490.1 hypothetical protein vBYpM22_00005 [Yersinia phage vB_YpM_22]	QKE55490.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05737.1	UNA05737.1 terminase, ATPase subunit [Yersinia phage vB_YenM_42.18]	UNA05737.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AJA72926.1	AJA72926.1 terminase ATPase subunit [Mannheimia phage vB_MhM_587AP1]	AJA72926.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBQ71546.1	QBQ71546.1 terminase [Klebsiella phage ST147-VIM1phi7.1]	QBQ71546.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGK86777.1	AGK86777.1 phage terminase ATPase subunit [Burkholderia phage ST79]	AGK86777.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABD90603.1	ABD90603.1 terminase ATPase subunit [Mannheimia phage phiMhaA1-BAA410]	ABD90603.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABD90554.1	ABD90554.1 terminase ATPase subunit [Mannheimia phage PHL101]	ABD90554.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AJA73106.1	AJA73106.1 terminase ATPase subunit [Mannheimia phage vB_MhM_2256AP1]	AJA73106.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AJA72875.1	AJA72875.1 terminase ATPase subunit [Mannheimia phage vB_MhM_535AP1]	AJA72875.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AJA73054.1	AJA73054.1 terminase ATPase subunit [Mannheimia phage vB_MhM_1127AP1]	AJA73054.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AFL46450.1	AFL46450.1 phage terminase ATPase subunit [Mannheimia phage vB_MhM_1152AP]	AFL46450.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC10015.1	URC10015.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-473R3]	URC10015.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGG36517.1	AGG36517.1 phage terminase, ATPase subunit [Escherichia phage P2]	AGG36517.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ALF02291.1	ALF02291.1 terminase ATPase subunit [Salmonella phage SEN4]	ALF02291.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ALF02340.1	ALF02340.1 terminase ATPase subunit [Salmonella phage SEN5]	ALF02340.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QMP23899.1	QMP23899.1 terminase [Vibrio phage ValB1MD-2]	QMP23899.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WPJ21747.1	WPJ21747.1 terminase family protein [Vibrio phage L9-1]	WPJ21747.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AUR95198.1	AUR95198.1 terminase large subunit [Vibrio phage 1.202.O._10N.222.45.E8]	AUR95198.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AOY11832.1	AOY11832.1 terminase ATPase subunit [Salinivibrio phage SMHB1]	AOY11832.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QGF21295.1	QGF21295.1 terminase large subunit [Vibrio phage vB_ValM-yong1]	QGF21295.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGW43560.1	AGW43560.1 terminase ATPase subunit [Vibrio phage VPUSM 8]	AGW43560.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ANA87654.1	ANA87654.1 terminase protein [Vibrio phage VcP032]	ANA87654.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BAF98815.1	BAF98815.1 putative terminase ATPase subunit [Vibrio phage Kappa]	BAF98815.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAL47515.1	AAL47515.1 orf16 [Bacteriophage K139]	AAL47515.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ARB15638.1	ARB15638.1 terminase, ATPase subunit [Klebsiella phage 3LV2017]	ARB15638.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP07917.1	QBP07917.1 oxidoreductase [Klebsiella phage ST101-KPC2phi6.2]	QBP07917.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QBP07937.1	QBP07937.1 oxidoreductase [Klebsiella phage ST16-OXA48phi5.4]	QBP07937.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	APM00235.1	APM00235.1 large terminase subunit [Pseudoalteromonas phage C5a]	APM00235.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UKL54200.1	UKL54200.1 terminase, ATPase subunit [Yersinia phage vB_YenM_324]	UKL54200.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AYD79789.1	AYD79789.1 hypothetical protein OGLPLLMI_00023 [Enterobacter phage phiT5282H]	AYD79789.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WKV24003.1	WKV24003.1 terminase, ATPase subunit [Pseudomonas phage PaBSM-2607-JFK]	WKV24003.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUF53500.1	VUF53500.1 TermL, Phage terminase, ATPase large subunit [Escherichia phage ESSI2_ev040]	VUF53500.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUF53463.1	VUF53463.1 Phage terminase large subunit, ATPase [Escherichia phage ESSI2_ev015]	VUF53463.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUF53531.1	VUF53531.1 TermL, terminase large subunit, ATPase [Escherichia phage ESSI2_ev129]	VUF53531.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ALY08257.1	ALY08257.1 putative terminase ATPase subunit [Pseudomonas phage phi3]	ALY08257.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUF53444.1	VUF53444.1 Phage terminase large subunit [Escherichia phage ESSI2_ev239]	VUF53444.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ADX32368.1	ADX32368.1 putative terminase ATPase subunit [Cronobacter phage ESSI-2]	ADX32368.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WOZ57142.1	WOZ57142.1 terminase family protein [Citrobacter phage Shae_phiSM]	WOZ57142.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URE76765.1	URE76765.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-705R2]	URE76765.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC09567.1	URC09567.1 putative large terminase subunit [Escherichia phage vB_EcoM-569R5]	URC09567.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	VUD40164.1	VUD40164.1 Phage terminase, ATPase subunit [Xuanwuvirus P884B11]	VUD40164.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AIZ95132.1	AIZ95132.1 terminase ATPase subunit [Escherichia phage P88]	AIZ95132.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WMT83780.1	WMT83780.1 large terminase subunit [Pseudoalteromonas phage proACA1-A]	WMT83780.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WMT83728.1	WMT83728.1 large terminase subunit [Pseudoalteromonas phage ACA2]	WMT83728.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WMT83676.1	WMT83676.1 large terminase subunit [Pseudoalteromonas phage ACA1]	WMT83676.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABG73174.1	ABG73174.1 putative terminase large subunit [Aeromonas phage phiO18P]	ABG73174.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UYE91963.1	UYE91963.1 terminase [Aeromonas phage A051]	UYE91963.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WGL39674.1	WGL39674.1 terminase large subunit [Aeromonas phage P05B]	WGL39674.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAZ93654.1	AAZ93654.1 unknown [Pasteurella phage F108]	AAZ93654.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAB09201.1	AAB09201.1 hypothetical protein [Haemophilus phage HP1]	AAB09201.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAK37798.1	AAK37798.1 orf16 [Haemophilus phage HP2]	AAK37798.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25522.1	QEI25522.1 terminase, ATPase subunit [Salmonella phage SW3]	QEI25522.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25484.1	QEI25484.1 terminase ATPase subunit [Salmonella phage SW5]	QEI25484.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25431.1	QEI25431.1 terminase, ATPase [Salmonella phage SI7]	QEI25431.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	WBY65432.1	WBY65432.1 hypothetical protein FP3_000001 [Pasteurella phage vB_PmuM_CFP3]	WBY65432.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEH60873.1	QEH60873.1 major coat protein, partial [Escherichia phage MoI-2019a]	QEH60873.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAA32202.1	AAA32202.1 CP12, partial [Eganvirus ev186]	AAA32202.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	URC10016.1	URC10016.1 terminase, ATPase subunit [Escherichia phage vB_EcoM-473R3]	URC10016.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAG50261.1	AAG50261.1 probable terminase, partial [Phage GMSE-1]	AAG50261.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ABG73173.1	ABG73173.1 truncated terminase ATPase subunit [Aeromonas phage phiO18P]	ABG73173.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05908.1	UNA05908.1 terminase, ATPase subunit [Yersinia phage vB_YenM_56.17]	UNA05908.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGG36518.1	AGG36518.1 phage terminase, ATPase subunit [Escherichia phage P2]	AGG36518.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	UNA05963.1	UNA05963.1 terminase, ATPase subunit [Yersinia phage vB_YenM_201.16]	UNA05963.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAC34147.1	AAC34147.1 W protein [Escherichia phage 186]	AAC34147.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ASD51186.1	ASD51186.1 terminase, ATPase subunit [Erwinia phage EtG]	ASD51186.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAN08364.1	AAN08364.1 gp2 [Salmonella phage PSP3]	AAN08364.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25341.1	QEI25341.1 terminase, ATPase subunit [Salmonella phage SI22]	QEI25341.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QEI25386.1	QEI25386.1 terminase, ATPase subunit [Salmonella phage SW9]	QEI25386.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	BDX35531.1	BDX35531.1 terminase [Thermus phage MN1]	BDX35531.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AWY03244.1	AWY03244.1 terminase large subunit [Pasteurella phage AFS-2018a]	AWY03244.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAO61393.1	AAO61393.1 putative large subunit terminase TerL [Halophage HF1]	AAO61393.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AAL55022.1	AAL55022.1 putative large subunit terminase TerL [Halorubrum phage HF2]	AAL55022.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	QIR31049.1	QIR31049.1 large subunit terminase TerL [Halorubrum virus Hardycor2]	QIR31049.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	ALF02062.1	ALF02062.1 terminase large subunit [Thiobacimonas phage vB_ThpS-P1]	ALF02062.1	0
+d7715b15-7a78-4a77-aaca-8235df42b2c5	AGR47349.1	AGR47349.1 terminase [Brevibacillus phage Emery]	AGR47349.1	0

--- a/cpt_protein_blast_grouping/test-data/outfile.txt
+++ b/cpt_protein_blast_grouping/test-data/outfile.txt
@@ -1,0 +1,22 @@
+# Top 20 Hits
+# Name                                             Unique Query Matches      Unique Subject Hits      
+Burkholderia phage Milagro                         47                        48                       
+Burkholderia phage Momento                         41                        45                       
+Burkholderia phage Musica                          39                        42                       
+Burkholderia phage Menos                           39                        40                       
+Burkholderia phage KL3                             38                        39                       
+Burkholderia phage PhiBP82.2                       35                        35                       
+Burkholderia phage PhiBP82.3                       34                        34                       
+Burkholderia phage phiE202                         34                        34                       
+Burkholderia phage phiE094                         34                        34                       
+Burkholderia phage phiX216                         33                        33                       
+Burkholderia phage phiE52237                       33                        33                       
+Burkholderia phage AP3                             33                        33                       
+Burkholderia phage Carl1                           33                        34                       
+Burkholderia phage Mana                            33                        34                       
+Burkholderia phage vB_HM387                        32                        32                       
+Burkholderia phage BEK                             31                        31                       
+Burkholderia phage KS5                             31                        32                       
+Ralstonia phage RsoM1USA                           28                        28                       
+Ralstonia phage RSA1                               28                        29                       
+Burkholderia phage PK23                            26                        27                       


### PR DESCRIPTION
Addresses the need to group by the organism found in the brackets.

It does the following:
* Reads a tab-delimited BLAST output file.
* Extracts organism names from the subject titles (text in square brackets).
* Counts unique query proteins that matched each organism and unique hit proteins from each organism.
* Sorts and displays results based on either unique queries or unique hits.
* The output is a formatted table showing the top N organisms with the most matches.

[#9]